### PR TITLE
fix(config): update misleading missing API key error message

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ First export the necessary environment variables.
 
 ```bash
 # Add this to your .bash_profile or .bashrc
-export NEW_RELIC_API_KEY="<your New Relic Personal API key>"
+export NEW_RELIC_API_KEY="<your New Relic User API key>"
 export NEW_RELIC_ADMIN_API_KEY="<your New Relic Admin API key>"
 export NEW_RELIC_REGION="US"
 ```

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
 	github.com/newrelic/go-agent/v3 v3.9.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go v0.55.0
+	github.com/newrelic/newrelic-client-go v0.55.2
 	github.com/stretchr/testify v1.6.1
 )

--- a/go.sum
+++ b/go.sum
@@ -409,8 +409,6 @@ github.com/newrelic/go-agent/v3 v3.9.0 h1:5bcTbdk/Up5cIYIkQjCG92Y+uNoett9wmhuz4k
 github.com/newrelic/go-agent/v3 v3.9.0/go.mod h1:1A1dssWBwzB7UemzRU6ZVaGDsI+cEn5/bNxI0wiYlIc=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go v0.55.0 h1:rjbhkfaQ9sHSKlQM3Es5HXNPfhrvJWtq+aO0pHdMr+E=
-github.com/newrelic/newrelic-client-go v0.55.0/go.mod h1:afAuAfcxjAl5JC3AjkGZa0eqcBBazOTP+hEyBsx23KA=
 github.com/newrelic/newrelic-client-go v0.55.2 h1:g2bCgWhuMeqywrRt8fGo0JWRlhFYplkmbHB6jRP+9y8=
 github.com/newrelic/newrelic-client-go v0.55.2/go.mod h1:afAuAfcxjAl5JC3AjkGZa0eqcBBazOTP+hEyBsx23KA=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=

--- a/go.sum
+++ b/go.sum
@@ -411,6 +411,8 @@ github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fz
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
 github.com/newrelic/newrelic-client-go v0.55.0 h1:rjbhkfaQ9sHSKlQM3Es5HXNPfhrvJWtq+aO0pHdMr+E=
 github.com/newrelic/newrelic-client-go v0.55.0/go.mod h1:afAuAfcxjAl5JC3AjkGZa0eqcBBazOTP+hEyBsx23KA=
+github.com/newrelic/newrelic-client-go v0.55.2 h1:g2bCgWhuMeqywrRt8fGo0JWRlhFYplkmbHB6jRP+9y8=
+github.com/newrelic/newrelic-client-go v0.55.2/go.mod h1:afAuAfcxjAl5JC3AjkGZa0eqcBBazOTP+hEyBsx23KA=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=

--- a/website/docs/guides/getting_started.html.markdown
+++ b/website/docs/guides/getting_started.html.markdown
@@ -13,58 +13,8 @@ description: |-
 
 * The examples below assume you already have a New Relic agent deployed. If you don't have New Relic integrated yet, check out [New Relic's introduction documentation](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/introduction-new-relic) to get started there, then head back over here to get started with the New Relic Terraform Provider using the examples provided.
 * [Install Terraform](https://www.terraform.io/intro/getting-started/install.html) and read the Terraform getting started guide that follows. This guide will assume a basic understanding of Terraform.
-* Locate your Personal API key by following [New Relic's Personal API key docs][personal_api_key].
+* Locate your Personal API key by following [New Relic's Personal API key docs][personal_api_key]. <br> <small>Note: To to locate or create your API key via our NerdGraph API, please follow these [instructions][personal_api_key_via_nerdgraph].
 
-  Note: For New Relic One users, you will need to create and view your Personal API key via NerdGraph, as folows:
-
-  1. Access the [NerdGraph Explorer](https://api.newrelic.com/graphiql) ([NerdGraph Explorer for EU accounts](https://api.eu.newrelic.com/graphiql))
-  1. If this is the first time, you'll need to create the API key:
-     1. Next to "GraphiQL" are three buttons: a play button and two drop downs.  Select the last drop down.
-     1. In the drop down is a label "Create a new API Key", and under that is your account number.  Select your account number.
-     1. This should create your key, although you cannot view it without running a query (next).
-  1. To view the API key, execute the follownig query:
-  
-     ```graphql
-     {
-       actor {
-         apiAccess {
-           keySearch(query: {types: USER}) {
-             nextCursor
-             keys {
-               ... on ApiAccessUserKey {
-                 key
-                 name
-                 id
-               }
-             }
-           }
-         }
-       }
-     }
-     ```
-  1. This will return a JSON object like so:
-  
-     ```json
-     {
-       "data": { 
-         "actor": {
-           "apiAccess": {
-             "keySearch": {
-               "keys": [
-                 {
-                   "key": "NRAK-«lots of other stuff»",
-                   "name": "API Key for Account XXX"
-                 }
-               ],
-               "nextCursor": null
-             }
-           }
-         }
-       }
-     }
-     ```
-  1. The value for data→actor→apiAccess→keySearch→keys→key is the key.
-  
 
 ## Configuring the Provider
 
@@ -280,4 +230,5 @@ If you ever need to make changes to your configuration, you can run `terraform a
 You can also run `terraform destroy` to tear down your resources if that's ever needed.
 
 [personal_api_key]: https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#personal-api-key
+[personal_api_key_via_nerdgraph]: https://docs.newrelic.com/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys
 [terraform_data_sources]: https://www.terraform.io/docs/configuration/data-sources.html

--- a/website/docs/guides/getting_started.html.markdown
+++ b/website/docs/guides/getting_started.html.markdown
@@ -13,8 +13,7 @@ description: |-
 
 * The examples below assume you already have a New Relic agent deployed. If you don't have New Relic integrated yet, check out [New Relic's introduction documentation](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/introduction-new-relic) to get started there, then head back over here to get started with the New Relic Terraform Provider using the examples provided.
 * [Install Terraform](https://www.terraform.io/intro/getting-started/install.html) and read the Terraform getting started guide that follows. This guide will assume a basic understanding of Terraform.
-* Locate your Personal API key by following [New Relic's Personal API key docs][personal_api_key]. <br> <small>Note: To to locate or create your API key via our NerdGraph API, please follow these [instructions][personal_api_key_via_nerdgraph].
-
+* Locate your User API key by following [New Relic's User API key docs][user_api_key] (previously referred to as "personal API key"). <br> <small>Note: To to locate or create your API key via our NerdGraph API, please follow these [instructions][user_api_key_via_nerdgraph].</small>
 
 ## Configuring the Provider
 
@@ -229,6 +228,6 @@ If you ever need to make changes to your configuration, you can run `terraform a
 
 You can also run `terraform destroy` to tear down your resources if that's ever needed.
 
-[personal_api_key]: https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#personal-api-key
-[personal_api_key_via_nerdgraph]: https://docs.newrelic.com/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys
+[user_api_key]: https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key
+[user_api_key_via_nerdgraph]: https://docs.newrelic.com/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys
 [terraform_data_sources]: https://www.terraform.io/docs/configuration/data-sources.html

--- a/website/docs/guides/getting_started.html.markdown
+++ b/website/docs/guides/getting_started.html.markdown
@@ -48,8 +48,8 @@ terraform {
 # Configure the New Relic provider
 provider "newrelic" {
   account_id = <Your Account ID>
-  api_key = <Your Personal API Key>    # usually prefixed with 'NRAK'
-  region = "US"                        # Valid regions are US and EU
+  api_key = <Your User API Key>    # usually prefixed with 'NRAK'
+  region = "US"                    # Valid regions are US and EU
 }
 ```
 

--- a/website/docs/guides/migration_guide_v2.html.markdown
+++ b/website/docs/guides/migration_guide_v2.html.markdown
@@ -14,14 +14,14 @@ Version 2.0 of the provider introduces some changes to the provider's configurat
 
 ### A Note About API Key Format
 
-Your New Relic [**Personal API Key**](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#personal-api-key) is now considered the default and standard API key for the provider.
+Your New Relic [**User API Key**](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key) is now considered the default and standard API key for the provider.
 
 As of version 2.10.2, New Relic [**Admin API keys**](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#admin) are no longer used for authentication within the New Relic Terraform provider.
 
--> <small>**Please note the following formatting for the provider's API key.** <br>Your **Personal API Key** has a prefix of `NRAK-` </small>
+-> <small>**Please note the following formatting for the provider's API key.** <br>Your **User API Key** has a prefix of `NRAK-` </small>
 
-**IMPORTANT** Please make sure that the Personal API Key has access to the
-account and resources you expect to be manipulating.  If the Personal API Key
+**IMPORTANT** Please make sure that the User API Key has access to the
+account and resources you expect to be manipulating.  If the User API Key
 does not have access, Terraform may not be able to detect existing resources
 correctly and may behave strangely.
 
@@ -31,7 +31,7 @@ If you have been using environment variables to configure the provider, you will
 
 1. **IMPORTANT:** All environment variables in use by the provider have been renamed with a new naming convention. The `NEWRELIC_*` prefix has been changed to `NEW_RELIC_*`. This will be the naming convention for environment variables moving forward.
 
-2. The environment variable `NEWRELIC_PERSONAL_API_KEY` has been replaced with `NEW_RELIC_API_KEY`. The Personal API Key is now considered the default and standard API key for the provider.
+2. The environment variable `NEWRELIC_PERSONAL_API_KEY` has been replaced with `NEW_RELIC_API_KEY`. The User API Key is now considered the default and standard API key for the provider.
 
     ```diff
     - NEWRELIC_PERSONAL_API_KEY
@@ -88,7 +88,7 @@ If you have been using environment variables to configure the provider, you will
 
 ### Provider Block Schema Updates
 
-1. Replace any existing `api_key` configuration setting with the value of the existing `personal_api_key` configuration setting. The Personal API Key is now considered the default and standard API key for the provider.
+1. Replace any existing `api_key` configuration setting with the value of the existing `personal_api_key` configuration setting. The User API Key is now considered the default and standard API key for the provider.
 
     ```diff
     provider "newrelic" {
@@ -99,10 +99,10 @@ If you have been using environment variables to configure the provider, you will
     }
     ```
 
-    -> <small>**Note:** Take note of where the `NRAK-***` and `NRAA-***` prefixes switch. This is important. Most Personal API Keys have the `NRAK-` prefix.</small>
+    -> <small>**Note:** Take note of where the `NRAK-***` and `NRAA-***` prefixes switch. This is important. Most User API keys have the `NRAK-` prefix.</small>
 
 2. Add `account_id` to your `provider` block and set it to your New Relic account ID. Note that you can also use the environment variable `NEW_RELIC_ACCOUNT_ID`.
 
 3. The `insights_account_id` configuration setting has been removed. The `account_id` configuration setting is now used instead.
 
-[nr-personal-api-key-url]: https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#personal-api-key
+[nr-personal-api-key-url]: https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key

--- a/website/docs/guides/provider_configuration.html.markdown
+++ b/website/docs/guides/provider_configuration.html.markdown
@@ -25,7 +25,7 @@ If you're using Terraform locally, you can set the environment variables in your
 
 ```bash
 # Add this to your .bash_profile or .bashrc
-export NEW_RELIC_API_KEY="<your New Relic Personal API key>"
+export NEW_RELIC_API_KEY="<your New Relic User API key>"
 export NEW_RELIC_REGION="US"
 ```
 
@@ -45,7 +45,7 @@ The table below shows the available environment variables and how they map to th
 | <small>Schema Attribute</small> | <small>Equivalent Env Variable</small> | <small>Required?</small> | <small>Default</small> | <small>Description</small>                                                                   |
 | ------------------------------- | -------------------------------------- | ------------------------ | ---------------------- | -------------------------------------------------------------------------------------------- |
 | `account_id`                    | `NEW_RELIC_ACCOUNT_ID`                 | required                 | `null`                 | Your New Relic [account ID].                                                                 |
-| `api_key`                       | `NEW_RELIC_API_KEY`                    | required                 | `null`                 | Your New Relic [personal API key] \(usually prefixed with `NRAK`).                                     |
+| `api_key`                       | `NEW_RELIC_API_KEY`                    | required                 | `null`                 | Your New Relic [User API key] \(usually prefixed with `NRAK`).                                     |
 | `region`                        | `NEW_RELIC_REGION`                     | required                 | `null`                 | Your New Relic account's [data center region] \(`US` or `EU`).                               |
 | `insights_insert_key`           | `NEW_RELIC_INSIGHTS_INSERT_KEY`        | optional                 | `null`                 | Your [Insights insert API key] for Insights events.                                          |
 | `insecure_skip_verify`          | `NEW_RELIC_API_SKIP_VERIFY`            | optional                 | `null`                 | Whether or not to trust self-signed SSL certificates.                                        |
@@ -62,7 +62,7 @@ Configuring the provider from within your HCL is a quick way to get started, how
 
 ```hcl
 provider "newrelic" {
-  api_key = <Your Personal API key>
+  api_key = <Your User API key>
   account_id = <your New Relic account ID>
   region = "US"
 }
@@ -87,7 +87,7 @@ provider "newrelic" {
 -> <small>**Note:** The provider supports ***one*** region per instance of the provider.</small>
 
 [account ID]: https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/account-id
-[personal API key]: https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#personal-api-key
+[User API key]: https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key
 [data center region]: https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers
 [Insights query API key]: https://docs.newrelic.com/docs/insights/insights-api/get-data/query-insights-event-data-api
 [Insights insert API key]: https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/introduction-event-api#register

--- a/website/docs/r/api_access_key.html.markdown
+++ b/website/docs/r/api_access_key.html.markdown
@@ -6,15 +6,15 @@ description: |-
   Create and Manage New Relic API access keys
 ---
 
-# Resource; newrelic_api_access_key
+# Resource: newrelic_api_access_key
 
 Use this resource to programmatically create and manage the following types of keys:
-- [Personal API keys](https://docs.newrelic.co.jp/docs/apis/get-started/intro-apis/types-new-relic-api-keys#personal-api-key)
+- [User API keys](https://docs.newrelic.co/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key)
 - License (or ingest) keys, including:
-    - General [license key](https://docs.newrelic.co.jp/docs/accounts/install-new-relic/account-setup/license-key) used for APM
-    - [Browser license key](https://docs.newrelic.co.jp/docs/browser/new-relic-browser/configuration/copy-browser-monitoring-license-key-app-id)
+    - General [license key](https://docs.newrelic.co/docs/accounts/install-new-relic/account-setup/license-key) used for APM
+    - [Browser license key](https://docs.newrelic.co/docs/browser/new-relic-browser/configuration/copy-browser-monitoring-license-key-app-id)
 
-Please visit the New Relic article ['Use NerdGraph to manage license keys and personal API keys'](https://docs.newrelic.co.jp/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-personal-api-keys)
+Please visit the New Relic article ['Use NerdGraph to manage license keys and User API keys'](https://docs.newrelic.com/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys)
 for more information.
 
 -> **IMPORTANT!**
@@ -24,13 +24,13 @@ invalidate the previous API key(s).
 
 ## Example Usage
 ```hcl-terraform
-    resource "newrelic_api_access_key" "foobar" {
-        account_id  = 1234567
-        key_type    = "INGEST"
-        ingest_type = "LICENSE"
-        name        = "APM Ingest License Key (blue)"
-        notes       = "To be used with service X"
-    }
+resource "newrelic_api_access_key" "foobar" {
+  account_id  = 1234567
+  key_type    = "INGEST"
+  ingest_type = "LICENSE"
+  name        = "APM Ingest License Key (blue)"
+  notes       = "To be used with service X"
+}
 ```
 
 ## Argument Reference

--- a/website/docs/r/dashboard.html.markdown
+++ b/website/docs/r/dashboard.html.markdown
@@ -131,7 +131,7 @@ All nested `widget` blocks support the following common arguments:
 
 <a name="cross-account-widget-help"></a>
 
--> **Configuring cross-account widgets** To configure a cross-account widget with an account different from the account associated with your API key, you must set the widget's `account_id` attribute to the account ID you wish to pull data from. Also note, the provider must be configured with an API Key that is scoped to a user with proper permissions to access and perform operations in other accounts that fall within or under the account associated with your API key. To facilitate cross-account widgets, we recommend [configuring the provider with a Personal API Key](../guides/provider_configuration.html#configuration-via-the-provider-block) from a user with **admin permissions** and access to the subaccount you would like to display data for in the widget.
+-> **Configuring cross-account widgets** To configure a cross-account widget with an account different from the account associated with your API key, you must set the widget's `account_id` attribute to the account ID you wish to pull data from. Also note, the provider must be configured with an API Key that is scoped to a user with proper permissions to access and perform operations in other accounts that fall within or under the account associated with your API key. To facilitate cross-account widgets, we recommend [configuring the provider with a User API Key](../guides/provider_configuration.html#configuration-via-the-provider-block) from a user with **admin permissions** and access to the subaccount you would like to display data for in the widget.
 
 ~> **Note** Due to API limitations, cross-account widgets can cause configuration drift due to the API response omitting data for widgets that that pull data from New Relic accounts outside the primary scope of the API key being used. If you need to configure cross-account widgets and also want to bypass the configuration drift for widgets, you can use Terraform's [`ignore_changes`](https://www.terraform.io/docs/configuration/resources.html#ignore_changes) using Terraforms `lifecycle` block. <br><br> ``` lifecycle { ignore_changes = [widget] }```
 
@@ -180,7 +180,7 @@ The example below shows how you can display data for an application from a prima
 
 ```hcl
 # IMPORTANT!
-# The Personal API Key must be from a user with admin permissions in the main account.
+# The User API Key must be from a user with admin permissions in the main account.
 provider "newrelic" {
   api_key = "NRAK-*****"
   # ... additional configuration

--- a/website/docs/r/workload.html.markdown
+++ b/website/docs/r/workload.html.markdown
@@ -10,9 +10,9 @@ description: |-
 
 Use this resource to create, update, and delete a New Relic One workload.
 
-A New Relic Personal API key is required to provision this resource.  Set the `api_key`
+A New Relic User API key is required to provision this resource.  Set the `api_key`
 attribute in the `provider` block or the `NEW_RELIC_API_KEY` environment
-variable with your Personal API key.
+variable with your User API key.
 
 ## Example Usage
 


### PR DESCRIPTION
Resolves: #1065 

Checklist
- [x] update client to v0.55.2 to capture updated messaging
- [x] update "getting started" docs to reflect the most recent changes for how customers can get their API key set up. 