### PR TITLE
fix: cannot create resource "newrelic_infra_alert_condition" of type …

### DIFF
--- a/newrelic/structures_newrelic_infra_alert_condition.go
+++ b/newrelic/structures_newrelic_infra_alert_condition.go
@@ -174,7 +174,7 @@ func validateAttributesForType(c *alerts.InfrastructureCondition) error {
 		if c.Critical.Function != "" {
 			return fmt.Errorf("time_function is not supported by condition type %s", c.Type)
 		}
-		if *c.Critical.Value != 0.0 {
+		if c.Critical.Value != nil && *c.Critical.Value != 0.0 {
 			return fmt.Errorf("value is not supported by condition type %s", c.Type)
 		}
 	}

--- a/newrelic/structures_newrelic_infra_alert_condition.go
+++ b/newrelic/structures_newrelic_infra_alert_condition.go
@@ -171,7 +171,7 @@ func validateAttributesForType(c *alerts.InfrastructureCondition) error {
 		if c.Critical.Function != "" {
 			return fmt.Errorf("time_function is not supported by condition type %s", c.Type)
 		}
-		if *c.Critical.Value >= 0.0 {
+		if *c.Critical.Value != 0.0 {
 			return fmt.Errorf("value is not supported by condition type %s", c.Type)
 		}
 	}


### PR DESCRIPTION
This patch fix issue #843. 

When type of resource "newrelic_infra_alert_condition" is "infra_host_not_reporting" then critical.value cannot be defined in the resource definition because it does not make sense, if c.Critical.Value is 0 in the check at line 174 then this means that the value has not been defined in a terraform resource definition, so using >= is wrong and always cause the error ```Error: value is not supported by condition type infra_host_not_reporting``` when perfoming terraform apply.

Please note that it is not enough to apply this patch, you also need to merge the pull request #832, otherwise a nil pointer deference error occours.