### PR TITLE
chore(changelog): Update CHANGELOG for v2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<a name="v2.4.1"></a>
+## [v2.4.1] - 2020-07-29
+### Bug Fixes
+- **alerts:** flatten condition scope properly for APM JVM metrics
+- **newrelic_alert_condition:** allow instance scope for JVM app metrics
+
 <a name="v2.4.0"></a>
 ## [v2.4.0] - 2020-07-28
 ### Bug Fixes
@@ -338,8 +344,8 @@
 ## [v0.1.1] - 2017-08-02
 <a name="v0.1.0"></a>
 ## v0.1.0 - 2017-06-21
-[Unreleased]: https://github.com/newrelic/terraform-provider-newrelic/compare/v2.5.0...HEAD
-[v2.5.0]: https://github.com/newrelic/terraform-provider-newrelic/compare/v2.4.0...v2.5.0
+[Unreleased]: https://github.com/newrelic/terraform-provider-newrelic/compare/v2.4.1...HEAD
+[v2.4.1]: https://github.com/newrelic/terraform-provider-newrelic/compare/v2.4.0...v2.4.1
 [v2.4.0]: https://github.com/newrelic/terraform-provider-newrelic/compare/v2.3.0...v2.4.0
 [v2.3.0]: https://github.com/newrelic/terraform-provider-newrelic/compare/v2.2.1...v2.3.0
 [v2.2.1]: https://github.com/newrelic/terraform-provider-newrelic/compare/v2.2.0...v2.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <a name="v2.4.0"></a>
-## [v2.4.0] - 2020-07-27
+## [v2.4.0] - 2020-07-28
 ### Bug Fixes
 - **alerts:** Unify how alert policy selects an account_id
 - **infra_alert_condition:** support zero-value thresholds for infra_alert_condition resource
@@ -10,31 +10,10 @@
 ### Features
 - **infra_alert_condition:** add description attribute
 
-<a name="v1.20.1"></a>
-## [v1.20.1] - 2020-07-27
-### Bug Fixes
-- **infra_alert_condition:** [v1.x] support zero-value thresholds for infra_alert_condition resource
-
 <a name="v2.3.0"></a>
 ## [v2.3.0] - 2020-07-23
 ### Features
 - add a newrelic_account data source
-
-<a name="v1.20.0"></a>
-## [v1.20.0] - 2020-07-23
-### Bug Fixes
-- **alerts:** infra alert condition zero value detection
-- **changelog:** remove 1.18.1 from changelog, 1.19.0 is the replacement
-- **client:** update the client for pagination URL fix
-- **test:** Workloads returns ordered list of scope account IDs, update test
-
-### Documentation Updates
-- **application_settings:** add application settings resource to sidebar ([#582](https://github.com/newrelic/terraform-provider-newrelic/issues/582))
-
-### Features
-- update the release process to prepare for repo handoff
-- **application:** implement newrelic_application resource ([#558](https://github.com/newrelic/terraform-provider-newrelic/issues/558))
-- **dashboard:** add grid_column_count to dashboard schema
 
 <a name="v2.2.1"></a>
 ## [v2.2.1] - 2020-07-10
@@ -67,76 +46,17 @@
 <a name="v2.1.2"></a>
 ## [v2.1.2] - 2020-06-26
 ### Bug Fixes
-- Require condition_scope = `instance` for validation_close_timer
-- Add validation to newrelic_alert_condtion condition_scope
 - **alerts:** require at least one violation time limit attr
 - **alerts:** improve nil handling for alert_channel
-- **alerts:** remove DiffSuppressFunc on TypeSet to avoid test drift
-- **alerts:** infra alert condition zero value detection
-- **alerts:** handle a nil reference with more grace
-- **application_settings:** Remove delete, as it is not possible
-- **deps:** Revert terraform sdk to 1.10.0
-- **newrelic:** fix the failing integration tests ([#519](https://github.com/newrelic/terraform-provider-newrelic/issues/519))
-- **nrql_alert_condition:** threshold_occurrences is case insensitive, attribute description updates
 
 ### Documentation Updates
-- DEPRECATION notice for 1.x
-- prep for v2.x, isolate v1.x docs
-- add callout to top of each v1.x doc page
-- add table for current endpoint in use per resource
-- update README with new pointers
-- update getting started guide to reference new material
-- update index header with improved words
-- include information on pinning a version
-- include sidebar link for 2.x upgrade
-- include v1 index.html in sidebar
-- tidy up after review
-- update API key references to match desires
-- include documentation about upgrading the provider to 2.x
-- **alert_channel:** fix broken 'nested config' anchor link
-- **alerts:** update examples to reflect deprecation
-- **alerts:** update wording to avoid implementation details
-- **alerts:** include deprecation notice for "terms"
-- **alerts:** include caveat about NRQL alerts condition operator usage with outliers
-- **getting started:** fix resource naming
-- **nrql_alert_condition:** update docs to reflect version 2.0 changes
-- **nrql_alert_condition:** add outlier example, add new attributes, deprecate old attributes, update import section
-- **provider:** add region to provider docs, removing references to API base URLs
 - **provider:** additional v2 updates, migration guide updates
-- **provider:** update getting started example to reflect v2 updates
-- **provider:** add provider configuration guide page
-- **provider:** add account_id to argument reference, move argument reference above the fold
-- **provider:** fix incorrect newrelic_application reference in some examples
 - **provider:** add getting started guide to the quick links
+- **provider:** fix incorrect newrelic_application reference in some examples
+- **provider:** add account_id to argument reference, move argument reference above the fold
 - **provider:** add environment variables and schema attribute table
+- **provider:** update getting started example to reflect v2 updates
 - **readme:** update title, add link to latest documentation
-- **workloads:** fix api key attribute name ([#489](https://github.com/newrelic/terraform-provider-newrelic/issues/489))
-
-### Features
-- update the release process to prepare for repo handoff
-- **alerts:** convert Alerts Policies to nerdgraph
-- **application:** implement newrelic_application resource
-- **dashboard:** add grid_column_count to dashboard schema
-- **entity_tags:** add an entity tag resource ([#679](https://github.com/newrelic/terraform-provider-newrelic/issues/679))
-- **eventstometrics:** add an events to metrics rule resource ([#690](https://github.com/newrelic/terraform-provider-newrelic/issues/690))
-- **nrql_alert_condition:** integrate nerdgraph for nrql alert conditions
-- **provider:** add region to provider schema, handle API URLs based off region
-
-<a name="v1.19.1"></a>
-## [v1.19.1] - 2020-06-24
-### Bug Fixes
-- **alerts:** infra alert condition zero value detection
-- **changelog:** remove 1.18.1 from changelog, 1.19.0 is the replacement
-- **client:** update the client for pagination URL fix
-- **test:** Workloads returns ordered list of scope account IDs, update test
-
-### Documentation Updates
-- **application_settings:** add application settings resource to sidebar ([#582](https://github.com/newrelic/terraform-provider-newrelic/issues/582))
-
-### Features
-- update the release process to prepare for repo handoff
-- **application:** implement newrelic_application resource ([#558](https://github.com/newrelic/terraform-provider-newrelic/issues/558))
-- **dashboard:** add grid_column_count to dashboard schema
 
 <a name="v2.1.1"></a>
 ## [v2.1.1] - 2020-06-23
@@ -196,6 +116,21 @@
 - **entity_tags:** add an entity tag resource ([#679](https://github.com/newrelic/terraform-provider-newrelic/issues/679))
 - **nrql_alert_condition:** integrate nerdgraph for nrql alert conditions
 - **provider:** add region to provider schema, handle API URLs based off region
+
+<a name="v1.20.1"></a>
+## [v1.20.1] - 2020-07-27
+### Bug Fixes
+- **infra_alert_condition:** [v1.x] support zero-value thresholds for infra_alert_condition resource
+
+<a name="v1.20.0"></a>
+## [v1.20.0] - 2020-07-23
+<a name="v1.19.1"></a>
+## [v1.19.1] - 2020-06-24
+### Bug Fixes
+- **changelog:** remove 1.18.1 from changelog, 1.19.0 is the replacement
+
+### Features
+- update the release process to prepare for repo handoff
 
 <a name="v1.19.0"></a>
 ## [v1.19.0] - 2020-06-05
@@ -403,18 +338,19 @@
 ## [v0.1.1] - 2017-08-02
 <a name="v0.1.0"></a>
 ## v0.1.0 - 2017-06-21
-[Unreleased]: https://github.com/newrelic/terraform-provider-newrelic/compare/v2.4.0...HEAD
-[v2.4.0]: https://github.com/newrelic/terraform-provider-newrelic/compare/v1.20.1...v2.4.0
-[v1.20.1]: https://github.com/newrelic/terraform-provider-newrelic/compare/v2.3.0...v1.20.1
-[v2.3.0]: https://github.com/newrelic/terraform-provider-newrelic/compare/v1.20.0...v2.3.0
-[v1.20.0]: https://github.com/newrelic/terraform-provider-newrelic/compare/v2.2.1...v1.20.0
+[Unreleased]: https://github.com/newrelic/terraform-provider-newrelic/compare/v2.5.0...HEAD
+[v2.5.0]: https://github.com/newrelic/terraform-provider-newrelic/compare/v2.4.0...v2.5.0
+[v2.4.0]: https://github.com/newrelic/terraform-provider-newrelic/compare/v2.3.0...v2.4.0
+[v2.3.0]: https://github.com/newrelic/terraform-provider-newrelic/compare/v2.2.1...v2.3.0
 [v2.2.1]: https://github.com/newrelic/terraform-provider-newrelic/compare/v2.2.0...v2.2.1
 [v2.2.0]: https://github.com/newrelic/terraform-provider-newrelic/compare/v2.1.2...v2.2.0
-[v2.1.2]: https://github.com/newrelic/terraform-provider-newrelic/compare/v1.19.1...v2.1.2
-[v1.19.1]: https://github.com/newrelic/terraform-provider-newrelic/compare/v2.1.1...v1.19.1
+[v2.1.2]: https://github.com/newrelic/terraform-provider-newrelic/compare/v2.1.1...v2.1.2
 [v2.1.1]: https://github.com/newrelic/terraform-provider-newrelic/compare/v2.1.0...v2.1.1
 [v2.1.0]: https://github.com/newrelic/terraform-provider-newrelic/compare/v2.0.0...v2.1.0
-[v2.0.0]: https://github.com/newrelic/terraform-provider-newrelic/compare/v1.19.0...v2.0.0
+[v2.0.0]: https://github.com/newrelic/terraform-provider-newrelic/compare/v1.20.1...v2.0.0
+[v1.20.1]: https://github.com/newrelic/terraform-provider-newrelic/compare/v1.20.0...v1.20.1
+[v1.20.0]: https://github.com/newrelic/terraform-provider-newrelic/compare/v1.19.1...v1.20.0
+[v1.19.1]: https://github.com/newrelic/terraform-provider-newrelic/compare/v1.19.0...v1.19.1
 [v1.19.0]: https://github.com/newrelic/terraform-provider-newrelic/compare/v1.18.0...v1.19.0
 [v1.18.0]: https://github.com/newrelic/terraform-provider-newrelic/compare/v1.17.1...v1.18.0
 [v1.17.1]: https://github.com/newrelic/terraform-provider-newrelic/compare/v1.17.0...v1.17.1

--- a/build/document.mk
+++ b/build/document.mk
@@ -3,7 +3,7 @@
 #
 
 GOTOOLS     += golang.org/x/tools/cmd/godoc \
-               github.com/git-chglog/git-chglog/cmd/git-chglog
+               github.com/newrelic-forks/git-chglog/cmd/git-chglog
 GODOC       ?= godoc
 GODOC_HTTP  ?= "localhost:6060"
 

--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,15 @@ go 1.13
 require (
 	github.com/bflad/tfproviderlint v0.14.0
 	github.com/client9/misspell v0.3.4
-	github.com/git-chglog/git-chglog v0.0.0-20200414013904-db796966b373
 	github.com/golangci/golangci-lint v1.29.0
 	github.com/goreleaser/goreleaser v0.140.1
 	github.com/hashicorp/terraform-plugin-sdk v1.15.0
+	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
+	github.com/newrelic-forks/git-chglog v0.10.0
 	github.com/newrelic/go-agent/v3 v3.8.1
 	github.com/newrelic/go-insights v1.0.3
 	github.com/newrelic/newrelic-client-go v0.33.2
 	github.com/stretchr/testify v1.6.1
+	golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1 // indirect
 	gotest.tools/gotestsum v0.5.2
 )

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,7 @@ contrib.go.opencensus.io/exporter/stackdriver v0.12.1/go.mod h1:iwB6wGarfphGGe/e
 contrib.go.opencensus.io/integrations/ocsql v0.1.4/go.mod h1:8DsSdjz3F+APR+0z0WkU1aRorQCFfRxvqjUUPMbF3fE=
 contrib.go.opencensus.io/resource v0.1.1/go.mod h1:F361eGI91LCmW1I/Saf+rX0+OFcigGlFvXwEGEnkRLA=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+github.com/AlecAivazis/survey/v2 v2.0.5/go.mod h1:WYBhg6f0y/fNYUuesWQc0PKbJcEliGcYHB9sNT3Bg74=
 github.com/Azure/azure-amqp-common-go/v3 v3.0.0/go.mod h1:SY08giD/XbhTz07tJdpw1SoxQXHPN30+DI3Z04SYqyg=
 github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
 github.com/Azure/azure-pipeline-go v0.2.2 h1:6oiIS9yaG6XCCzhgAgKFfIWyo4LLCiDhZot6ltoThhY=
@@ -543,6 +544,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/pty v1.1.4/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.8 h1:AkaSdXYQOWeaO3neb8EM634ahkXXe3jYbVh/F9lq+GI=
 github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -598,6 +600,8 @@ github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpe
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
+github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=
+github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0 h1:iGBIsUe3+HZ/AD/Vd7DErOt5sU9fa8Uj7A2s1aggv1Y=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -635,6 +639,8 @@ github.com/nakabonne/nestif v0.3.0 h1:+yOViDGhg8ygGrmII72nV9B/zGxY188TYpfolntsaP
 github.com/nakabonne/nestif v0.3.0/go.mod h1:dI314BppzXjJ4HsCnbo7XzrJHPszZsjnk5wEBSYHI2c=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d h1:AREM5mwr4u1ORQBMvzfzBgpsctsbQikCVpvC+tX285E=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
+github.com/newrelic-forks/git-chglog v0.10.0 h1:1QAb4KKJ3IzvViA9CHjbsjeDJJfbn4BKxi9CNOTNJHc=
+github.com/newrelic-forks/git-chglog v0.10.0/go.mod h1:c5tYOYWs8zVtWt9i5yFzmVIryDjNEiV421lr5KNXtus=
 github.com/newrelic/go-agent/v3 v3.8.1 h1:PzM7tOO7ojBxHxEXY/AQJ8bAKrM9vFeFbHPkTaVo8+Q=
 github.com/newrelic/go-agent/v3 v3.8.1/go.mod h1:1A1dssWBwzB7UemzRU6ZVaGDsI+cEn5/bNxI0wiYlIc=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
@@ -821,6 +827,8 @@ github.com/ultraware/whitespace v0.0.4 h1:If7Va4cM03mpgrNH9k49/VOicWpGoG70XPBFFO
 github.com/ultraware/whitespace v0.0.4/go.mod h1:aVMh/gQve5Maj9hQ/hg+F75lr/X5A89uZnzAmWSineA=
 github.com/urfave/cli v1.22.2 h1:gsqYFH8bb9ekPA12kRo0hfjngWQjkJPlN9R0N78BoUo=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli v1.22.4 h1:u7tSpNPPswAFymm8IehJhy4uJMlUuU/GmqSkvJ1InXA=
+github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/uudashr/gocognit v1.0.1 h1:MoG2fZ0b/Eo7NXoIwCVFLG5JED3qgQz5/NEE+rOsjPs=
 github.com/uudashr/gocognit v1.0.1/go.mod h1:j44Ayx2KW4+oB6SWMv8KsmHzZrOInQav7D3cQMJ5JUM=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
@@ -870,6 +878,7 @@ golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
@@ -989,6 +998,7 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502175342-a43fa875dd82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190530182044-ad28b68e88f1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1018,6 +1028,8 @@ golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1 h1:sIky/MyNRSHTrdxfsiUSS4WIAMvInbeXljJz+jDjeYE=
+golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1189,6 +1201,8 @@ google.golang.org/protobuf v1.24.0 h1:UhZDfRO8JRQru4/+LlLE0BRKGF8L+PICnvYZmx/fEG
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 gopkg.in/AlecAivazis/survey.v1 v1.8.7 h1:oBJqtgsyBLg9K5FK9twNUbcPnbCPoh+R9a+7nag3qJM=
 gopkg.in/AlecAivazis/survey.v1 v1.8.7/go.mod h1:iBNOmqKz/NUbZx3bA+4hAGLRC7fSK7tgtVDT4tB22XA=
+gopkg.in/AlecAivazis/survey.v1 v1.8.8 h1:5UtTowJZTz1j7NxVzDGKTz6Lm9IWm8DDF6b7a2wq9VY=
+gopkg.in/AlecAivazis/survey.v1 v1.8.8/go.mod h1:CaHjv79TCgAvXMSFJSVgonHXYWxnhzI3eoHtnX5UgUo=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -5,8 +5,8 @@ package main
 import (
 	_ "github.com/bflad/tfproviderlint/cmd/tfproviderlint"
 	_ "github.com/client9/misspell/cmd/misspell"
-	_ "github.com/git-chglog/git-chglog/cmd/git-chglog"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/goreleaser/goreleaser"
+	_ "github.com/newrelic-forks/git-chglog/cmd/git-chglog"
 	_ "gotest.tools/gotestsum"
 )


### PR DESCRIPTION
The PR also fixes our CHANGELOG by swapping out `git-chglog/git-chglog` for `newrelic-forks/git-chglog`