### PR TITLE
chore: allow integration tests to run for non-DTK accounts

### DIFF
--- a/build/test.mk
+++ b/build/test.mk
@@ -33,7 +33,7 @@ test-unit: tools
 test-integration: tools
 	@echo "=== $(PROJECT_NAME) === [ test-integration ]: running integration tests..."
 	@mkdir -p $(COVERAGE_DIR)
-	@TF_ACC=1 NR_ACC_TESTING=1 $(TEST_RUNNER) -f testname --junitfile $(COVERAGE_DIR)/integration.xml --rerun-fails=3 --packages "$(GO_PKGS)" \
+	@TF_ACC=1 $(TEST_RUNNER) -f testname --junitfile $(COVERAGE_DIR)/integration.xml --rerun-fails=3 --packages "$(GO_PKGS)" \
 		-- -v -parallel 4 -tags=integration $(TEST_ARGS) -covermode=$(COVERMODE) -coverprofile $(COVERAGE_DIR)/integration.tmp \
 		   -timeout 120m -ldflags=$(LDFLAGS_TEST)
 

--- a/newrelic/resource_newrelic_alert_condition_integration_test.go
+++ b/newrelic/resource_newrelic_alert_condition_integration_test.go
@@ -173,6 +173,10 @@ func TestAccNewRelicAlertCondition_ApplicationScopeWithCloseTimer(t *testing.T) 
 }
 
 func TestAccNewRelicAlertCondition_InstanceScopeWithCloseTimer(t *testing.T) {
+	if !nrInternalAccount {
+		t.Skipf("New Relic internal testing account required")
+	}
+
 	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -188,6 +192,10 @@ func TestAccNewRelicAlertCondition_InstanceScopeWithCloseTimer(t *testing.T) {
 }
 
 func TestAccNewRelicAlertCondition_APMJVMMetricApplicationScope(t *testing.T) {
+	if !nrInternalAccount {
+		t.Skipf("New Relic internal testing account required")
+	}
+
 	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -202,6 +210,10 @@ func TestAccNewRelicAlertCondition_APMJVMMetricApplicationScope(t *testing.T) {
 	})
 }
 func TestAccNewRelicAlertCondition_APMJVMMetricInstanceScope(t *testing.T) {
+	if !nrInternalAccount {
+		t.Skipf("New Relic internal testing account required")
+	}
+
 	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/newrelic/resource_newrelic_entity_tags_test.go
+++ b/newrelic/resource_newrelic_entity_tags_test.go
@@ -20,14 +20,14 @@ func TestAccNewRelicEntityTags_Basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test: Create
 			{
-				Config: testAccNewRelicEntityTagsConfig(testApplicationName),
+				Config: testAccNewRelicEntityTagsConfig(testAccExpectedApplicationName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicEntityTagsExist(resourceName, []string{"test_key"}),
 				),
 			},
 			// Test: Update
 			{
-				Config: testAccNewRelicEntityTagsConfigUpdated(testApplicationName),
+				Config: testAccNewRelicEntityTagsConfigUpdated(testAccExpectedApplicationName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicEntityTagsExist(resourceName, []string{"test_key_2"}),
 				),

--- a/newrelic/resource_newrelic_infra_alert_condition_test.go
+++ b/newrelic/resource_newrelic_infra_alert_condition_test.go
@@ -141,6 +141,10 @@ func TestAccNewRelicInfraAlertCondition_Thresholds(t *testing.T) {
 }
 
 func TestAccNewRelicInfraAlertCondition_ThresholdFloatValue(t *testing.T) {
+	if !nrInternalAccount {
+		t.Skipf("New Relic internal testing account required")
+	}
+
 	resourceName := "newrelic_infra_alert_condition.foo"
 	rand := acctest.RandString(5)
 	rName := fmt.Sprintf("tf-test-%s", rand)
@@ -166,7 +170,11 @@ func TestAccNewRelicInfraAlertCondition_ThresholdFloatValue(t *testing.T) {
 	})
 }
 
-func TestAccNewRelicInfraAlertCondition_VoilationCloseTimerDisable(t *testing.T) {
+func TestAccNewRelicInfraAlertCondition_ViolationCloseTimerDisable(t *testing.T) {
+	if !nrInternalAccount {
+		t.Skipf("New Relic internal testing account required")
+	}
+
 	resourceName := "newrelic_infra_alert_condition.foo"
 	rand := acctest.RandString(5)
 	rName := fmt.Sprintf("tf-test-%s", rand)

--- a/newrelic/resource_newrelic_workload_test.go
+++ b/newrelic/resource_newrelic_workload_test.go
@@ -11,11 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-var (
-	testEntityGUID      = "MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1"
-	testApplicationName = "Dummy App"
-)
-
 func TestAccNewRelicWorkload_Basic(t *testing.T) {
 	resourceName := "newrelic_workload.foo"
 	rName := acctest.RandString(5)
@@ -160,47 +155,66 @@ func testAccCheckNewRelicWorkloadDestroy(s *terraform.State) error {
 
 func testAccNewRelicWorkloadConfig(name string) string {
 	return fmt.Sprintf(`
+
+data "newrelic_entity" "app" {
+	name = "%[3]s"
+	domain = "APM"
+	type = "APPLICATION"
+}
+
 resource "newrelic_workload" "foo" {
 	name = "%[2]s"
 	account_id = %[1]d
 
-	entity_guids = ["%[3]s"]
+	entity_guids = [data.newrelic_entity.app.guid]
 
 	entity_search_query {
-		query = "name like '%[4]s'"
+		query = "name like '%[3]s'"
 	}
 
 	scope_account_ids =  [%[1]d, 1]
 }
-`, testAccountID, name, testEntityGUID, testApplicationName)
+`, testAccountID, name, testAccExpectedApplicationName)
 }
 
 func testAccNewRelicWorkloadConfigUpdated(name string) string {
 	return fmt.Sprintf(`
+data "newrelic_entity" "app" {
+	name = "%[3]s"
+	domain = "APM"
+	type = "APPLICATION"
+}
+
 resource "newrelic_workload" "foo" {
 	name = "%[2]s-updated"
 	account_id = %[1]d
 
-	entity_guids = ["%[3]s"]
+	entity_guids = [data.newrelic_entity.app.guid]
 
 	entity_search_query {
-		query = "name like '%[4]s'"
+		query = "name like '%[3]s'"
 	}
 
 	scope_account_ids =  [%[1]d, 1]
 }
-`, testAccountID, name, testEntityGUID, testApplicationName)
+`, testAccountID, name, testAccExpectedApplicationName)
 }
 
 func testAccNewRelicWorkloadConfigEntitiesOnly(name string) string {
 	return fmt.Sprintf(`
+data "newrelic_entity" "app" {
+	name = "%[3]s"
+	domain = "APM"
+	type = "APPLICATION"
+}
+
 resource "newrelic_workload" "foo" {
 	name = "%[2]s"
 	account_id = %[1]d
 
-	entity_guids = ["%[3]s"]
+	entity_guids = [data.newrelic_entity.app.guid]
 }
-`, testAccountID, name, testEntityGUID)
+`, testAccountID, name, testAccExpectedApplicationName)
 }
 
 func testAccNewRelicWorkloadConfigEntitySearchQueriesOnly(name string) string {


### PR DESCRIPTION
To test, point the integration suite at an account other than the DTK test account and run.

DTK team members will need to set NR_ACC_TESTING=1 locally to run the entire suite after this is merged.