### PR TITLE
Swap deprecation of violation_time_limit fields for NRQL alert condition

### DIFF
--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -241,13 +241,12 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 				ConflictsWith: []string{"open_violation_on_group_overlap"},
 			},
 			"violation_time_limit_seconds": {
-				Deprecated:    "use `violation_time_limit` attribute instead",
 				Type:          schema.TypeInt,
 				Optional:      true,
-				Description:   "Sets a time limit, in seconds, that will automatically force-close a long-lasting violation after the time limit you select. Possible values are 3600, 7200, 14400, 28800, 43200, and 86400.",
+				Description:   "Sets a time limit, in seconds, that will automatically force-close a long-lasting violation after the time limit you select.  Must be in the range of 300 to 2592000 (inclusive)",
 				ConflictsWith: []string{"violation_time_limit"},
 				AtLeastOneOf:  []string{"violation_time_limit_seconds", "violation_time_limit"},
-				ValidateFunc:  validation.IntInSlice([]int{3600, 7200, 14400, 28800, 43200, 86400}),
+				ValidateFunc:  validation.IntBetween(300, 2592000),
 			},
 			// Exists in NerdGraph, but with different values. Conversion
 			// between new:old and old:new is handled via maps in structures file.
@@ -274,7 +273,9 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 			},
 			"violation_time_limit": {
 				Type:          schema.TypeString,
+				Deprecated:    "use `violation_time_limit_seconds` attribute instead",
 				Optional:      true,
+				Computed:      true,
 				Description:   "Sets a time limit, in hours, that will automatically force-close a long-lasting violation after the time limit you select. Possible values are 'ONE_HOUR', 'TWO_HOURS', 'FOUR_HOURS', 'EIGHT_HOURS', 'TWELVE_HOURS', 'TWENTY_FOUR_HOURS', 'THIRTY_DAYS' (case insensitive).",
 				ConflictsWith: []string{"violation_time_limit_seconds"},
 				AtLeastOneOf:  []string{"violation_time_limit_seconds", "violation_time_limit"},

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -43,8 +43,12 @@ func TestAccNewRelicNrqlAlertCondition_Basic(t *testing.T) {
 				ImportStateVerify: true,
 				// Ignore items with deprecated fields because
 				// we don't set deprecated fields on import
-				ImportStateVerifyIgnore: []string{"term", "nrql", "violation_time_limit"},
-				ImportStateIdFunc:       testAccImportStateIDFunc(resourceName, "static"),
+				ImportStateVerifyIgnore: []string{
+					"term",                 // contains nested attributes that are deprecated
+					"nrql",                 // contains nested attributes that are deprecated
+					"violation_time_limit", // deprecated in favor of violation_time_limit_seconds
+				},
+				ImportStateIdFunc: testAccImportStateIDFunc(resourceName, "static"),
 			},
 		},
 	})
@@ -324,9 +328,9 @@ func TestAccNewRelicNrqlAlertCondition_NerdGraphStatic(t *testing.T) {
 				// Ignore items with deprecated fields because
 				// we don't set deprecated fields on import
 				ImportStateVerifyIgnore: []string{
-					"term", // contains nested attributes that are deprecated
-					"nrql", // contains nested attributes that are deprecated
-					"violation_time_limit",
+					"term",                 // contains nested attributes that are deprecated
+					"nrql",                 // contains nested attributes that are deprecated
+					"violation_time_limit", // deprecated in favor of violation_time_limit_seconds
 				},
 				ImportStateIdFunc: testAccImportStateIDFunc(resourceName, "static"),
 			},
@@ -383,8 +387,9 @@ func TestAccNewRelicNrqlAlertCondition_NerdGraphOutlier(t *testing.T) {
 				// Ignore items with deprecated fields because
 				// we don't set deprecated fields on import
 				ImportStateVerifyIgnore: []string{
-					"term", // contains nested attributes that are deprecated
-					"nrql", // contains nested attributes that are deprecated
+					"term",                 // contains nested attributes that are deprecated
+					"nrql",                 // contains nested attributes that are deprecated
+					"violation_time_limit", // deprecated in favor of violation_time_limit_seconds
 				},
 				ImportStateIdFunc: testAccImportStateIDFunc(resourceName, "outlier"),
 			},
@@ -491,7 +496,7 @@ resource "newrelic_nrql_alert_condition" "foo" {
   name                           = "tf-test-%[1]s"
   runbook_url                    = "https://foo.example.com"
   enabled                        = false
-  violation_time_limit           = "EIGHT_HOURS"
+  violation_time_limit_seconds   = 28800
   fill_option                    = "%[4]s"
   fill_value                     = %[5]s
   aggregation_window             = %[7]s
@@ -606,7 +611,7 @@ resource "newrelic_nrql_alert_condition" "foo" {
 	runbook_url                    = "https://foo.example.com"
 	enabled                        = false
 	description                    = "test description"
-	violation_time_limit           = "one_hour"
+	violation_time_limit_seconds   = 3600
 	fill_option                    = "%[5]s"
 	fill_value                     = %[6]s
 	close_violations_on_expiration = true
@@ -660,7 +665,7 @@ resource "newrelic_nrql_alert_condition" "foo" {
 	runbook_url          = "https://foo.example.com"
 	enabled              = false
 	description          = "test description"
-	violation_time_limit = "one_hour"
+	violation_time_limit_seconds = 3600
 	aggregation_window   = 60
 
 	nrql {

--- a/newrelic/structures_newrelic_nrql_alert_condition.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition.go
@@ -23,26 +23,6 @@ var (
 	}
 
 	// old:new
-	violationTimeLimitMap = map[int]alerts.NrqlConditionViolationTimeLimit{
-		3600:  alerts.NrqlConditionViolationTimeLimits.OneHour,
-		7200:  alerts.NrqlConditionViolationTimeLimits.TwoHours,
-		14400: alerts.NrqlConditionViolationTimeLimits.FourHours,
-		28800: alerts.NrqlConditionViolationTimeLimits.EightHours,
-		43200: alerts.NrqlConditionViolationTimeLimits.TwelveHours,
-		86400: alerts.NrqlConditionViolationTimeLimits.TwentyFourHours,
-	}
-
-	// new:old
-	violationTimeLimitMapNewOld = map[alerts.NrqlConditionViolationTimeLimit]int{
-		alerts.NrqlConditionViolationTimeLimits.OneHour:         3600,
-		alerts.NrqlConditionViolationTimeLimits.TwoHours:        7200,
-		alerts.NrqlConditionViolationTimeLimits.FourHours:       14400,
-		alerts.NrqlConditionViolationTimeLimits.EightHours:      28800,
-		alerts.NrqlConditionViolationTimeLimits.TwelveHours:     43200,
-		alerts.NrqlConditionViolationTimeLimits.TwentyFourHours: 86400,
-	}
-
-	// old:new
 	fillOptionMap = map[string]*alerts.AlertsFillOption{
 		"none":       &alerts.AlertsFillOptionTypes.NONE,
 		"last_value": &alerts.AlertsFillOptionTypes.LAST_VALUE,
@@ -61,10 +41,9 @@ var (
 func expandNrqlAlertConditionInput(d *schema.ResourceData) (*alerts.NrqlConditionInput, error) {
 	input := alerts.NrqlConditionInput{
 		NrqlConditionBase: alerts.NrqlConditionBase{
-			Description:        d.Get("description").(string),
-			Enabled:            d.Get("enabled").(bool),
-			Name:               d.Get("name").(string),
-			ViolationTimeLimit: alerts.NrqlConditionViolationTimeLimit(strings.ToUpper(d.Get("violation_time_limit").(string))),
+			Description: d.Get("description").(string),
+			Enabled:     d.Get("enabled").(bool),
+			Name:        d.Get("name").(string),
 		},
 	}
 
@@ -121,7 +100,7 @@ func expandNrqlAlertConditionInput(d *schema.ResourceData) (*alerts.NrqlConditio
 	}
 
 	if violationTimeLimitSec, ok := d.GetOk("violation_time_limit_seconds"); ok {
-		input.ViolationTimeLimit = violationTimeLimitMap[violationTimeLimitSec.(int)]
+		input.ViolationTimeLimitSeconds = violationTimeLimitSec.(int)
 	} else if violationTimeLimit, ok := d.GetOk("violation_time_limit"); ok {
 		input.ViolationTimeLimit = alerts.NrqlConditionViolationTimeLimit(strings.ToUpper(violationTimeLimit.(string)))
 	}
@@ -433,7 +412,7 @@ func flattenNrqlAlertCondition(accountID int, condition *alerts.NrqlAlertConditi
 	}
 
 	if _, ok := d.GetOk("violation_time_limit_seconds"); ok {
-		d.Set("violation_time_limit_seconds", violationTimeLimitMapNewOld[condition.ViolationTimeLimit])
+		d.Set("violation_time_limit_seconds", condition.ViolationTimeLimitSeconds)
 	} else {
 		d.Set("violation_time_limit", condition.ViolationTimeLimit)
 	}

--- a/website/docs/d/entity.html.markdown
+++ b/website/docs/d/entity.html.markdown
@@ -32,14 +32,14 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_nrql_alert_condition" "foo" {
-  policy_id            = newrelic_alert_policy.foo.id
-  type                 = "static"
-  name                 = "foo"
-  description          = "Alert when transactions are taking too long"
-  runbook_url          = "https://www.example.com"
-  enabled              = true
-  value_function       = "single_value"
-  violation_time_limit = "one_hour"
+  policy_id                    = newrelic_alert_policy.foo.id
+  type                         = "static"
+  name                         = "foo"
+  description                  = "Alert when transactions are taking too long"
+  runbook_url                  = "https://www.example.com"
+  enabled                      = true
+  value_function               = "single_value"
+  violation_time_limit_seconds = 3600
 
   nrql {
     query             = "SELECT average(duration) FROM Transaction where appName = '${data.newrelic_entity.app.name}'"

--- a/website/docs/guides/getting_started.html.markdown
+++ b/website/docs/guides/getting_started.html.markdown
@@ -156,14 +156,14 @@ resource "newrelic_alert_policy" "alert_policy_name" {
 
 # NRQL alert condition
 resource "newrelic_nrql_alert_condition" "foo" {
-  policy_id            = newrelic_alert_policy.alert_policy_name.id
-  type                 = "static"
-  name                 = "foo"
-  description          = "Alert when transactions are taking too long"
-  runbook_url          = "https://www.example.com"
-  enabled              = true
-  value_function       = "single_value"
-  violation_time_limit = "one_hour"
+  policy_id                    = newrelic_alert_policy.alert_policy_name.id
+  type                         = "static"
+  name                         = "foo"
+  description                  = "Alert when transactions are taking too long"
+  runbook_url                  = "https://www.example.com"
+  enabled                      = true
+  value_function               = "single_value"
+  violation_time_limit_seconds = 3600
 
   nrql {
     query             = "SELECT average(duration) FROM Transaction where appName = '${data.newrelic_entity.app_name.name}'"

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -109,14 +109,14 @@ resource "newrelic_alert_policy" "alert" {
 
 # Add a condition
 resource "newrelic_nrql_alert_condition" "foo" {
-  policy_id            = newrelic_alert_policy.alert.id
-  type                 = "static"
-  name                 = "foo"
-  description          = "Alert when transactions are taking too long"
-  runbook_url          = "https://www.example.com"
-  enabled              = true
-  value_function       = "single_value"
-  violation_time_limit = "one_hour"
+  policy_id                    = newrelic_alert_policy.alert.id
+  type                         = "static"
+  name                         = "foo"
+  description                  = "Alert when transactions are taking too long"
+  runbook_url                  = "https://www.example.com"
+  enabled                      = true
+  value_function               = "single_value"
+  violation_time_limit_seconds = 3600
 
   nrql {
     query             = "SELECT average(duration) FROM Transaction where appName = '${data.newrelic_entity.foo.name}'"

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -23,15 +23,15 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_nrql_alert_condition" "foo" {
-  account_id           = <Your Account ID>
-  policy_id            = newrelic_alert_policy.foo.id
-  type                 = "static"
-  name                 = "foo"
-  description          = "Alert when transactions are taking too long"
-  runbook_url          = "https://www.example.com"
-  enabled              = true
-  violation_time_limit = "one_hour"
-  value_function       = "single_value"
+  account_id                   = <Your Account ID>
+  policy_id                    = newrelic_alert_policy.foo.id
+  type                         = "static"
+  name                         = "foo"
+  description                  = "Alert when transactions are taking too long"
+  runbook_url                  = "https://www.example.com"
+  enabled                      = true
+  violation_time_limit_seconds = 3600
+  value_function               = "single_value"
 
   fill_option          = "static"
   fill_value           = 1.0
@@ -83,10 +83,10 @@ The following arguments are supported:
 - `expected_groups` - (Optional) Number of expected groups when using `outlier` detection.
 - `open_violation_on_group_overlap` - (Optional) Whether or not to trigger a violation when groups overlap. Set to `true` if you want to trigger a violation when groups overlap. This argument is only applicable in `outlier` conditions.
 - `ignore_overlap` - (Optional) **DEPRECATED:** Use `open_violation_on_group_overlap` instead, but use the inverse value of your boolean - e.g. if `ignore_overlap = false`, use `open_violation_on_group_overlap = true`. This argument sets whether to trigger a violation when groups overlap. If set to `true` overlapping groups will not trigger a violation. This argument is only applicable in `outlier` conditions.
-- `violation_time_limit` - (Optional*) Sets a time limit, in hours, that will automatically force-close a long-lasting violation after the time limit you select. Possible values are `ONE_HOUR`, `TWO_HOURS`, `FOUR_HOURS`, `EIGHT_HOURS`, `TWELVE_HOURS`, `TWENTY_FOUR_HOURS`, `THIRTY_DAYS` (case insensitive).<br>
+- `violation_time_limit` - (Optional*) **DEPRECATED:** Use `violation_time_limit_seconds` instead. Sets a time limit, in hours, that will automatically force-close a long-lasting violation after the time limit you select. Possible values are `ONE_HOUR`, `TWO_HOURS`, `FOUR_HOURS`, `EIGHT_HOURS`, `TWELVE_HOURS`, `TWENTY_FOUR_HOURS`, `THIRTY_DAYS` (case insensitive).<br>
 <small>\***Note**: One of `violation_time_limit` _or_ `violation_time_limit_seconds` must be set, but not both.</small>
 
-- `violation_time_limit_seconds` - (Optional*) **DEPRECATED:** Use `violation_time_limit` instead. Sets a time limit, in seconds, that will automatically force-close a long-lasting violation after the time limit you select. Possible values are `3600`, `7200`, `14400`, `28800`, `43200`, and `86400`.<br>
+- `violation_time_limit_seconds` - (Optional*) Sets a time limit, in seconds, that will automatically force-close a long-lasting violation after the time limit you select. The value must be between 300 seconds (5 minutes) to 2592000 seconds (30 days) (inclusive). <br>
 <small>\***Note**: One of `violation_time_limit` _or_ `violation_time_limit_seconds` must be set, but not both.</small>
 
 - `fill_option` - (Optional) Which strategy to use when filling gaps in the signal. Possible values are `none`, `last_value` or `static`. If `static`, the `fill_value` field will be used for filling gaps in the signal.
@@ -145,14 +145,14 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_nrql_alert_condition" "foo" {
-  type                 = "baseline"
-  account_id           = <Your Account ID>
-  name                 = "foo"
-  policy_id            = newrelic_alert_policy.foo.id
-  description          = "Alert when transactions are taking too long"
-  enabled              = true
-  runbook_url          = "https://www.example.com"
-  violation_time_limit = "one_hour"
+  type                         = "baseline"
+  account_id                   = <Your Account ID>
+  name                         = "foo"
+  policy_id                    = newrelic_alert_policy.foo.id
+  description                  = "Alert when transactions are taking too long"
+  enabled                      = true
+  runbook_url                  = "https://www.example.com"
+  violation_time_limit_seconds = 3600
 
   # baseline type only
   baseline_direction = "upper_only"
@@ -190,14 +190,14 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_nrql_alert_condition" "foo" {
-  type                 = "outlier"
-  account_id           = <Your Account ID>
-  name                 = "foo"
-  policy_id            = newrelic_alert_policy.foo.id
-  description          = "Alert when outlier conditions occur"
-  enabled              = true
-  runbook_url          = "https://www.example.com"
-  violation_time_limit = "one_hour"
+  type                         = "outlier"
+  account_id                   = <Your Account ID>
+  name                         = "foo"
+  policy_id                    = newrelic_alert_policy.foo.id
+  description                  = "Alert when outlier conditions occur"
+  enabled                      = true
+  runbook_url                  = "https://www.example.com"
+  violation_time_limit_seconds = 3600
 
   # Outlier only
   expected_groups = 2


### PR DESCRIPTION
Depends on https://github.com/newrelic/newrelic-client-go/pull/550
With the addition of `violation_time_limit_seconds` to NerdGraph's NRQL Alert Condition models, we now have a first class `seconds` field where users can choose an arbitrary value between 300s (5 minutes) and 2592000s (30 days). 
The old enum field `violation_time_limit` is restricted to a much smaller selection of values and is now deprecated in NerdGraph. 

Previously, a field `violation_time_limit_seconds` existed that accepted the same limited range of values as `violation_time_limit`, expressed as seconds. 

This PR deprecates the `violation_time_limit` field in favor of `violation_time_limit_seconds` to  align the NR terraform provider's representation of violationTTL with NerdGraph. 

Note to reviewer:

The fields `violation_time_limit` and `violation_time_limit_seconds` are distinct in NerdGraph, but behind the scenes, they set the same field for an alert condition. 

With `violation_time_limit` being an enum, and `violation_time_limit_seconds` is an arbitrary integer, values outside of the enum are represented as "NON_MATCHABLE_LIMIT_VALUE"

Since it always gets a value, even when configuring `violation_time_limit_seconds`,  I've marked `violation_time_limit` as `computed`, and set both fields to optional, and conflicting with one another.  Is this correct? 