### PR TITLE
fix(newrelic_alert_condition): allow instance scope for JVM app metrics

### DIFF
--- a/newrelic/resource_newrelic_alert_condition_integration_test.go
+++ b/newrelic/resource_newrelic_alert_condition_integration_test.go
@@ -4,6 +4,7 @@ package newrelic
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -150,6 +151,66 @@ func TestAccNewRelicAlertCondition_AlertPolicyNotFound(t *testing.T) {
 				PreConfig: testAccDeleteNewRelicAlertPolicy(rName),
 				Config:    testAccNewRelicAlertConditionConfig(rName),
 				Check:     testAccCheckNewRelicAlertConditionExists("newrelic_alert_condition.foo"),
+			},
+		},
+	})
+}
+
+func TestAccNewRelicAlertCondition_ApplicationScopeWithCloseTimer(t *testing.T) {
+	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccNewRelicAlertConditionApplicationScopeWithCloseTimerConfig(rName),
+				ExpectError: regexp.MustCompile("violation_close_timer only supported for apm_app_metric when condition_scope = 'instance'"),
+			},
+		},
+	})
+}
+
+func TestAccNewRelicAlertCondition_InstanceScopeWithCloseTimer(t *testing.T) {
+	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNewRelicAlertConditionInstanceScopeWithCloseTimerConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccNewRelicAlertCondition_APMJVMMetricApplicationScope(t *testing.T) {
+	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNewRelicAlertConditionAPMJVMMetricApplicationScopeConfig(rName),
+			},
+		},
+	})
+}
+func TestAccNewRelicAlertCondition_APMJVMMetricInstanceScope(t *testing.T) {
+	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNewRelicAlertConditionAPMJVMMetricInstanceScopeConfig(rName),
 			},
 		},
 	})

--- a/newrelic/resource_newrelic_alert_condition_test.go
+++ b/newrelic/resource_newrelic_alert_condition_test.go
@@ -178,6 +178,7 @@ resource "newrelic_alert_condition" "foo" {
 	metric          = "apdex"
 	runbook_url     = "https://foo.example.com"
 	condition_scope = "application"
+
 	term {
 		duration      = %[2]d
 		operator      = "below"
@@ -187,4 +188,140 @@ resource "newrelic_alert_condition" "foo" {
 	}
 }
 `, name, duration)
+}
+
+func testAccNewRelicAlertConditionApplicationScopeWithCloseTimerConfig(rName string) string {
+	return fmt.Sprintf(`
+provider "newrelic" {
+	api_key = "%[3]s"
+}
+data "newrelic_application" "app" {
+	name = "%[2]s"
+}
+resource "newrelic_alert_policy" "foo" {
+	name = "%[1]s"
+}
+resource "newrelic_alert_condition" "foo" {
+	policy_id = newrelic_alert_policy.foo.id
+
+	name            = "%[1]s"
+	enabled         = true
+	type            = "apm_app_metric"
+	entities        = [data.newrelic_application.app.id]
+	metric          = "apdex"
+	runbook_url     = "https://foo.example.com"
+	condition_scope = "application"
+	violation_close_timer = 24
+
+	term {
+		duration      = 5
+		operator      = "below"
+		priority      = "critical"
+		threshold     = "0.75"
+		time_function = "all"
+	}
+}
+`, rName, testAccExpectedApplicationName, testAccAPIKey)
+}
+
+func testAccNewRelicAlertConditionInstanceScopeWithCloseTimerConfig(rName string) string {
+	return fmt.Sprintf(`
+provider "newrelic" {
+	api_key = "%[3]s"
+}
+data "newrelic_application" "app" {
+	name = "%[2]s"
+}
+resource "newrelic_alert_policy" "foo" {
+	name = "%[1]s"
+}
+resource "newrelic_alert_condition" "foo" {
+	policy_id = newrelic_alert_policy.foo.id
+
+	name            = "%[1]s"
+	enabled         = true
+	type            = "apm_app_metric"
+	entities        = [317250408]
+	metric          = "apdex"
+	runbook_url     = "https://foo.example.com"
+	condition_scope = "instance"
+	violation_close_timer = 24
+
+	term {
+		duration      = 5
+		operator      = "below"
+		priority      = "critical"
+		threshold     = "0.75"
+		time_function = "all"
+	}
+}
+`, rName, testAccExpectedApplicationName, testAccAPIKey)
+}
+
+func testAccNewRelicAlertConditionAPMJVMMetricApplicationScopeConfig(rName string) string {
+	return fmt.Sprintf(`
+provider "newrelic" {
+	api_key = "%[3]s"
+}
+data "newrelic_application" "app" {
+	name = "%[2]s"
+}
+resource "newrelic_alert_policy" "foo" {
+	name = "%[1]s"
+}
+resource "newrelic_alert_condition" "foo" {
+	policy_id = newrelic_alert_policy.foo.id
+
+	name            = "%[1]s"
+	enabled         = true
+	type            = "apm_jvm_metric"
+	entities        = [317250408]
+	metric          = "heap_memory_usage"
+	runbook_url     = "https://foo.example.com"
+	condition_scope = "application"
+	violation_close_timer = 24
+
+	term {
+		duration      = 5
+		operator      = "below"
+		priority      = "critical"
+		threshold     = "0.75"
+		time_function = "all"
+	}
+}
+`, rName, testAccExpectedApplicationName, testAccAPIKey)
+}
+
+func testAccNewRelicAlertConditionAPMJVMMetricInstanceScopeConfig(rName string) string {
+	return fmt.Sprintf(`
+provider "newrelic" {
+	api_key = "%[3]s"
+}
+data "newrelic_application" "app" {
+	name = "%[2]s"
+}
+resource "newrelic_alert_policy" "foo" {
+	name = "%[1]s"
+}
+resource "newrelic_alert_condition" "foo" {
+	policy_id = newrelic_alert_policy.foo.id
+
+	name            = "%[1]s"
+	enabled         = true
+	type            = "apm_jvm_metric"
+	entities        = [317250408]
+	metric          = "heap_memory_usage"
+	runbook_url     = "https://foo.example.com"
+	condition_scope = "instance"
+	violation_close_timer = 24
+
+	term {
+		duration      = 5
+		operator      = "below"
+		priority      = "critical"
+		threshold     = "0.75"
+		time_function = "all"
+	}
+}
+`, rName, testAccExpectedApplicationName, testAccAPIKey)
 }

--- a/newrelic/structures_newrelic_alert_condition.go
+++ b/newrelic/structures_newrelic_alert_condition.go
@@ -22,12 +22,11 @@ func expandAlertCondition(d *schema.ResourceData) (*alerts.Condition, error) {
 	condition.Terms = expandAlertConditionTerms(d.Get("term").(*schema.Set).List())
 
 	if violationCloseTimer, ok := d.GetOk("violation_close_timer"); ok {
-		if condition.Type == "apm_app_metric" && condition.Scope == "instance" {
-			condition.ViolationCloseTimer = violationCloseTimer.(int)
-		} else {
+		if condition.Type == "apm_app_metric" && condition.Scope == "application" {
 			return nil, fmt.Errorf("violation_close_timer only supported for apm_app_metric when condition_scope = 'instance'")
 		}
 
+		condition.ViolationCloseTimer = violationCloseTimer.(int)
 	}
 
 	if attr, ok := d.GetOk("runbook_url"); ok {
@@ -79,11 +78,19 @@ func flattenAlertCondition(condition *alerts.Condition, d *schema.ResourceData) 
 	d.Set("type", condition.Type)
 	d.Set("metric", condition.Metric)
 	d.Set("runbook_url", condition.RunbookURL)
-	d.Set("condition_scope", condition.Scope)
 	d.Set("violation_close_timer", condition.ViolationCloseTimer)
 	d.Set("gc_metric", condition.GCMetric)
 	d.Set("user_defined_metric", condition.UserDefined.Metric)
 	d.Set("user_defined_value_function", condition.UserDefined.ValueFunction)
+
+	// The condition_scope field is not always returned by the API. This conditional
+	// handles flattening for all cases.
+	if condition.Scope != "" {
+		d.Set("condition_scope", condition.Scope)
+	} else {
+		conditionScope := d.Get("condition_scope")
+		d.Set("condition_scope", conditionScope)
+	}
 
 	entities, err := flattenAlertConditionEntities(&condition.Entities)
 

--- a/newrelic/structures_newrelic_alert_condition.go
+++ b/newrelic/structures_newrelic_alert_condition.go
@@ -22,10 +22,10 @@ func expandAlertCondition(d *schema.ResourceData) (*alerts.Condition, error) {
 	condition.Terms = expandAlertConditionTerms(d.Get("term").(*schema.Set).List())
 
 	if violationCloseTimer, ok := d.GetOk("violation_close_timer"); ok {
-		if condition.Scope == "instance" {
+		if condition.Type == "apm_app_metric" && condition.Scope == "instance" {
 			condition.ViolationCloseTimer = violationCloseTimer.(int)
 		} else {
-			return nil, fmt.Errorf("violation_close_timer only supported when condition_scope = 'instance'")
+			return nil, fmt.Errorf("violation_close_timer only supported for apm_app_metric when condition_scope = 'instance'")
 		}
 
 	}


### PR DESCRIPTION
Resolves #795.

Scoping this validation to `apm_app_metric` condition type only so it doesn't affect users of `jvm_app_metric`. 

This also uncovered a state flattening bug for conditions of type `apm_jvm_metric` that could cause drift.  The state flattening required some additional logic since the underlying API fails to return the `condition_scope` field when that condition type is provisioned.

https://docs.newrelic.com/docs/alerts/rest-api-alerts/new-relic-alerts-rest-api/alerts-conditions-api-field-names#violation_close_timer