### PR TITLE
chore(ci): remove lint job as dependency on test-unit job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,6 @@ jobs:
         file-extension: '.markdown'
 
   test-unit:
-    needs: lint
     runs-on: ubuntu-latest
     steps:
     - name: Install Go


### PR DESCRIPTION
The PR should provide a slight boost in CI efficiency by parallelizing the `test-unit` job by removing a dependency on the `lint` job.