### PR TITLE
fix(alerts): avoid bad index reference

### DIFF
--- a/newrelic/structures_newrelic_nrql_alert_condition.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition.go
@@ -530,16 +530,24 @@ func flattenNrqlTerms(terms []alerts.NrqlConditionTerm, configTerms []interface{
 			"threshold": term.Threshold,
 		}
 
-		setDuration := configuredTerms[i]["duration"]
-		if setDuration != nil && setDuration.(int) > 0 {
-			dst["duration"] = term.ThresholdDuration / 60 // convert to minutes for old way
+		if i < len(configuredTerms) {
+			setDuration := configuredTerms[i]["duration"]
+			if setDuration != nil && setDuration.(int) > 0 {
+				dst["duration"] = term.ThresholdDuration / 60 // convert to minutes for old way
+			} else {
+				dst["threshold_duration"] = term.ThresholdDuration
+			}
 		} else {
 			dst["threshold_duration"] = term.ThresholdDuration
 		}
 
-		setTimeFunction := configuredTerms[i]["time_function"]
-		if setTimeFunction != nil && setTimeFunction.(string) != "" {
-			dst["time_function"] = timeFunctionMapNewOld[term.ThresholdOccurrences]
+		if i < len(configuredTerms) {
+			setTimeFunction := configuredTerms[i]["time_function"]
+			if setTimeFunction != nil && setTimeFunction.(string) != "" {
+				dst["time_function"] = timeFunctionMapNewOld[term.ThresholdOccurrences]
+			} else {
+				dst["threshold_occurrences"] = strings.ToLower(string(term.ThresholdOccurrences))
+			}
 		} else {
 			dst["threshold_occurrences"] = strings.ToLower(string(term.ThresholdOccurrences))
 		}


### PR DESCRIPTION
Without this change, cases where the configured number of terms differ from that
in the API, we incorrectly reference an index that doesn't exist.  This also
looks to be the condition when we deprecate an item, and the state has
half-moved over to the new values.  Here we ensure that we check the length of
the conditions before we attempt to use the values and avoid a bad index
reference.

fixes: #882