### PR TITLE
chore: integration test improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,6 +104,7 @@ jobs:
           ${{ runner.os }}-go-
 
     - name: Integration Tests
+      if: github.event.pull_request.head.repo.full_name == github.repository
       run: make test-integration
       env:
         NEW_RELIC_ACCOUNT_ID: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
       run: make test-unit
 
     - name: New Relic JUnit Reporter
-      if: ${{ always() }}
+      if: github.event.pull_request.head.repo.full_name == github.repository
       uses: newrelic/junit-reporter-action@v0.1.1
       with:
         accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
@@ -115,7 +115,7 @@ jobs:
         NR_ACC_TESTING: ${{ secrets.NR_ACC_TESTING }}
 
     - name: New Relic JUnit Reporter
-      if: ${{ always() }}
+      if: github.event.pull_request.head.repo.full_name == github.repository
       uses: newrelic/junit-reporter-action@v0.1.1
       with:
         accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}

--- a/README.md
+++ b/README.md
@@ -80,18 +80,31 @@ $ make build
 
 #### Testing
 
-In order to test the provider, run `make test`. This will run the unit test suite.
+In order to test the provider, run `make test`. This will run the full test suite.
 
 ```sh
 $ make test
 ```
 
-In order to run the full suite of Acceptance tests, run `make testacc`.
+In order to run the unit test suite only, run `make test-unit`.
+```sh
+$ make test-unit
+```
 
-_Note:_ Acceptance tests _create real resources_, and often cost money to run. The environment variables `NEW_RELIC_API_KEY` and `NEW_RELIC_LICENSE_KEY` must also be set with your associated keys for acceptance tests to work properly.
+In order to run the acceptance test suite only, run `make test-integration`.
+```sh
+$ make test-integration
+```
+
+_Note:_ Acceptance tests _create real resources_. The following environment
+variables must bet set for acceptance tests to run:
 
 ```sh
-$ make testacc
+NEW_RELIC_API_KEY
+NEW_RELIC_ACCOUNT_ID
+NEW_RELIC_INSIGHTS_INSERT_KEY
+NEW_RELIC_LICENSE_KEY
+NEW_RELIC_REGION
 ```
 
 #### Go Version Support

--- a/build/test.mk
+++ b/build/test.mk
@@ -33,7 +33,7 @@ test-unit: tools
 test-integration: tools
 	@echo "=== $(PROJECT_NAME) === [ test-integration ]: running integration tests..."
 	@mkdir -p $(COVERAGE_DIR)
-	@TF_ACC=1 NR_ACC_TESTING=1 $(TEST_RUNNER) -f testname --junitfile $(COVERAGE_DIR)/integration.xml --rerun-fails=3 --packages $(GO_PKGS) \
+	@TF_ACC=1 NR_ACC_TESTING=1 $(TEST_RUNNER) -f testname --junitfile $(COVERAGE_DIR)/integration.xml --rerun-fails=3 --packages "$(GO_PKGS)" \
 		-- -v -parallel 4 -tags=integration $(TEST_ARGS) -covermode=$(COVERMODE) -coverprofile $(COVERAGE_DIR)/integration.tmp \
 		   -timeout 120m -ldflags=$(LDFLAGS_TEST)
 

--- a/newrelic/provider_integration_test.go
+++ b/newrelic/provider_integration_test.go
@@ -29,6 +29,7 @@ func TestAccNewRelicProvider_Region(t *testing.T) {
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: func(*terraform.State) error { return nil },
 		Steps: []resource.TestStep{

--- a/newrelic/provider_test.go
+++ b/newrelic/provider_test.go
@@ -76,15 +76,15 @@ resource "newrelic_alert_policy" "foo" {
 
 func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("NEW_RELIC_API_KEY"); v == "" {
-		t.Fatal("[WARN] NEW_RELIC_API_KEY has not been set for acceptance tests")
+		t.Skipf("[WARN] NEW_RELIC_API_KEY has not been set for acceptance tests")
 	}
 
 	if v := os.Getenv("NEW_RELIC_LICENSE_KEY"); v == "" {
-		t.Fatal("NEW_RELIC_LICENSE_KEY must be set for acceptance tests")
+		t.Skipf("NEW_RELIC_LICENSE_KEY must be set for acceptance tests")
 	}
 
-	if v := os.Getenv("NEW_RELIC_ADMIN_API_KEY"); v == "" {
-		t.Fatal("NEW_RELIC_ADMIN_API_KEY must be set for acceptance tests")
+	if v := os.Getenv("NEW_RELIC_ACCOUNT_ID"); v == "" {
+		t.Skipf("NEW_RELIC_ACCOUNT_ID must be set for acceptance tests")
 	}
 
 	//testAccApplicationsCleanup(t)

--- a/newrelic/resource_newrelic_alert_policy_integration_test.go
+++ b/newrelic/resource_newrelic_alert_policy_integration_test.go
@@ -88,6 +88,7 @@ func TestAccNewRelicAlertPolicy_WithChannels(t *testing.T) {
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicAlertPolicyDestroy,
 		Steps: []resource.TestStep{

--- a/newrelic/resource_newrelic_application_settings_test.go
+++ b/newrelic/resource_newrelic_application_settings_test.go
@@ -24,7 +24,7 @@ func TestAccNewRelicApplicationSettings_Basic(t *testing.T) {
 	testExpectedApplicationName = fmt.Sprintf("tf_test_%s", acctest.RandString(10))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicApplicationDestroy,
 		Steps: []resource.TestStep{
@@ -108,15 +108,11 @@ func testAccCheckNewRelicApplicationExists(n string) resource.TestCheckFunc {
 
 func testPreCheck(t *testing.T) {
 	if v := os.Getenv("NEW_RELIC_API_KEY"); v == "" {
-		t.Fatal("NEW_RELIC_API_KEY must be set for acceptance tests")
+		t.Skipf("NEW_RELIC_API_KEY must be set for acceptance tests")
 	}
 
 	if v := os.Getenv("NEW_RELIC_LICENSE_KEY"); v == "" {
-		t.Fatal("NEW_RELIC_LICENSE_KEY must be set for acceptance tests")
-	}
-
-	if v := os.Getenv("NEW_RELIC_ADMIN_API_KEY"); v == "" {
-		t.Log("[WARN] NEW_RELIC_ADMIN_API_KEY has not been set for acceptance tests")
+		t.Skipf("NEW_RELIC_LICENSE_KEY must be set for acceptance tests")
 	}
 
 	testCreateApplication(t)

--- a/newrelic/resource_newrelic_application_settings_test.go
+++ b/newrelic/resource_newrelic_application_settings_test.go
@@ -24,7 +24,7 @@ func TestAccNewRelicApplicationSettings_Basic(t *testing.T) {
 	testExpectedApplicationName = fmt.Sprintf("tf_test_%s", acctest.RandString(10))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicApplicationDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
- suppress integration tests on PRs initiated from a fork
- suppress JUnit test reporting on PRs initiated from a fork
- fix test-integration make target
- allow integration test suite to pass if environment has not been configured, skipping the tests inside
- update readme