### PR TITLE
fix(changelog): ensure proper branch to base from

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -27,6 +27,21 @@ jobs:
           make changelog
           make spell-check-fix
 
+      - uses: actions/upload-artifact@v2
+        with:
+          name: CHANGELOG.md
+          path: CHANGELOG.md
+
+      - name: Checkout the pull request base
+        uses: actions/checkout@v2
+        with:
+          ref: master
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: CHANGELOG.md
+          path: .
+
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
Without this change, the pull-request action doesn't have a valid base due to
the detached head state when the tag is checked out.  Here we use the upload and
download artifact actions around switch to the master branch before we submit a
pull request.  This should result in the desired behavior, accounting for the
needs of the pull-request action.