### PR TITLE
fix(nrql_alert_condition): reverse attribute detection for migration

### DIFF
--- a/newrelic/structures_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition_test.go
@@ -491,6 +491,7 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 
 		case alerts.NrqlConditionTypes.Outlier:
 			require.Equal(t, 2, d.Get("expected_groups").(int))
+			require.Zero(t, d.Get("ignore_overlap").(bool))
 			require.True(t, d.Get("open_violation_on_group_overlap").(bool))
 			require.Zero(t, d.Get("baseline_direction").(string))
 			require.Zero(t, d.Get("value_function").(string))


### PR DESCRIPTION
Without this change, the deprecated attributes are preferred when they are found
within the state.  Here we reverse the order that the attributes are read to
determine if the particular resource has been migrated to the new API values.
This should ensure a clean migration from 1.x to 2.x in the case of an outlier
condition.