### PR TITLE
fix(nrql_alert_condition): use better term operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk v1.10.0
 	github.com/newrelic/go-agent/v3 v3.7.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go v0.31.1
+	github.com/newrelic/newrelic-client-go v0.31.2
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -560,8 +560,8 @@ github.com/newrelic/go-agent/v3 v3.7.0 h1:cPpvzLDfQZ0p0/nAIOKiojoAgiHi9MiLlLloJ9
 github.com/newrelic/go-agent/v3 v3.7.0/go.mod h1:1A1dssWBwzB7UemzRU6ZVaGDsI+cEn5/bNxI0wiYlIc=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go v0.31.1 h1:jBCwDJpsoaZ3O32dWsW4Vi+kXuGN8sYuE2Pf/1++dNg=
-github.com/newrelic/newrelic-client-go v0.31.1/go.mod h1:2+0/M/IvdkL56sL+hH1mfe7OVmhv61dmUuJfBtR+2nI=
+github.com/newrelic/newrelic-client-go v0.31.2 h1:2oQXutNYERj82xBUh2lYZZlOWtY6UprKRrilMmbXARc=
+github.com/newrelic/newrelic-client-go v0.31.2/go.mod h1:2+0/M/IvdkL56sL+hH1mfe7OVmhv61dmUuJfBtR+2nI=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -32,9 +32,12 @@ func termSchema() *schema.Resource {
 			"operator": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "equal",
+				Default:      "equals",
 				Description:  "One of (above, below, equal). Defaults to 'equal'.",
-				ValidateFunc: validation.StringInSlice([]string{"above", "below", "equal"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"above", "below", "equals"}, true),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.EqualFold(old, new)
+				},
 			},
 			"threshold": {
 				Type:         schema.TypeFloat,

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -417,7 +417,7 @@ resource "newrelic_nrql_alert_condition" "foo" {
 	}
 
 	warning {
-		operator              = "above"
+		operator              = "equals"
 		threshold             = 0.5
 		threshold_duration    = 120
 		threshold_occurrences = "AT_LEAST_ONCE"

--- a/newrelic/structures_newrelic_nrql_alert_condition.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition.go
@@ -206,7 +206,7 @@ func expandNrqlConditionTerm(term map[string]interface{}, conditionType, priorit
 	}
 
 	return &alerts.NrqlConditionTerm{
-		Operator:             alerts.NrqlConditionOperator(strings.ToUpper(term["operator"].(string))),
+		Operator:             alerts.AlertsNrqlConditionTermsOperator(strings.ToUpper(term["operator"].(string))),
 		Priority:             alerts.NrqlConditionPriority(strings.ToUpper(priority)),
 		Threshold:            threshold,
 		ThresholdDuration:    duration,

--- a/newrelic/structures_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition_test.go
@@ -21,7 +21,7 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 		"threshold":             1,
 		"threshold_occurrences": alerts.ThresholdOccurrences.AtLeastOnce,
 		"threshold_duration":    600,
-		"operator":              alerts.NrqlConditionOperators.Above,
+		"operator":              alerts.AlertsNrqlConditionTermsOperatorTypes.ABOVE,
 	})
 
 	var warningTerms []map[string]interface{}
@@ -29,7 +29,7 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 		"threshold":             9.1,
 		"threshold_occurrences": alerts.ThresholdOccurrences.AtLeastOnce,
 		"threshold_duration":    660,
-		"operator":              alerts.NrqlConditionOperators.Below,
+		"operator":              alerts.AlertsNrqlConditionTermsOperatorTypes.BELOW,
 	})
 
 	expectedNrql := &alerts.NrqlConditionInput{}
@@ -112,7 +112,7 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 						Threshold:            1,
 						ThresholdOccurrences: alerts.ThresholdOccurrences.AtLeastOnce,
 						ThresholdDuration:    600,
-						Operator:             alerts.NrqlConditionOperators.Above,
+						Operator:             alerts.AlertsNrqlConditionTermsOperatorTypes.ABOVE,
 						Priority:             alerts.NrqlConditionPriorities.Critical,
 					},
 				}
@@ -139,14 +139,14 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 						Threshold:            1,
 						ThresholdOccurrences: alerts.ThresholdOccurrences.AtLeastOnce,
 						ThresholdDuration:    600,
-						Operator:             alerts.NrqlConditionOperators.Above,
+						Operator:             alerts.AlertsNrqlConditionTermsOperatorTypes.ABOVE,
 						Priority:             alerts.NrqlConditionPriorities.Critical,
 					},
 					{
 						Threshold:            9.1,
 						ThresholdOccurrences: alerts.ThresholdOccurrences.AtLeastOnce,
 						ThresholdDuration:    660,
-						Operator:             alerts.NrqlConditionOperators.Below,
+						Operator:             alerts.AlertsNrqlConditionTermsOperatorTypes.BELOW,
 						Priority:             alerts.NrqlConditionPriorities.Warning,
 					},
 				}
@@ -233,14 +233,14 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 					Threshold:            1,
 					ThresholdOccurrences: alerts.ThresholdOccurrences.AtLeastOnce,
 					ThresholdDuration:    600,
-					Operator:             alerts.NrqlConditionOperators.Above,
+					Operator:             alerts.AlertsNrqlConditionTermsOperatorTypes.ABOVE,
 					Priority:             alerts.NrqlConditionPriorities.Critical,
 				},
 				{
 					Threshold:            9.1,
 					ThresholdOccurrences: alerts.ThresholdOccurrences.AtLeastOnce,
 					ThresholdDuration:    660,
-					Operator:             alerts.NrqlConditionOperators.Below,
+					Operator:             alerts.AlertsNrqlConditionTermsOperatorTypes.BELOW,
 					Priority:             alerts.NrqlConditionPriorities.Warning,
 				},
 			},
@@ -335,10 +335,10 @@ func TestExpandNrqlConditionTerm(t *testing.T) {
 				"threshold":             10.1,
 				"threshold_duration":    5,
 				"threshold_occurrences": "ALL",
-				"operator":              "equal",
+				"operator":              "equals",
 			},
 			Expected: &alerts.NrqlConditionTerm{
-				Operator:             alerts.NrqlConditionOperator("EQUAL"),
+				Operator:             alerts.AlertsNrqlConditionTermsOperator("EQUALS"),
 				Priority:             alerts.NrqlConditionPriority("CRITICAL"),
 				Threshold:            10.1,
 				ThresholdDuration:    5,
@@ -352,11 +352,11 @@ func TestExpandNrqlConditionTerm(t *testing.T) {
 				"threshold":             10.1,
 				"threshold_duration":    5,
 				"threshold_occurrences": "ALL",
-				"operator":              "equal",
+				"operator":              "equals",
 				"priority":              "critical",
 			},
 			Expected: &alerts.NrqlConditionTerm{
-				Operator:             alerts.NrqlConditionOperator("EQUAL"),
+				Operator:             alerts.AlertsNrqlConditionTermsOperator("EQUALS"),
 				Priority:             alerts.NrqlConditionPriority("CRITICAL"),
 				Threshold:            10.1,
 				ThresholdDuration:    5,
@@ -370,10 +370,10 @@ func TestExpandNrqlConditionTerm(t *testing.T) {
 				"threshold":             10.9,
 				"threshold_duration":    9,
 				"threshold_occurrences": "ALL",
-				"operator":              "equal",
+				"operator":              "equals",
 			},
 			Expected: &alerts.NrqlConditionTerm{
-				Operator:             alerts.NrqlConditionOperator("EQUAL"),
+				Operator:             alerts.AlertsNrqlConditionTermsOperator("EQUALS"),
 				Priority:             alerts.NrqlConditionPriority("WARNING"),
 				Threshold:            10.9,
 				ThresholdDuration:    9,
@@ -387,11 +387,11 @@ func TestExpandNrqlConditionTerm(t *testing.T) {
 				"threshold":             10.9,
 				"threshold_duration":    9,
 				"threshold_occurrences": "ALL",
-				"operator":              "equal",
+				"operator":              "equals",
 				"priority":              "warning",
 			},
 			Expected: &alerts.NrqlConditionTerm{
-				Operator:             alerts.NrqlConditionOperator("EQUAL"),
+				Operator:             alerts.AlertsNrqlConditionTermsOperator("EQUALS"),
 				Priority:             alerts.NrqlConditionPriority("WARNING"),
 				Threshold:            10.9,
 				ThresholdDuration:    9,
@@ -405,11 +405,11 @@ func TestExpandNrqlConditionTerm(t *testing.T) {
 				"threshold":             10.9,
 				"threshold_duration":    9,
 				"threshold_occurrences": "ALL",
-				"operator":              "equal",
+				"operator":              "equals",
 				"priority":              "critical",
 			},
 			Expected: &alerts.NrqlConditionTerm{
-				Operator:             alerts.NrqlConditionOperator("EQUAL"),
+				Operator:             alerts.AlertsNrqlConditionTermsOperator("EQUALS"),
 				Priority:             alerts.NrqlConditionPriority("WARNING"),
 				Threshold:            10.9,
 				ThresholdDuration:    9,

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -95,7 +95,7 @@ NRQL alert conditions support up to two terms. At least one `term` must have `pr
 The `term` block the following arguments:
 
 - `duration` - (Required) In minutes, must be in the range of `1` to `120`, inclusive.
-- `operator` - (Optional) `above`, `below`, or `equal`. Defaults to `equal`. Note that when using a `type` of `outlier`, the only valid option here is `above`.
+- `operator` - (Optional) Valid values are `above`, `below`, or `equals` (case insensitive). Defaults to `equals`. Note that when using a `type` of `outlier`, the only valid option here is `above`.
 - `priority` - (Optional) `critical` or `warning`. Defaults to `critical`.
 - `threshold` - (Required) The value which will trigger a violation. Must be `0` or greater.
 - `threshold_duration` - (Optional) The duration of time, in seconds, that the threshold must violate for in order to create a violation. Value must be a multiple of 60.


### PR DESCRIPTION
Without this change, the term operator incorrectly uses the word "equal" when
the API requires the use of "equals".  Here we make the necessary code, test,
and docs updates to ensure users are able to make use of the "equal" term
operator on their static conditions.