### PR TITLE
chore: replace some v2 GetPolicy() with nerdgrpah QueryPolicy()

### DIFF
--- a/newrelic/resource_helpers.go
+++ b/newrelic/resource_helpers.go
@@ -109,10 +109,14 @@ func resourceImportStateWithMetadata(defaultIDCount int, attribute string) schem
 // resources can be scoped to specific accounts. Bear in mind those accounts must be
 // accessible with the provided Personal API Key (APIKS).
 func selectAccountID(providerCondig *ProviderConfig, d *schema.ResourceData) int {
-	resourceAccountID := d.Get("account_id").(int)
+	resourceAccountIDAttr := d.Get("account_id")
 
-	if resourceAccountID != 0 {
-		return resourceAccountID
+	if resourceAccountIDAttr != nil {
+		resourceAccountID := resourceAccountIDAttr.(int)
+
+		if resourceAccountID != 0 {
+			return resourceAccountID
+		}
 	}
 
 	return providerCondig.AccountID

--- a/newrelic/resource_newrelic_alert_condition.go
+++ b/newrelic/resource_newrelic_alert_condition.go
@@ -3,6 +3,7 @@ package newrelic
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -221,7 +222,9 @@ func resourceNewRelicAlertConditionCreate(d *schema.ResourceData, meta interface
 }
 
 func resourceNewRelicAlertConditionRead(d *schema.ResourceData, meta interface{}) error {
+	providerConfig := meta.(*ProviderConfig)
 	client := meta.(*ProviderConfig).NewClient
+	accountID := selectAccountID(providerConfig, d)
 
 	log.Printf("[INFO] Reading New Relic alert condition %s", d.Id())
 
@@ -233,13 +236,12 @@ func resourceNewRelicAlertConditionRead(d *schema.ResourceData, meta interface{}
 	policyID := ids[0]
 	id := ids[1]
 
-	_, err = client.Alerts.GetPolicy(policyID)
+	_, err = client.Alerts.QueryPolicy(accountID, strconv.Itoa(policyID))
 	if err != nil {
 		if _, ok := err.(*errors.NotFound); ok {
 			d.SetId("")
 			return nil
 		}
-
 		return err
 	}
 

--- a/newrelic/resource_newrelic_infra_alert_condition.go
+++ b/newrelic/resource_newrelic_infra_alert_condition.go
@@ -2,6 +2,7 @@ package newrelic
 
 import (
 	"log"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -197,7 +198,9 @@ func resourceNewRelicInfraAlertConditionCreate(d *schema.ResourceData, meta inte
 }
 
 func resourceNewRelicInfraAlertConditionRead(d *schema.ResourceData, meta interface{}) error {
+	providerConfig := meta.(*ProviderConfig)
 	client := meta.(*ProviderConfig).NewClient
+	accountID := selectAccountID(providerConfig, d)
 
 	log.Printf("[INFO] Reading New Relic Infra alert condition %s", d.Id())
 
@@ -209,7 +212,7 @@ func resourceNewRelicInfraAlertConditionRead(d *schema.ResourceData, meta interf
 	policyID := ids[0]
 	id := ids[1]
 
-	_, err = client.Alerts.GetPolicy(policyID)
+	_, err = client.Alerts.QueryPolicy(accountID, strconv.Itoa(policyID))
 	if err != nil {
 		if _, ok := err.(*errors.NotFound); ok {
 			d.SetId("")

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -391,9 +391,10 @@ func resourceNewRelicNrqlAlertConditionRead(d *schema.ResourceData, meta interfa
 		return err
 	}
 
+	policyID := ids[0]
 	conditionID := ids[1]
 
-	_, err = client.Alerts.QueryPolicy(accountID, strconv.Itoa(ids[0]))
+	_, err = client.Alerts.QueryPolicy(accountID, strconv.Itoa(policyID))
 	if err != nil {
 		if _, ok := err.(*errors.NotFound); ok {
 			d.SetId("")

--- a/newrelic/resource_newrelic_plugins_alert_condition.go
+++ b/newrelic/resource_newrelic_plugins_alert_condition.go
@@ -2,6 +2,7 @@ package newrelic
 
 import (
 	"log"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -137,7 +138,9 @@ func resourceNewRelicPluginsAlertConditionCreate(d *schema.ResourceData, meta in
 }
 
 func resourceNewRelicPluginsAlertConditionRead(d *schema.ResourceData, meta interface{}) error {
+	providerConfig := meta.(*ProviderConfig)
 	client := meta.(*ProviderConfig).NewClient
+	accountID := selectAccountID(providerConfig, d)
 
 	log.Printf("[INFO] Reading New Relic alert condition %s", d.Id())
 
@@ -149,7 +152,7 @@ func resourceNewRelicPluginsAlertConditionRead(d *schema.ResourceData, meta inte
 	policyID := ids[0]
 	id := ids[1]
 
-	_, err = client.Alerts.GetPolicy(policyID)
+	_, err = client.Alerts.QueryPolicy(accountID, strconv.Itoa(policyID))
 	if err != nil {
 		if _, ok := err.(*errors.NotFound); ok {
 			d.SetId("")


### PR DESCRIPTION
Without this change, in large environments it appears that we place too much
load on the backing services, which can cause sporadic behavior.  With recent
API key changes, we are now in a position to straddle the line between REST and
Nerdgraph for a single resource, and so here we use Nerdgraph to replace the
GetPolicy calls, which perform a list to detect if the policy in question exists
before throwing away the response.