### PR TITLE
chore(build): Add go-mod-outdated for tools/ to make

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -39,6 +39,7 @@ include build/lint.mk
 include build/release.mk
 include build/terraform.mk
 include build/test.mk
+include build/tools.mk
 include build/util.mk
 
 .PHONY: all build build-ci clean

--- a/build/deps.mk
+++ b/build/deps.mk
@@ -2,28 +2,8 @@
 # Makefile fragment for installing deps
 #
 
-GO           ?= go
-GOFMT        ?= gofmt
-VENDOR_CMD   ?= ${GO} mod tidy
-BUILD_DIR    ?= ./bin/
-
-# Go file to track tool deps with go modules
-TOOL_DIR     ?= tools
-TOOL_CONFIG  ?= $(TOOL_DIR)/tools.go
-
-GOTOOLS ?= $(shell cd $(TOOL_DIR) && go list -f '{{ .Imports }}' -tags tools |tr -d '[]')
-
-tools: check-version
-	@echo "=== $(PROJECT_NAME) === [ tools            ]: Installing tools required by the project..."
-	@cd $(TOOL_DIR) && $(GO) install $(GOTOOLS)
-	@cd $(TOOL_DIR) && $(VENDOR_CMD)
-
-tools-update: check-version
-	@echo "=== $(PROJECT_NAME) === [ tools-update     ]: Updating tools required by the project..."
-	@cd $(TOOL_DIR) && for x in $(GOTOOLS); do \
-		$(GO) get -u $$x; \
-	done
-	@cd $(TOOL_DIR) && $(VENDOR_CMD)
+GO               ?= go
+VENDOR_CMD       ?= ${GO} mod tidy
 
 deps: tools deps-only
 
@@ -31,4 +11,4 @@ deps-only:
 	@echo "=== $(PROJECT_NAME) === [ deps             ]: Installing package dependencies required by the project..."
 	@$(VENDOR_CMD)
 
-.PHONY: deps deps-only tools tools-update
+.PHONY: deps deps-only tools tools-update tools-outdated

--- a/build/lint.mk
+++ b/build/lint.mk
@@ -55,7 +55,7 @@ golangci: deps
 	@echo "=== $(PROJECT_NAME) === [ golangci-lint    ]: Linting using $(GOLINTER) ($(COMMIT_LINT_CMD))..."
 	@$(GOLINTER) run
 
-outdated: deps
+outdated: deps tools-outdated
 	@echo "=== $(PROJECT_NAME) === [ outdated         ]: Finding outdated deps with $(GO_MOD_OUTDATED)..."
 	@$(GO) list -u -m -json all | $(GO_MOD_OUTDATED) -direct -update
 

--- a/build/tools.mk
+++ b/build/tools.mk
@@ -1,0 +1,33 @@
+#
+# Makefile fragment for installing tools
+#
+
+GO               ?= go
+GOFMT            ?= gofmt
+VENDOR_CMD       ?= ${GO} mod tidy
+GO_MOD_OUTDATED  ?= go-mod-outdated
+BUILD_DIR        ?= ./bin/
+
+# Go file to track tool deps with go modules
+TOOL_DIR     ?= tools
+TOOL_CONFIG  ?= $(TOOL_DIR)/tools.go
+
+GOTOOLS ?= $(shell cd $(TOOL_DIR) && go list -f '{{ .Imports }}' -tags tools |tr -d '[]')
+
+tools: check-version
+	@echo "=== $(PROJECT_NAME) === [ tools            ]: Installing tools required by the project..."
+	@cd $(TOOL_DIR) && $(GO) install $(GOTOOLS)
+	@cd $(TOOL_DIR) && $(VENDOR_CMD)
+
+tools-outdated: check-version
+	@echo "=== $(PROJECT_NAME) === [ tools-outdated   ]: Finding outdated tool deps with $(GO_MOD_OUTDATED)..."
+	@cd $(TOOL_DIR) && $(GO) list -u -m -json all | $(GO_MOD_OUTDATED) -direct -update
+
+tools-update: check-version
+	@echo "=== $(PROJECT_NAME) === [ tools-update     ]: Updating tools required by the project..."
+	@cd $(TOOL_DIR) && for x in $(GOTOOLS); do \
+		$(GO) get -u $$x; \
+	done
+	@cd $(TOOL_DIR) && $(VENDOR_CMD)
+
+.PHONY: tools tools-update tools-outdated

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -11,6 +11,6 @@ require (
 	github.com/newrelic-forks/git-chglog v0.10.0
 	github.com/psampaz/go-mod-outdated v0.7.0
 	github.com/stretchr/testify v1.6.1
-	golang.org/x/tools v0.0.0-20210105210202-9ed45478a130
+	golang.org/x/tools v0.0.0-20210106172347-465c416cfcfa
 	gotest.tools/gotestsum v0.6.0
 )

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1149,7 +1149,8 @@ golang.org/x/tools v0.0.0-20201202200335-bef1c476418a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20201203202102-a1a1cbeaa516/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201208233053-a543418bbed2 h1:vEtypaVub6UvKkiXZ2xx9QIvp9TL7sI7xp7vdi2kezA=
 golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.0.0-20210105210202-9ed45478a130/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.0.0-20210106172347-465c416cfcfa h1:ld0Mt31i8iliq+/75HVpk4XwGADOaGBlB6TYwTUCwSg=
+golang.org/x/tools v0.0.0-20210106172347-465c416cfcfa/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Cleanup a bit more, ensure that `make` now scans `tools/` for outdated packages as well.