### PR TITLE
chore: allow integration tests to run for all accounts

### DIFF
--- a/newrelic/data_source_newrelic_account_test.go
+++ b/newrelic/data_source_newrelic_account_test.go
@@ -27,6 +27,10 @@ func TestAccNewRelicAccountDataSource_Basic(t *testing.T) {
 }
 
 func TestAccNewRelicAccountDataSource_ByName(t *testing.T) {
+	if !nrInternalAccount {
+		t.Skipf("New Relic internal testing account required")
+	}
+	
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,

--- a/newrelic/resource_newrelic_workload_test.go
+++ b/newrelic/resource_newrelic_workload_test.go
@@ -172,7 +172,7 @@ resource "newrelic_workload" "foo" {
 		query = "name like '%[3]s'"
 	}
 
-	scope_account_ids =  [%[1]d, 1]
+	scope_account_ids =  [%[1]d]
 }
 `, testAccountID, name, testAccExpectedApplicationName)
 }
@@ -195,7 +195,7 @@ resource "newrelic_workload" "foo" {
 		query = "name like '%[3]s'"
 	}
 
-	scope_account_ids =  [%[1]d, 1]
+	scope_account_ids =  [%[1]d]
 }
 `, testAccountID, name, testAccExpectedApplicationName)
 }
@@ -236,7 +236,7 @@ resource "newrelic_workload" "foo" {
 	name = "%[2]s"
 	account_id = %[1]d
 
-	scope_account_ids =  [%[1]d, 1]
+	scope_account_ids =  [%[1]d]
 }
 `, testAccountID, name)
 }


### PR DESCRIPTION
This time fixing some tests so they no longer have to be run in a sub of account 1.