### PR TITLE
fix(dashboard): use state migration to fix 500 error when upgrading from v2.7.5 to v2.8+

### DIFF
--- a/newrelic/resource_newrelic_dashboard.go
+++ b/newrelic/resource_newrelic_dashboard.go
@@ -172,14 +172,14 @@ func resourceNewRelicDashboard() *schema.Resource {
 }
 
 // v2.8.0 changed `widget` from TypeSet to TypeList, but we didn't
-// use state migration. Since this change broke things for folks
-// trying to upgrade from v2.7.5 to v2.8.0 in some cases, we have
-// to switch back to TypeSet. So this time we need to make sure we
-// migrate the state to the latest SchemaVersion, this basically
-// reverts the previous change and hopefully allows those that
-// upgraded to v2.8+ to continue to upgrade to which ever version
-// this is released in. In the future, we should always use state
-// migration if an attribute changes its schema type.
+// use state migration. Since this change broke things for some
+// folks trying to upgrade from v2.7.5 to v2.8.0, we have to switch
+// back to TypeSet. So this time we need to make sure we migrate
+// the state to the latest SchemaVersion, this basically reverts
+// the previous change and hopefully allows those that upgraded to
+// v2.8+ to continue to upgrade to which ever version this is
+// released in. In the future, we should always use state migration
+// if an attribute changes its schema type.
 func resourceV0() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceNewRelicDashboardCreate,

--- a/newrelic/resource_newrelic_dashboard.go
+++ b/newrelic/resource_newrelic_dashboard.go
@@ -179,7 +179,7 @@ func resourceNewRelicDashboard() *schema.Resource {
 // reverts the previous change and hopefully allows those that
 // upgraded to v2.8+ to continue to upgrade to which ever version
 // this is released in. In the future, we should always use state
-// migration is an attribute changes its schema type.
+// migration if an attribute changes its schema type.
 func resourceV0() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceNewRelicDashboardCreate,

--- a/newrelic/resource_newrelic_dashboard_test.go
+++ b/newrelic/resource_newrelic_dashboard_test.go
@@ -57,14 +57,9 @@ func TestAccNewRelicDashboard_CrossAccountWidget(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test: Create
 			{
-				Config: testAccCheckNewRelicDashboardConfigCrossAccountWidgets(rName, widgetPrimaryAcct, widgetSubAcct),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNewRelicDashboardExists("newrelic_dashboard.foo"),
-				),
-			},
-			// Test: Reodering widgets should NOT drift since we sort before storing in state.
-			{
-				Config: testAccCheckNewRelicDashboardConfigCrossAccountWidgets(rName, widgetSubAcct, widgetPrimaryAcct),
+				// cross-account widgets cause drift due to the API not returning that data
+				ExpectNonEmptyPlan: true,
+				Config:             testAccCheckNewRelicDashboardConfigCrossAccountWidgets(rName, widgetPrimaryAcct, widgetSubAcct),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicDashboardExists("newrelic_dashboard.foo"),
 				),

--- a/newrelic/structures_newrelic_dashboard.go
+++ b/newrelic/structures_newrelic_dashboard.go
@@ -3,12 +3,20 @@ package newrelic
 import (
 	"fmt"
 	"log"
-	"sort"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
 	"github.com/newrelic/newrelic-client-go/pkg/dashboards"
 )
+
+// migrateStateV0toV1 currently facilitates migrating the `widgets`
+// attribute from TypeList to TypeSet. Since the underlying
+// data structure is []map[string]interface{} for both, we don't
+// need to do anything other than return the state and Terraform
+// will handle the rest.
+func migrateStateV0toV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	return rawState, nil
+}
 
 // Assemble the *dashboards.Dashboard struct.
 // Used by the newrelic_dashboard Create and Update functions.
@@ -32,7 +40,8 @@ func expandDashboard(d *schema.ResourceData) (*dashboards.Dashboard, error) {
 
 	log.Printf("[INFO] widget schema: %+v\n", d.Get("widget"))
 	if widgets, ok := d.GetOk("widget"); ok {
-		expandedWidgets, err := expandWidgets(widgets)
+		expandedWidgets, err := expandWidgets(widgets.(*schema.Set).List())
+
 		if err != nil {
 			return nil, err
 		}
@@ -57,26 +66,25 @@ func expandFilter(filter map[string]interface{}) dashboards.DashboardFilter {
 	return perms
 }
 
-func expandWidgets(in interface{}) ([]dashboards.DashboardWidget, error) {
-	widgetsIn := in.([]interface{})
-	if len(widgetsIn) < 1 {
+func expandWidgets(widgets []interface{}) ([]dashboards.DashboardWidget, error) {
+	if len(widgets) < 1 {
 		return []dashboards.DashboardWidget{}, nil
 	}
 
-	expanded := make([]dashboards.DashboardWidget, len(widgetsIn))
+	perms := make([]dashboards.DashboardWidget, len(widgets))
 
-	for i, wg := range widgetsIn {
-		w := wg.(map[string]interface{})
+	for i, rawCfg := range widgets {
+		cfg := rawCfg.(map[string]interface{})
+		expandedWidget, err := expandWidget(cfg)
 
-		expandedWidget, err := expandWidget(w)
 		if err != nil {
 			return nil, err
 		}
 
-		expanded[i] = *expandedWidget
+		perms[i] = *expandedWidget
 	}
 
-	return expanded, nil
+	return perms, nil
 }
 
 func expandWidget(cfg map[string]interface{}) (*dashboards.DashboardWidget, error) {
@@ -321,13 +329,6 @@ func flattenDashboard(dashboard *dashboards.Dashboard, d *schema.ResourceData) e
 		return filterErr
 	}
 
-	// IMPORTANT! Sorting the widgets before storing in state helps prevent drift
-	// in multiple scenarios, such as when/if the API returns widgets in a different
-	// order or if the user changes the order the HCL resource configuration.
-	sort.SliceStable(dashboard.Widgets, func(i, j int) bool {
-		return dashboard.Widgets[i].ID < dashboard.Widgets[j].ID
-	})
-
 	if dashboard.Widgets != nil && len(dashboard.Widgets) > 0 {
 		if widgetErr := d.Set("widget", flattenWidgets(&dashboard.Widgets, d)); widgetErr != nil {
 			return widgetErr
@@ -337,213 +338,105 @@ func flattenDashboard(dashboard *dashboards.Dashboard, d *schema.ResourceData) e
 	return nil
 }
 
-func isValidViz(viz dashboards.VisualizationType) bool {
-	vizString := string(viz)
-	for _, vizType := range validWidgetVisualizationValues {
-		if vizString == vizType {
-			return true
+// TODO: Reduce the cyclomatic complexity of this func
+// nolint:gocyclo
+func flattenWidgets(in *[]dashboards.DashboardWidget, d *schema.ResourceData) []map[string]interface{} {
+	var out = make([]map[string]interface{}, len(*in))
+
+	// wgts := d.Get("widget")
+	// configuredWidgets := wgts.(*schema.Set).List()
+
+	for i, w := range *in {
+		m := make(map[string]interface{})
+
+		m["widget_id"] = w.ID
+
+		// The REST API returns cross-account widgets
+		// as "inaccessible" so we can't really do anything
+		// with that. An inaccessible widget does not
+		// contain enough data in the response to bother setting
+		// it in the state. As a consequence, if customers want to
+		// use cross-account widgets, they will need to either
+		// ignore the lifecycle changes for `widget` block or
+		// use `-auto-approve` when running `terraform apply`.
+		if w.Visualization != "inaccessible" {
+			m["visualization"] = w.Visualization
+			m["title"] = w.Presentation.Title
+			m["notes"] = w.Presentation.Notes
+			m["row"] = w.Layout.Row
+			m["column"] = w.Layout.Column
+			m["width"] = w.Layout.Width
+			m["height"] = w.Layout.Height
+
+			if w.Presentation.DrilldownDashboardID > 0 {
+				m["drilldown_dashboard_id"] = w.Presentation.DrilldownDashboardID
+			}
+
+			if w.Presentation.Threshold != nil {
+				threshold := w.Presentation.Threshold
+
+				if threshold.Red > 0 {
+					m["threshold_red"] = threshold.Red
+				}
+
+				if threshold.Yellow > 0 {
+					m["threshold_yellow"] = threshold.Yellow
+				}
+			}
+
+			if w.Data != nil && len(w.Data) > 0 {
+				data := w.Data[0]
+
+				if data.NRQL != "" {
+					m["nrql"] = data.NRQL
+				}
+
+				if data.Source != "" {
+					m["source"] = data.Source
+				}
+
+				if data.Duration > 0 {
+					m["duration"] = data.Duration
+				}
+
+				if data.EndTime > 0 {
+					m["end_time"] = data.EndTime
+				}
+
+				if data.RawMetricName != "" {
+					m["raw_metric_name"] = data.RawMetricName
+				}
+
+				if data.Facet != "" {
+					m["facet"] = data.Facet
+				}
+
+				if data.OrderBy != "" {
+					m["order_by"] = data.OrderBy
+				}
+
+				if data.Limit > 0 {
+					m["limit"] = data.Limit
+				}
+
+				if data.EntityIds != nil && len(data.EntityIds) > 0 {
+					m["entity_ids"] = data.EntityIds
+				}
+
+				if data.CompareWith != nil && len(data.CompareWith) > 0 {
+					m["compare_with"] = flattenWidgetDataCompareWith(data.CompareWith)
+				}
+
+				if data.Metrics != nil && len(data.Metrics) > 0 {
+					m["metric"] = flattenWidgetDataMetrics(data.Metrics)
+				}
+			}
 		}
-	}
 
-	return false
-}
-
-func flattenWidgets(widgetsIn *[]dashboards.DashboardWidget, d *schema.ResourceData) []map[string]interface{} {
-	var out = make([]map[string]interface{}, len(*widgetsIn))
-
-	widgetCfg, ok := d.GetOk("widget")
-
-	for i, w := range *widgetsIn {
-		if !ok {
-			// If not widgets are configured, we need
-			// to provide an empty map to populate
-			// using the incoming API response widget data.
-			wgt := map[string]interface{}{}
-			out[i] = flattenWidget(w, wgt)
-		} else {
-			widgetConfig := widgetCfg.([]interface{})
-			wgt := widgetConfig[i].(map[string]interface{})
-			out[i] = flattenWidget(w, wgt)
-		}
+		out[i] = m
 	}
 
 	return out
-}
-
-// SUPPORTING CROSS-ACCOUNT WIDGETS WITH THE REST API USING APIKS KEYS
-//
-// If a user sets `account_id` to a subaccount that's scoped outside of
-// the user's API key, the API returns the widget as "inaccessible" and omits data.
-// This function attempts to avoid configuration drift when certain configuration
-// scenarios are presented.
-//
-// If a user sets `account_id` that's "inaccessible" per the API, we avoid setting
-// with the API response data and just use the same ID the user provided in the HCL.
-//
-// If the user sets `account_id` to an accessible account associated with the API key,
-// we need to set this in the Terraform state to avoid drift.
-//
-// If the user does not set `account_id`, then the user is basically using the default
-// behavior and we don't need to set it in the state since it's not in the HCL.
-// nolint:gocyclo
-func flattenWidget(w dashboards.DashboardWidget, widgetCfg map[string]interface{}) map[string]interface{} {
-	m := make(map[string]interface{})
-	wgtConfigAcctID := getConfiguredWidgetAcctID(widgetCfg)
-
-	if wgtConfigAcctID > 0 && w.AccountID != 0 {
-		m["account_id"] = w.AccountID
-	} else {
-		m["account_id"] = wgtConfigAcctID
-	}
-
-	if w.ID != 0 {
-		m["widget_id"] = w.ID
-	}
-
-	// Cross-account widgets will have a visualization
-	// set to "inaccessible" in some cases, so we must
-	// ensure a valid visualization is provided in the
-	// API's widget response.
-	if isValidViz(w.Visualization) {
-		m["visualization"] = w.Visualization
-	} else {
-		m["visualization"] = widgetCfg["visualization"]
-	}
-
-	if w.Layout.Row != 0 {
-		m["row"] = w.Layout.Row
-	} else {
-		m["row"] = widgetCfg["row"]
-	}
-
-	if w.Layout.Column != 0 {
-		m["column"] = w.Layout.Column
-	} else {
-		m["column"] = widgetCfg["column"]
-	}
-
-	if w.Layout.Width != 0 {
-		m["width"] = w.Layout.Width
-	} else {
-		m["width"] = widgetCfg["width"]
-	}
-
-	if w.Layout.Height != 0 {
-		m["height"] = w.Layout.Height
-	} else {
-		m["height"] = widgetCfg["height"]
-	}
-
-	if w.Presentation.Title != "" {
-		m["title"] = w.Presentation.Title
-	} else {
-		m["title"] = widgetCfg["title"]
-	}
-
-	if w.Presentation.Notes != "" {
-		m["notes"] = w.Presentation.Notes
-	} else {
-		m["notes"] = widgetCfg["notes"]
-	}
-
-	if w.Presentation.DrilldownDashboardID > 0 {
-		m["drilldown_dashboard_id"] = w.Presentation.DrilldownDashboardID
-	} else {
-		m["drilldown_dashboard_id"] = widgetCfg["drilldown_dashboard_id"]
-	}
-
-	if w.Presentation.Threshold != nil {
-		threshold := w.Presentation.Threshold
-
-		if threshold.Red > 0 {
-			m["threshold_red"] = threshold.Red
-		} else {
-			m["threshold_red"] = widgetCfg["threshold_red"]
-		}
-
-		if threshold.Yellow > 0 {
-			m["threshold_yellow"] = threshold.Yellow
-		} else {
-			m["threshold_yellow"] = widgetCfg["threshold_yellow"]
-		}
-	} else {
-		m["threshold_red"] = widgetCfg["threshold_red"]
-		m["threshold_yellow"] = widgetCfg["threshold_yellow"]
-	}
-
-	if w.Data != nil && len(w.Data) > 0 {
-		data := w.Data[0]
-
-		if data.NRQL != "" {
-			m["nrql"] = data.NRQL
-		}
-
-		if data.Source != "" {
-			m["source"] = data.Source
-		}
-
-		if data.Duration > 0 {
-			m["duration"] = data.Duration
-		}
-
-		if data.EndTime > 0 {
-			m["end_time"] = data.EndTime
-		}
-
-		if data.RawMetricName != "" {
-			m["raw_metric_name"] = data.RawMetricName
-		}
-
-		if data.Facet != "" {
-			m["facet"] = data.Facet
-		}
-
-		if data.OrderBy != "" {
-			m["order_by"] = data.OrderBy
-		}
-
-		if data.Limit > 0 {
-			m["limit"] = data.Limit
-		}
-
-		if data.EntityIds != nil && len(data.EntityIds) > 0 {
-			m["entity_ids"] = data.EntityIds
-		}
-
-		if data.CompareWith != nil && len(data.CompareWith) > 0 {
-			m["compare_with"] = flattenWidgetDataCompareWith(data.CompareWith)
-		}
-
-		if data.Metrics != nil && len(data.Metrics) > 0 {
-			m["metric"] = flattenWidgetDataMetrics(data.Metrics)
-		}
-	} else {
-		// Handle the "inaccessible" subaccount widget scenario.
-		// Populate the attributes with the values the user set
-		// within their HCL. The values are not returned from
-		// the API if an inaccessible subaccount is queried.
-		attributeKeys := []string{
-			"nrql",
-			"source",
-			"duration",
-			"end_time",
-			"raw_metric_name",
-			"facet",
-			"order_by",
-			"limit",
-			"entity_ids",
-			"compare_with",
-			"metric",
-		}
-
-		for _, k := range attributeKeys {
-			if v, ok := widgetCfg[k]; ok {
-				m[k] = v
-			}
-		}
-	}
-
-	return m
 }
 
 func flattenWidgetDataCompareWith(in []dashboards.DashboardWidgetDataCompareWith) []map[string]interface{} {
@@ -612,14 +505,4 @@ func flattenFilter(f *dashboards.DashboardFilter) []interface{} {
 	filterResult["attributes"] = schema.NewSet(schema.HashString, attributesList)
 	filterResult["event_types"] = schema.NewSet(schema.HashString, eventTypesList)
 	return []interface{}{filterResult}
-}
-
-// A helper function to get the value of the `account_id` from the HCL attribute if it was set.
-func getConfiguredWidgetAcctID(widgetConfig map[string]interface{}) int {
-	val, ok := widgetConfig["account_id"]
-	if !ok {
-		return 0
-	}
-
-	return val.(int)
 }

--- a/newrelic/structures_newrelic_dashboard.go
+++ b/newrelic/structures_newrelic_dashboard.go
@@ -71,7 +71,7 @@ func expandWidgets(widgets []interface{}) ([]dashboards.DashboardWidget, error) 
 		return []dashboards.DashboardWidget{}, nil
 	}
 
-	perms := make([]dashboards.DashboardWidget, len(widgets))
+	expanded := make([]dashboards.DashboardWidget, len(widgets))
 
 	for i, rawCfg := range widgets {
 		cfg := rawCfg.(map[string]interface{})
@@ -81,10 +81,10 @@ func expandWidgets(widgets []interface{}) ([]dashboards.DashboardWidget, error) 
 			return nil, err
 		}
 
-		perms[i] = *expandedWidget
+		expanded[i] = *expandedWidget
 	}
 
-	return perms, nil
+	return expanded, nil
 }
 
 func expandWidget(cfg map[string]interface{}) (*dashboards.DashboardWidget, error) {
@@ -342,9 +342,6 @@ func flattenDashboard(dashboard *dashboards.Dashboard, d *schema.ResourceData) e
 // nolint:gocyclo
 func flattenWidgets(in *[]dashboards.DashboardWidget, d *schema.ResourceData) []map[string]interface{} {
 	var out = make([]map[string]interface{}, len(*in))
-
-	// wgts := d.Get("widget")
-	// configuredWidgets := wgts.(*schema.Set).List()
 
 	for i, w := range *in {
 		m := make(map[string]interface{})

--- a/website/docs/r/dashboard.html.markdown
+++ b/website/docs/r/dashboard.html.markdown
@@ -108,7 +108,7 @@ The following arguments are supported:
 
   <a name="widget-configuration-recommendation"></a>
 
-  -> **Widget configuration recommendation:** While the `newrelic_dashboard` resource attempts to avoid configuration drift where possible, there is still potential for drift to occur due to underlying API limitations, usually involving [cross-account widgets](#account_id). To better facilitate the prevention of configuration drift with widgets, we recommend ordering your widgets in a consistent manner and maintaining that order if possible. An example could be ordering the `widget` blocks in the order they appear your New Relic Dashboard UI. The first `widget` block would be the widget displayed at the top left of your dashboard and the last `widget` block would be the widget at the bottom right of the dashboard.
+  -> **Widget configuration recommendation** While the `newrelic_dashboard` resource attempts to avoid configuration drift where possible, there is still potential for drift to occur due to underlying API limitations, usually involving [cross-account widgets](#account_id). Also, even though the ordering of your widgets can be arbitrary, we recommend ordering your widgets in a consistent manner and maintaining that order if possible. An example could be ordering the `widget` blocks in the order they appear your New Relic Dashboard UI. The first `widget` block would be the widget displayed at the top left of your dashboard and the last `widget` block would be the widget at the bottom right of the dashboard.
 
 ## Attribute Reference
 
@@ -131,7 +131,9 @@ All nested `widget` blocks support the following common arguments:
 
 <a name="cross-account-widget-help"></a>
 
- -> **Configuring cross-account widgets:** To configure a cross-account widget with an account different from the account associated with your API key, you must set the widget's `account_id` attribute to the account ID you wish to pull data from. Also note, the provider must be configured with an API Key that is scoped to a user with proper permissions to access and perform operations in other accounts that fall within or under the account associated with your API key. To facilitate cross-account widgets, we recommend [configuring the provider with a Personal API Key](../guides/provider_configuration.html#configuration-via-the-provider-block) from a user with **admin permissions** and access to the subaccount you would like to display data for in the widget.
+-> **Configuring cross-account widgets** To configure a cross-account widget with an account different from the account associated with your API key, you must set the widget's `account_id` attribute to the account ID you wish to pull data from. Also note, the provider must be configured with an API Key that is scoped to a user with proper permissions to access and perform operations in other accounts that fall within or under the account associated with your API key. To facilitate cross-account widgets, we recommend [configuring the provider with a Personal API Key](../guides/provider_configuration.html#configuration-via-the-provider-block) from a user with **admin permissions** and access to the subaccount you would like to display data for in the widget.
+
+~> **Note** Due to API limitations, cross-account widgets can cause configuration drift due to the API response omitting data for widgets that that pull data from New Relic accounts outside the primary scope of the API key being used. If you need to configure cross-account widgets and also want to bypass the configuration drift for widgets, you can use Terraform's [`ignore_changes`](https://www.terraform.io/docs/configuration/resources.html#ignore_changes) using Terraforms `lifecycle` block. <br><br> ``` lifecycle { ignore_changes = [widget] }```
 
 Each `visualization` type supports an additional set of arguments:
 
@@ -266,4 +268,4 @@ New Relic dashboards can be imported using their ID, e.g.
 $ terraform import newrelic_dashboard.my_dashboard 8675309
 ```
 
-~> **NOTE:** Due to API restrictions, importing a dashboard resource will set the `grid_column_count` attribute to `3`. If your dashboard is a New Relic One dashboard _and_ uses a 12 column grid, you will need to make sure `grid_column_count` is set to `12` in your configuration, then run `terraform apply` after importing to sync remote state with Terraform state. Also note, cross-account widgets cannot be imported due to API restrictions.
+~> **NOTE** Due to API restrictions, importing a dashboard resource will set the `grid_column_count` attribute to `3`. If your dashboard is a New Relic One dashboard _and_ uses a 12 column grid, you will need to make sure `grid_column_count` is set to `12` in your configuration, then run `terraform apply` after importing to sync remote state with Terraform state. Also note, cross-account widgets cannot be imported due to API restrictions.


### PR DESCRIPTION
Resolves: #923 

Steps to manually test locally:

1. Using v2.7.5 of the provider, configure and provision a dashboard with multiple widgets with at least one widget being something more complex like displaying the apdex is an app with a `metric_line_chart` visualization.
    ```hcl
    provider "newrelic" {
      version = "2.7.5"
    }

    resource newrelic_dashboard" "foo" {
      // ... configuration w/ widgets 'n such (no cross-account widgets)
    }
    ```

2. Install the latest local version of the provider (the code in this PR) by commenting out the `version` part of the provider configuration.

    ```hcl
    provider "newrelic" {
      # version = "2.7.5" 
    }

    // ...
    ```
    - Run ` rm -rf .terraform && rm terraform-provider-newrelic && go build && tf init` to reinitialize and install the provider using the local binary. **IMPORTANT: DO NOT DELETE THE STATE FILE!** 😉
    - Run `terraform apply` and things should run without any errors and no changes or diff should show up.
