### PR TITLE
Allow empty string to user_defined_value_function

### DIFF
--- a/newrelic/resource_newrelic_alert_condition.go
+++ b/newrelic/resource_newrelic_alert_condition.go
@@ -191,7 +191,7 @@ func resourceNewRelicAlertCondition() *schema.Resource {
 			"user_defined_value_function": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"average", "min", "max", "total", "sample_size"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"average", "min", "max", "total", "sample_size", ""}, false),
 				Description:  "One of: (average, min, max, total, sample_size).",
 			},
 		},


### PR DESCRIPTION
user_defined_value_function is present only when user_defined_metric is present. 

To be able to reuse the module for all apm conditions, user_defined_value_function should allow empty string. 