### PR TITLE
chore(deps): update newrelic/newrelic-client-go to v0.41.2

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -46,6 +46,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v3
         with:
+          base: master
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "docs: update changelog"
           committer: GitHub <noreply@github.com>

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/newrelic-forks/git-chglog v0.10.0
 	github.com/newrelic/go-agent/v3 v3.8.1
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go v0.41.0
+	github.com/newrelic/newrelic-client-go v0.41.2
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1 // indirect
 	gotest.tools/gotestsum v0.5.3

--- a/go.sum
+++ b/go.sum
@@ -671,8 +671,8 @@ github.com/newrelic/go-agent/v3 v3.8.1 h1:PzM7tOO7ojBxHxEXY/AQJ8bAKrM9vFeFbHPkTa
 github.com/newrelic/go-agent/v3 v3.8.1/go.mod h1:1A1dssWBwzB7UemzRU6ZVaGDsI+cEn5/bNxI0wiYlIc=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go v0.41.0 h1:WYRmU9jAc9q2NGaoyxozZaiP/+UFQbVcRhuH1+XNoZE=
-github.com/newrelic/newrelic-client-go v0.41.0/go.mod h1:Ao+Iogn+6P2i0+tjdk48XJXn4IPwougANyEnAIhJYPI=
+github.com/newrelic/newrelic-client-go v0.41.2 h1:QJVBRkSbv4hNzbFL3FAfodlC+GpF0YnHS+bWCSbE7pI=
+github.com/newrelic/newrelic-client-go v0.41.2/go.mod h1:Ao+Iogn+6P2i0+tjdk48XJXn4IPwougANyEnAIhJYPI=
 github.com/newrelic/tutone v0.2.3/go.mod h1:tfWM773ZGUHqQu70NV3DPjrFmxQ9+p8/++7UJ1J1gmE=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=


### PR DESCRIPTION
Resolves: #860 

- #860 is fixed per a [fix in newrelic-client-go](https://github.com/newrelic/newrelic-client-go/pull/478)
- This PR also includes a fix for the `create-pull-request` GitHub Action (adds `base` to the config) 