### PR TITLE
Add support for cross account widgets

### DIFF
--- a/newrelic/resource_newrelic_dashboard.go
+++ b/newrelic/resource_newrelic_dashboard.go
@@ -263,6 +263,11 @@ func resourceNewRelicDashboard() *schema.Resource {
 							Elem:        &schema.Schema{Type: schema.TypeInt},
 							Description: "A collection of entity ids to display data for. These are typically application IDs.",
 						},
+						"account_id": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "Source account to fetch data from, if not the current account.",
+						},
 						"metric": {
 							Type:        schema.TypeSet,
 							Optional:    true,

--- a/newrelic/structures_newrelic_dashboard.go
+++ b/newrelic/structures_newrelic_dashboard.go
@@ -84,6 +84,10 @@ func expandWidget(cfg map[string]interface{}) (*dashboards.DashboardWidget, erro
 		ID:            cfg["widget_id"].(int),
 	}
 
+	if accountID, ok := cfg["account_id"]; ok {
+		widget.AccountID = accountID.(int)
+	}
+
 	err := validateWidgetData(cfg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Adding support for `account_id` attribute in dashboard widgets (#476) 

Unfortunately due to the API being unable to retrieve cross account widgets, this does mean that changes are detected every time.

Acceptance tests are difficult as I'm not sure if the account used by the CI server has access to other New Relic accounts. Happy to add these if required 👍 