### PR TITLE
chore(stalebot): shorter daysUntilStale, shorter daysUntilClose

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,11 +1,11 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 30
+daysUntilStale: 21
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-daysUntilClose: 14
+daysUntilClose: 7
 
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
 onlyLabels: []


### PR DESCRIPTION
Shortening `daysUntilStale` and `daysUntilClose` just a bit to help lighten the repo maintenance workload.