### PR TITLE
chore(build): add temporary workaround for -ldflags to ProviderVersion during releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,7 +17,7 @@ builds:
     - arm
     - arm64
   ldflags:
-    - -s -w -X version.ProviderVersion={{.Version}}
+    - -s -w -X main.ProviderVersion={{.Version}}
   ignore:
     - goos: darwin
       goarch: '386'

--- a/main.go
+++ b/main.go
@@ -6,7 +6,17 @@ import (
 	"github.com/newrelic/terraform-provider-newrelic/v2/newrelic"
 )
 
+var (
+	// ProviderVersion is set during the release process to the release version of the binary.
+	// See .goreleaser.yml for more details.
+	ProviderVersion = "dev"
+)
+
 func main() {
+	// We need to set the ProviderVersion variable in the newrelic package
+	// to ensure it gets properly set as part of the user agent header.
+	newrelic.ProviderVersion = ProviderVersion
+
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: newrelic.Provider})
 }

--- a/newrelic/provider.go
+++ b/newrelic/provider.go
@@ -9,8 +9,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/hashicorp/terraform-plugin-sdk/meta"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
 
-	"github.com/newrelic/terraform-provider-newrelic/v2/version"
+var (
+	// ProviderVersion is set during the release process to the
+	// release version of the binary via `-ldflags`. This is technically
+	// set in main.go which sets the variable below.
+	//
+	// Note: This is a temporary workaround until we figure out why the original way
+	// no longer works.
+	ProviderVersion = "dev"
 )
 
 // TerraformProviderProductUserAgent string used to identify this provider in User Agent requests
@@ -162,8 +170,10 @@ func providerConfigure(data *schema.ResourceData, terraformVersion string) (inte
 	adminAPIKey := data.Get("admin_api_key").(string)
 	personalAPIKey := data.Get("api_key").(string)
 	terraformUA := fmt.Sprintf("HashiCorp Terraform/%s (+https://www.terraform.io) Terraform Plugin SDK/%s", terraformVersion, meta.SDKVersionString())
-	userAgent := fmt.Sprintf("%s %s/%s", terraformUA, TerraformProviderProductUserAgent, version.ProviderVersion)
+	userAgent := fmt.Sprintf("%s %s/%s", terraformUA, TerraformProviderProductUserAgent, ProviderVersion)
 	accountID := data.Get("account_id").(int)
+
+	log.Printf("[INFO] UserAgent: %s", userAgent)
 
 	cfg := Config{
 		AdminAPIKey:          adminAPIKey,

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,0 @@
-package version
-
-var (
-	// ProviderVersion is set during the release process to the release version of the binary
-	ProviderVersion = "dev"
-)


### PR DESCRIPTION
Testing it out (easiest to test locally with Terraform version 0.12.x)

Create a .tf file with a simple provider configuration and do not add a `version` argument. 

```
provider "newrelic" {}
```

```
go build -ldflags "-s -w -X main.ProviderVersion=99999999" && terraform init && TF_LOG=debug terraform plan
```

Then search for `99999999`. It should exist in the logs somewhere 😎 