### PR TITLE
chore: remove integration tests from push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -3,5 +3,5 @@ echo
 echo "Running tests before pushing..."
 echo
 
-make test
+make test-unit
 


### PR DESCRIPTION
Integration tests are timing out git push operations on account of how long they run.  This PR removes them from the pre-push git hook.