### PR TITLE
chore(githooks): keep commit-msg hook, remove pre-push and pre-commit hooks

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 echo
-echo "Checking commit message..."
+echo "Checking commit message format..."
 echo
 
 make lint-commit COMMIT_MSG_FILE=$1
-

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,0 @@
-#!/bin/sh
-echo
-echo "Running pre-commit checks..."
-echo
-
-make lint

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,7 +1,0 @@
-#!/bin/sh
-echo
-echo "Running tests before pushing..."
-echo
-
-make test-unit
-


### PR DESCRIPTION
We experimented with `pre-push` and `pre-commit` hooks for linting and testing, but this became cumbersome. 

Note: We still lint commit message format using the `commit-msg` hook.