### PR TITLE
Fixed an issue with empty extrapolation settings causing API errors

### DIFF
--- a/newrelic/provider_test.go
+++ b/newrelic/provider_test.go
@@ -90,6 +90,7 @@ func testAccPreCheck(t *testing.T) {
 
 func testAccCreateApplication(t *testing.T) {
 	app, err := newrelic.NewApplication(
+		newrelic.ConfigFromEnvironment(),
 		newrelic.ConfigAppName(testAccExpectedApplicationName),
 		newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
 	)

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -304,6 +304,10 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 					// Always store lowercase to prevent state drift
 					return strings.ToLower(v.(string))
 				},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// Assume that empty string and 'none' are the same for diff purposes due to API defaults
+					return (old == "" || old == "none") == (new == "" || new == "none")
+				},
 			},
 			"fill_value": {
 				Type:         schema.TypeFloat,

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -68,8 +68,6 @@ func TestAccNewRelicNrqlAlertCondition_MissingPolicy(t *testing.T) {
 					3,
 					3600,
 					conditionalAttr,
-					"none",
-					"null",
 					facetClause,
 				),
 			},
@@ -81,8 +79,6 @@ func TestAccNewRelicNrqlAlertCondition_MissingPolicy(t *testing.T) {
 					3,
 					3600,
 					conditionalAttr,
-					"none",
-					"null",
 					facetClause,
 				),
 				Check: testAccCheckNewRelicNrqlAlertConditionExists("newrelic_nrql_alert_condition.foo"),
@@ -291,8 +287,6 @@ func TestAccNewRelicNrqlAlertCondition_NerdGraphOutlier(t *testing.T) {
 					3,
 					3600,
 					conditionalAttr,
-					"none",
-					"null",
 					facetClause,
 				),
 				Check: resource.ComposeTestCheckFunc(
@@ -307,8 +301,6 @@ func TestAccNewRelicNrqlAlertCondition_NerdGraphOutlier(t *testing.T) {
 					3,
 					1800,
 					conditionalAttr,
-					"none",
-					"null",
 					facetClause,
 				),
 				Check: resource.ComposeTestCheckFunc(
@@ -581,8 +573,6 @@ func testAccNewRelicNrqlAlertConditionOutlierNerdGraphConfig(
 	nrqlEvalOffset int,
 	termDuration int,
 	conditionalAttr string,
-	fillOption string,
-	fillValue string,
 	facetClause string,
 ) string {
 	return fmt.Sprintf(`
@@ -599,11 +589,9 @@ resource "newrelic_nrql_alert_condition" "foo" {
 	enabled              = false
 	description          = "test description"
 	violation_time_limit = "one_hour"
-	fill_option          = "%[6]s"
-	fill_value           = %[7]s
 
 	nrql {
-		query             = "SELECT uniqueCount(hostname) FROM ComputeSample %[8]s"
+		query             = "SELECT uniqueCount(hostname) FROM ComputeSample %[6]s"
 		evaluation_offset = %[3]d
 	}
 
@@ -617,5 +605,5 @@ resource "newrelic_nrql_alert_condition" "foo" {
 	# Will be one of baseline_direction, value_function, expected_groups, or open_violation_on_group_overlap depending on condition type
 	%[5]s
 }
-`, name, conditionType, nrqlEvalOffset, termDuration, conditionalAttr, fillOption, fillValue, facetClause)
+`, name, conditionType, nrqlEvalOffset, termDuration, conditionalAttr, facetClause)
 }

--- a/newrelic/structures_newrelic_nrql_alert_condition.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition.go
@@ -43,10 +43,10 @@ var (
 	}
 
 	// old:new
-	fillOptionMap = map[string]alerts.AlertsFillOption{
-		"none":       alerts.AlertsFillOptionTypes.NONE,
-		"last_value": alerts.AlertsFillOptionTypes.LAST_VALUE,
-		"static":     alerts.AlertsFillOptionTypes.STATIC,
+	fillOptionMap = map[string]*alerts.AlertsFillOption{
+		"none":       &alerts.AlertsFillOptionTypes.NONE,
+		"last_value": &alerts.AlertsFillOptionTypes.LAST_VALUE,
+		"static":     &alerts.AlertsFillOptionTypes.STATIC,
 	}
 
 	// new:old
@@ -344,10 +344,9 @@ func expandExpiration(d *schema.ResourceData) (*alerts.AlertsNrqlConditionExpira
 
 // NerdGraph
 func expandSignal(d *schema.ResourceData) (*alerts.AlertsNrqlConditionSignal, error) {
-	var signal alerts.AlertsNrqlConditionSignal
-
-	mappedFillOption := fillOptionMap[strings.ToLower(d.Get("fill_option").(string))]
-	signal.FillOption = &mappedFillOption
+	signal := alerts.AlertsNrqlConditionSignal{
+		FillOption: fillOptionMap[strings.ToLower(d.Get("fill_option").(string))],
+	}
 
 	// Due to the way that nulls are handled as zeros in Terraform 0.11, add another check that a 0 fill_value
 	// can only be applied when the fill_option is static


### PR DESCRIPTION
When excluding `fill_option` an API error would be returned. This PR fixes that issue.

```
Error: Argument "condition" has invalid value $condition.
In field "signal": Expected type "AlertsNrqlConditionSignalInput", found {fillOption: "", fillValue: null}.
In field "fillOption": Expected type "AlertsFillOption", found ""., null
```