### PR TITLE
fix: avoid perpetual drift due to `account_id` inheritance from the provider block

### DIFF
--- a/newrelic/data_source_newrelic_alert_policy.go
+++ b/newrelic/data_source_newrelic_alert_policy.go
@@ -22,6 +22,7 @@ func dataSourceNewRelicAlertPolicy() *schema.Resource {
 			"account_id": {
 				Type:        schema.TypeInt,
 				Optional:    true,
+				Computed:    true,
 				Description: "The New Relic account ID to operate on.",
 			},
 			"incident_preference": {

--- a/newrelic/helpers.go
+++ b/newrelic/helpers.go
@@ -3,13 +3,10 @@ package newrelic
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
 	"unicode"
-
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func parseIDs(serializedID string, count int) ([]int, error) {
@@ -94,31 +91,4 @@ func stringInSlice(slice []string, str string) bool {
 	}
 
 	return false
-}
-
-// setIfConfigured will set a resource attribute if it was found to already
-// exist in the configuration for the resource.
-func setIfConfigured(d *schema.ResourceData, attr string, value interface{}) error {
-	if d != nil && attr != "" {
-		if _, ok := d.GetOk(attr); ok {
-			return d.Set(attr, value)
-		}
-	}
-
-	return nil
-}
-
-// envAccountID implements the DefaultFunc to allow a resource to retrieve a number from the environment.
-func envAccountID() (interface{}, error) {
-	if v := os.Getenv("NEW_RELIC_ACCOUNT_ID"); v != "" {
-
-		accountID, err := strconv.Atoi(v)
-		if err != nil {
-			return nil, err
-		}
-
-		return accountID, nil
-	}
-
-	return nil, nil
 }

--- a/newrelic/resource_newrelic_alert_policy.go
+++ b/newrelic/resource_newrelic_alert_policy.go
@@ -32,8 +32,8 @@ func resourceNewRelicAlertPolicy() *schema.Resource {
 			"account_id": {
 				Type:        schema.TypeInt,
 				Optional:    true,
+				Computed:    true,
 				Description: "The New Relic account ID to operate on.",
-				DefaultFunc: envAccountID,
 			},
 			"incident_preference": {
 				Type:         schema.TypeString,

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -3,7 +3,6 @@ package newrelic
 import (
 	"fmt"
 	"log"
-	"os"
 	"strconv"
 	"strings"
 
@@ -258,17 +257,8 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 			"account_id": {
 				Type:        schema.TypeInt,
 				Optional:    true,
+				Computed:    true,
 				Description: "The New Relic account ID for managing your NRQL alert conditions.",
-				DefaultFunc: func() (interface{}, error) {
-					envAcctID := os.Getenv("NEW_RELIC_ACCOUNT_ID")
-					if envAcctID != "" {
-						acctID, err := strconv.Atoi(envAcctID)
-
-						return acctID, err
-					}
-
-					return nil, nil
-				},
 			},
 			"description": {
 				Type:        schema.TypeString,

--- a/newrelic/structures_newrelic_alert_policy.go
+++ b/newrelic/structures_newrelic_alert_policy.go
@@ -18,7 +18,7 @@ func flattenAlertPolicy(policy *alerts.AlertsPolicy, d *schema.ResourceData, acc
 		return err
 	}
 
-	err = setIfConfigured(d, "account_id", accountID)
+	err = d.Set("account_id", accountID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Resolves: #809 