### PR TITLE
Update for Dashboard API change [CLOSED BETA]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
 	github.com/newrelic/go-agent/v3 v3.10.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go v0.55.5
+	github.com/newrelic/newrelic-client-go v0.55.8
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -396,8 +396,8 @@ github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZX
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/mitchellh/mapstructure v1.4.0 h1:7ks8ZkOP5/ujthUsT07rNv+nkLXCQWKNHuwzOAesEks=
-github.com/mitchellh/mapstructure v1.4.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
+github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY70sEEpE=
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
@@ -409,8 +409,8 @@ github.com/newrelic/go-agent/v3 v3.10.0 h1:qHcDwtC1DjOTI0r0nCtf8jT2LfEoNQ6gSo2tc
 github.com/newrelic/go-agent/v3 v3.10.0/go.mod h1:1A1dssWBwzB7UemzRU6ZVaGDsI+cEn5/bNxI0wiYlIc=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go v0.55.5 h1:wGIalEJoJvDmuwxamr0kUSdS9JG0tnqTE2XH2tl7d7A=
-github.com/newrelic/newrelic-client-go v0.55.5/go.mod h1:afAuAfcxjAl5JC3AjkGZa0eqcBBazOTP+hEyBsx23KA=
+github.com/newrelic/newrelic-client-go v0.55.8 h1:7X1tW8kF22gY+L8Jnonh6YqCvDpcjC35FVsCGqU4Z1k=
+github.com/newrelic/newrelic-client-go v0.55.8/go.mod h1:k6e8L+H4I1n7oimYAwAe1b07wyutjNTkFpw0yGIEbug=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
@@ -488,8 +488,7 @@ github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoH
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=

--- a/newrelic/resource_newrelic_one_dashboard.go
+++ b/newrelic/resource_newrelic_one_dashboard.go
@@ -133,10 +133,10 @@ func dashboardPageSchemaElem() *schema.Resource {
 	}
 }
 
-// dashboardWidgetQuerySchemaElem defines a NRQL query for use on a dashboard
+// dashboardWidgetNRQLQuerySchemaElem defines a NRQL query for use on a dashboard
 //
 // see: newrelic/newrelic-client-go/pkg/entities/DashboardWidgetQuery
-func dashboardWidgetQuerySchemaElem() *schema.Resource {
+func dashboardWidgetNRQLQuerySchemaElem() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"account_id": {
@@ -144,7 +144,7 @@ func dashboardWidgetQuerySchemaElem() *schema.Resource {
 				Required:    true,
 				Description: "The account id used for the NRQL query.",
 			},
-			"nrql": {
+			"query": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The NRQL query.",
@@ -181,10 +181,10 @@ func dashboardWidgetBillboardSchemaElem() *schema.Resource {
 				Default:      4,
 				ValidateFunc: validation.IntBetween(1, 12),
 			},
-			"query": {
+			"nrql_query": {
 				Type:     schema.TypeList,
 				Required: true,
-				Elem:     dashboardWidgetQuerySchemaElem(),
+				Elem:     dashboardWidgetNRQLQuerySchemaElem(),
 			},
 			"title": {
 				Type:        schema.TypeString,
@@ -234,10 +234,10 @@ func dashboardWidgetGraphSchemaElem() *schema.Resource {
 				Default:      4,
 				ValidateFunc: validation.IntBetween(1, 12),
 			},
-			"query": {
+			"nrql_query": {
 				Type:     schema.TypeList,
 				Required: true,
-				Elem:     dashboardWidgetQuerySchemaElem(),
+				Elem:     dashboardWidgetNRQLQuerySchemaElem(),
 			},
 			"title": {
 				Type:        schema.TypeString,

--- a/newrelic/resource_newrelic_one_dashboard_test.go
+++ b/newrelic/resource_newrelic_one_dashboard_test.go
@@ -126,9 +126,9 @@ func testAccCheckNewRelicOneDashboardConfig_PageSimple(pageName string, accountI
       title = "foo"
       row = 4
       column = 1
-      query {
+      nrql_query {
         account_id = ` + accountID + `
-        nrql = "FROM Transaction SELECT count(*) FACET name"
+        query      = "FROM Transaction SELECT count(*) FACET name"
       }
     }
   }
@@ -149,9 +149,9 @@ func testAccCheckNewRelicOneDashboardConfig_PageFull(pageName string, accountID 
       height = 3
       width = 12
 
-      query {
+      nrql_query {
         account_id = ` + accountID + `
-        nrql = "FROM Transaction SELECT 51 TIMESERIES"
+        query      = "FROM Transaction SELECT 51 TIMESERIES"
       }
     }
 
@@ -159,9 +159,9 @@ func testAccCheckNewRelicOneDashboardConfig_PageFull(pageName string, accountID 
       title = "foo"
       row = 4
       column = 1
-      query {
+      nrql_query {
         account_id = ` + accountID + `
-        nrql = "FROM Transaction SELECT count(*) FACET name"
+        query      = "FROM Transaction SELECT count(*) FACET name"
       }
     }
 
@@ -169,9 +169,9 @@ func testAccCheckNewRelicOneDashboardConfig_PageFull(pageName string, accountID 
       title = "top 40"
       row = 4
       column = 5
-      query {
+      nrql_query {
         account_id = ` + accountID + `
-        nrql = "FROM Transaction SELECT count(*)"
+        query      = "FROM Transaction SELECT count(*)"
       }
 
       warning = 1
@@ -182,13 +182,13 @@ func testAccCheckNewRelicOneDashboardConfig_PageFull(pageName string, accountID 
       title = "over the"
       row = 4
       column = 9
-      query {
+      nrql_query {
         account_id = ` + accountID + `
-        nrql = "FROM Transaction SELECT 1 TIMESERIES"
+        query      = "FROM Transaction SELECT 1 TIMESERIES"
       }
-      query {
+      nrql_query {
         account_id = ` + accountID + `
-        nrql = "FROM Transaction SELECT 2 TIMESERIES"
+        query      = "FROM Transaction SELECT 2 TIMESERIES"
       }
     }
 
@@ -203,9 +203,9 @@ func testAccCheckNewRelicOneDashboardConfig_PageFull(pageName string, accountID 
       title = "3.14"
       row = 7
       column = 5
-      query {
+      nrql_query {
         account_id = ` + accountID + `
-        nrql = "FROM Transaction SELECT count(*) FACET name"
+        query      = "FROM Transaction SELECT count(*) FACET name"
       }
     }
 
@@ -213,9 +213,9 @@ func testAccCheckNewRelicOneDashboardConfig_PageFull(pageName string, accountID 
       title = "Round"
       row = 7
       column = 9
-      query {
+      nrql_query {
         account_id = ` + accountID + `
-        nrql = "FROM Transaction SELECT *"
+        query      = "FROM Transaction SELECT *"
       }
     }
   }

--- a/newrelic/structures_newrelic_one_dashboard.go
+++ b/newrelic/structures_newrelic_one_dashboard.go
@@ -190,8 +190,8 @@ func expandDashboardAreaWidgetConfigurationInput(i map[string]interface{}) (*das
 	var err error
 
 	// just has queries
-	if q, ok := i["query"]; ok {
-		cfg.Queries, err = expandDashboardWidgetQueryInput(q.([]interface{}))
+	if q, ok := i["nrql_query"]; ok {
+		cfg.NRQLQueries, err = expandDashboardWidgetNRQLQueryInput(q.([]interface{}))
 		if err != nil {
 			return nil, err
 		}
@@ -204,8 +204,8 @@ func expandDashboardBarWidgetConfigurationInput(i map[string]interface{}) (*dash
 	var err error
 
 	// just has queries
-	if q, ok := i["query"]; ok {
-		cfg.Queries, err = expandDashboardWidgetQueryInput(q.([]interface{}))
+	if q, ok := i["nrql_query"]; ok {
+		cfg.NRQLQueries, err = expandDashboardWidgetNRQLQueryInput(q.([]interface{}))
 		if err != nil {
 			return nil, err
 		}
@@ -218,8 +218,8 @@ func expandDashboardBillboardWidgetConfigurationInput(i map[string]interface{}) 
 	var cfg dashboards.DashboardBillboardWidgetConfigurationInput
 	var err error
 
-	if q, ok := i["query"]; ok {
-		cfg.Queries, err = expandDashboardWidgetQueryInput(q.([]interface{}))
+	if q, ok := i["nrql_query"]; ok {
+		cfg.NRQLQueries, err = expandDashboardWidgetNRQLQueryInput(q.([]interface{}))
 		if err != nil {
 			return nil, err
 		}
@@ -249,8 +249,8 @@ func expandDashboardLineWidgetConfigurationInput(i map[string]interface{}) (*das
 	var err error
 
 	// just has queries
-	if q, ok := i["query"]; ok {
-		cfg.Queries, err = expandDashboardWidgetQueryInput(q.([]interface{}))
+	if q, ok := i["nrql_query"]; ok {
+		cfg.NRQLQueries, err = expandDashboardWidgetNRQLQueryInput(q.([]interface{}))
 		if err != nil {
 			return nil, err
 		}
@@ -275,8 +275,8 @@ func expandDashboardPieWidgetConfigurationInput(i map[string]interface{}) (*dash
 	var err error
 
 	// just has queries
-	if q, ok := i["query"]; ok {
-		cfg.Queries, err = expandDashboardWidgetQueryInput(q.([]interface{}))
+	if q, ok := i["nrql_query"]; ok {
+		cfg.NRQLQueries, err = expandDashboardWidgetNRQLQueryInput(q.([]interface{}))
 		if err != nil {
 			return nil, err
 		}
@@ -289,8 +289,8 @@ func expandDashboardTableWidgetConfigurationInput(i map[string]interface{}) (*da
 	var err error
 
 	// just has queries
-	if q, ok := i["query"]; ok {
-		cfg.Queries, err = expandDashboardWidgetQueryInput(q.([]interface{}))
+	if q, ok := i["nrql_query"]; ok {
+		cfg.NRQLQueries, err = expandDashboardWidgetNRQLQueryInput(q.([]interface{}))
 		if err != nil {
 			return nil, err
 		}
@@ -326,23 +326,23 @@ func expandDashboardWidgetInput(w map[string]interface{}) (dashboards.DashboardW
 	return widget, nil
 }
 
-func expandDashboardWidgetQueryInput(queries []interface{}) ([]dashboards.DashboardWidgetQueryInput, error) {
+func expandDashboardWidgetNRQLQueryInput(queries []interface{}) ([]dashboards.DashboardWidgetNRQLQueryInput, error) {
 	if len(queries) < 1 {
-		return []dashboards.DashboardWidgetQueryInput{}, nil
+		return []dashboards.DashboardWidgetNRQLQueryInput{}, nil
 	}
 
-	expanded := make([]dashboards.DashboardWidgetQueryInput, len(queries))
+	expanded := make([]dashboards.DashboardWidgetNRQLQueryInput, len(queries))
 
 	for i, v := range queries {
-		var query dashboards.DashboardWidgetQueryInput
+		var query dashboards.DashboardWidgetNRQLQueryInput
 		q := v.(map[string]interface{})
 
 		if acct, ok := q["account_id"]; ok {
 			query.AccountID = acct.(int)
 		}
 
-		if nrql, ok := q["nrql"]; ok {
-			query.NRQL = nrdb.NRQL(nrql.(string))
+		if nrql, ok := q["query"]; ok {
+			query.Query = nrdb.NRQL(nrql.(string))
 		}
 
 		expanded[i] = query
@@ -473,16 +473,16 @@ func flattenDashboardWidget(in *entities.DashboardWidget) map[string]interface{}
 
 	switch in.Visualization.ID {
 	case "viz.area":
-		if len(in.Configuration.Area.Queries) > 0 {
-			out["query"] = flattenDashboardWidgetQuery(&in.Configuration.Area.Queries)
+		if len(in.Configuration.Area.NRQLQueries) > 0 {
+			out["nrql_query"] = flattenDashboardWidgetNRQLQuery(&in.Configuration.Area.NRQLQueries)
 		}
 	case "viz.bar":
-		if len(in.Configuration.Bar.Queries) > 0 {
-			out["query"] = flattenDashboardWidgetQuery(&in.Configuration.Bar.Queries)
+		if len(in.Configuration.Bar.NRQLQueries) > 0 {
+			out["nrql_query"] = flattenDashboardWidgetNRQLQuery(&in.Configuration.Bar.NRQLQueries)
 		}
 	case "viz.billboard":
-		if len(in.Configuration.Billboard.Queries) > 0 {
-			out["query"] = flattenDashboardWidgetQuery(&in.Configuration.Billboard.Queries)
+		if len(in.Configuration.Billboard.NRQLQueries) > 0 {
+			out["nrql_query"] = flattenDashboardWidgetNRQLQuery(&in.Configuration.Billboard.NRQLQueries)
 		}
 		if len(in.Configuration.Billboard.Thresholds) > 0 {
 			for _, v := range in.Configuration.Billboard.Thresholds {
@@ -495,34 +495,34 @@ func flattenDashboardWidget(in *entities.DashboardWidget) map[string]interface{}
 			}
 		}
 	case "viz.line":
-		if len(in.Configuration.Line.Queries) > 0 {
-			out["query"] = flattenDashboardWidgetQuery(&in.Configuration.Line.Queries)
+		if len(in.Configuration.Line.NRQLQueries) > 0 {
+			out["nrql_query"] = flattenDashboardWidgetNRQLQuery(&in.Configuration.Line.NRQLQueries)
 		}
 	case "viz.markdown":
 		if in.Configuration.Markdown.Text != "" {
 			out["text"] = in.Configuration.Markdown.Text
 		}
 	case "viz.pie":
-		if len(in.Configuration.Pie.Queries) > 0 {
-			out["query"] = flattenDashboardWidgetQuery(&in.Configuration.Pie.Queries)
+		if len(in.Configuration.Pie.NRQLQueries) > 0 {
+			out["nrql_query"] = flattenDashboardWidgetNRQLQuery(&in.Configuration.Pie.NRQLQueries)
 		}
 	case "viz.table":
-		if len(in.Configuration.Table.Queries) > 0 {
-			out["query"] = flattenDashboardWidgetQuery(&in.Configuration.Table.Queries)
+		if len(in.Configuration.Table.NRQLQueries) > 0 {
+			out["nrql_query"] = flattenDashboardWidgetNRQLQuery(&in.Configuration.Table.NRQLQueries)
 		}
 	}
 
 	return out
 }
 
-func flattenDashboardWidgetQuery(in *[]entities.DashboardWidgetQuery) []interface{} {
+func flattenDashboardWidgetNRQLQuery(in *[]entities.DashboardWidgetNRQLQuery) []interface{} {
 	out := make([]interface{}, len(*in))
 
 	for i, v := range *in {
 		m := make(map[string]interface{})
 
 		m["account_id"] = v.AccountID
-		m["nrql"] = v.NRQL
+		m["query"] = v.Query
 
 		out[i] = m
 	}

--- a/website/docs/r/one_dashboard.html.markdown
+++ b/website/docs/r/one_dashboard.html.markdown
@@ -32,7 +32,7 @@ resource "newrelic_one_dashboard" "exampledash" {
       row = 1
       column = 1
 
-      query {
+      nrql_query {
         account_id = <Your Account ID>
         nrql       = "FROM Transaction SELECT rate(count(*), 1 minute)"
       }
@@ -43,7 +43,7 @@ resource "newrelic_one_dashboard" "exampledash" {
       row = 1
       column = 5
 
-      query {
+      nrql_query {
         account_id = <Your Account ID>
         nrql       = "FROM Transaction SELECT average(duration) FACET appName"
       }
@@ -113,22 +113,22 @@ All nested `widget` blocks support the following common arguments:
 Each widget type supports an additional set of arguments:
 
   * `widget_area`, `widget_bar`, `widget_line`, `widget_pie`, `widget_table`
-    * `query` - (Required) A nested block that describes a NRQL Query. See [Nested query blocks](#nested-query-blocks) below for details.
+    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql-query-blocks) below for details.
   * `widget_billboard`
-    * `query` - (Required) A nested block that describes a NRQL Query. See [Nested query blocks](#nested-query-blocks) below for details.
+    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql-query-blocks) below for details.
     * `critical` - (Optional) Threshold above which the displayed value will be styled with a red color.
     * `warning` - (Optional) Threshold above which the displayed value will be styled with a yellow color.
   * `widget_markdown`:
     * `text` - (Required) The markdown source to be rendered in the widget.
 
-### Nested `query` blocks
+### Nested `nrql_query` blocks
 
-Nested query blocks allow you to make one or more NRQL queries within a widget, against a specified account.
+Nested `nrql_query` blocks allow you to make one or more NRQL queries within a widget, against a specified account.
 
 The following arguments are supported:
 
   * `account_id` - (Required) The New Relic account ID to issue the query against.
-  * `nrql` - (Required) Valid NRQL query string. See [Writing NRQL Queries](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/using-nrql/introduction-nrql) for help.
+  * `query` - (Required) Valid NRQL query string. See [Writing NRQL Queries](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/using-nrql/introduction-nrql) for help.
 
 ## Additional Examples
 
@@ -151,9 +151,9 @@ resource "newrelic_one_dashboard" "multi_page_dashboard" {
       row    = 1
       column = 1
 
-      query {
+      nrql_query {
         account_id = <Your Account ID>
-        nrql       = "FROM Transaction SELECT count(*) FACET name"
+        query      = "FROM Transaction SELECT count(*) FACET name"
       }
     }
   }
@@ -166,13 +166,13 @@ resource "newrelic_one_dashboard" "multi_page_dashboard" {
       row    = 1
       column = 1
       width  = 12
-      query {
+      nrql_query {
         account_id = <First Account ID>
-        nrql       = "FROM Metric SELECT rate(count(apm.service.transaction.duration), 1 minute) as 'First Account Throughput' TIMESERIES"
+        query      = "FROM Metric SELECT rate(count(apm.service.transaction.duration), 1 minute) as 'First Account Throughput' TIMESERIES"
       }
-      query {
+      nrql_query {
         account_id = <Second Account ID>
-        nrql       = "FROM Metric SELECT rate(count(apm.service.transaction.duration), 1 minute) as 'Second Account Throughput' TIMESERIES"
+        query      = "FROM Metric SELECT rate(count(apm.service.transaction.duration), 1 minute) as 'Second Account Throughput' TIMESERIES"
       }
     }
   }


### PR DESCRIPTION
**Note:** These changes are for a CLOSED BETA feature, where breaking changes are expected.

The NerdGraph Dashboard API has change shape slightly to be more consistent with other areas of the API.  Updates to the HCL have also been driven down for consistency.

Existing API will be removed on Jan 22, 20201

Here's an example of the change to end-users:

### Previous config

```hcl
resource "newrelic_one_dashboard" "bar" {
  name = "bar dashboard"
  permissions = "private"

  page {
    name = "bar dashboard"

    widget_bar {
      title = "foo"
      row = 4
      column = 1

      query {
        account_id = 12345
        nrql      = "FROM Transaction SELECT count(*) FACET name"
      }
    }
  }
}
```

### Updated config

```hcl
resource "newrelic_one_dashboard" "bar" {
  name = "bar dashboard"
  permissions = "private"

  page {
    name = "bar dashboard"

    widget_bar {
      title = "foo"
      row = 4
      column = 1

      # THIS CHANGED from "query"
      nrql_query {
        account_id = 12345

        # THIS CHANGED from "nrql"
        query      = "FROM Transaction SELECT count(*) FACET name"
      }
    }
  }
}
```