### PR TITLE
feat(one_dashboard): add linked entities to widget schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
 	github.com/newrelic/go-agent/v3 v3.10.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go v0.57.0
+	github.com/newrelic/newrelic-client-go v0.57.1
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -409,8 +409,8 @@ github.com/newrelic/go-agent/v3 v3.10.0 h1:qHcDwtC1DjOTI0r0nCtf8jT2LfEoNQ6gSo2tc
 github.com/newrelic/go-agent/v3 v3.10.0/go.mod h1:1A1dssWBwzB7UemzRU6ZVaGDsI+cEn5/bNxI0wiYlIc=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go v0.57.0 h1:AAusMUlYNuP7Nt4OM3cQ64wU7HIGydx9S4lXQhemM8A=
-github.com/newrelic/newrelic-client-go v0.57.0/go.mod h1:k6e8L+H4I1n7oimYAwAe1b07wyutjNTkFpw0yGIEbug=
+github.com/newrelic/newrelic-client-go v0.57.1 h1:NnMETNhk7XY2cPE/6dK9u3IZHiFCqXI06DIxUoDrvLA=
+github.com/newrelic/newrelic-client-go v0.57.1/go.mod h1:k6e8L+H4I1n7oimYAwAe1b07wyutjNTkFpw0yGIEbug=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=

--- a/newrelic/resource_newrelic_one_dashboard.go
+++ b/newrelic/resource_newrelic_one_dashboard.go
@@ -97,7 +97,7 @@ func dashboardPageSchemaElem() *schema.Resource {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Description: "A bar widget.",
-				Elem:        dashboardWidgetGraphSchemaElem(),
+				Elem:        dashboardWidgetBarSchemaElem(),
 			},
 			"widget_billboard": {
 				Type:        schema.TypeList,
@@ -109,7 +109,7 @@ func dashboardPageSchemaElem() *schema.Resource {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Description: "A line widget.",
-				Elem:        dashboardWidgetGraphSchemaElem(),
+				Elem:        dashboardWidgetLineSchemaElem(),
 			},
 			"widget_markdown": {
 				Type:        schema.TypeList,
@@ -121,7 +121,7 @@ func dashboardPageSchemaElem() *schema.Resource {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Description: "A pie widget.",
-				Elem:        dashboardWidgetGraphSchemaElem(),
+				Elem:        dashboardWidgetPieSchemaElem(),
 			},
 			"widget_table": {
 				Type:        schema.TypeList,
@@ -129,6 +129,41 @@ func dashboardPageSchemaElem() *schema.Resource {
 				Description: "A table widget.",
 				Elem:        dashboardWidgetGraphSchemaElem(),
 			},
+		},
+	}
+}
+
+func dashboardWidgetSchemaBase() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The ID of the widget.",
+		},
+		"title": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "A title for the widget.",
+		},
+		"column": {
+			Type:     schema.TypeInt,
+			Required: true,
+		},
+		"height": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Default:      3,
+			ValidateFunc: validation.IntAtLeast(1),
+		},
+		"row": {
+			Type:     schema.TypeInt,
+			Required: true,
+		},
+		"width": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Default:      4,
+			ValidateFunc: validation.IntBetween(1, 12),
 		},
 	}
 }
@@ -153,139 +188,117 @@ func dashboardWidgetNRQLQuerySchemaElem() *schema.Resource {
 	}
 }
 
-func dashboardWidgetBillboardSchemaElem() *schema.Resource {
+// dashboardWidgetGraphSchemaElem is a reusable schema element for graphs
+func dashboardWidgetGraphSchemaElem() *schema.Resource {
+	s := dashboardWidgetSchemaBase()
+
+	s["nrql_query"] = &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		Elem:     dashboardWidgetNRQLQuerySchemaElem(),
+	}
+
 	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"id": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "The ID of the widget.",
-			},
-			"column": {
-				Type:     schema.TypeInt,
-				Required: true,
-			},
-			"height": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      3,
-				ValidateFunc: validation.IntAtLeast(1),
-			},
-			"row": {
-				Type:     schema.TypeInt,
-				Required: true,
-			},
-			"width": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      4,
-				ValidateFunc: validation.IntBetween(1, 12),
-			},
-			"nrql_query": {
-				Type:     schema.TypeList,
-				Required: true,
-				Elem:     dashboardWidgetNRQLQuerySchemaElem(),
-			},
-			"title": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "A title for the widget.",
-			},
-			"critical": {
-				Type:        schema.TypeFloat,
-				Optional:    true,
-				Description: "The critical threshold value.",
-			},
-			"warning": {
-				Type:        schema.TypeFloat,
-				Optional:    true,
-				Description: "The warning threshold value.",
-			},
-		},
+		Schema: s,
 	}
 }
 
-// dashboardWidgetGraphSchemaElem is a reusable schema element for graphs
-func dashboardWidgetGraphSchemaElem() *schema.Resource {
+func dashboardWidgetBarSchemaElem() *schema.Resource {
+	s := dashboardWidgetSchemaBase()
+
+	s["nrql_query"] = &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		Elem:     dashboardWidgetNRQLQuerySchemaElem(),
+	}
+
+	s["linked_entity_guids"] = dashboardWidgetLinkedEntityGUIDsSchema()
+
 	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"id": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "The ID of the widget.",
-			},
-			"column": {
-				Type:     schema.TypeInt,
-				Required: true,
-			},
-			"height": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      3,
-				ValidateFunc: validation.IntAtLeast(1),
-			},
-			"row": {
-				Type:     schema.TypeInt,
-				Required: true,
-			},
-			"width": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      4,
-				ValidateFunc: validation.IntBetween(1, 12),
-			},
-			"nrql_query": {
-				Type:     schema.TypeList,
-				Required: true,
-				Elem:     dashboardWidgetNRQLQuerySchemaElem(),
-			},
-			"title": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "A title for the widget.",
-			},
-		},
+		Schema: s,
 	}
 }
-func dashboardWidgetMarkdownSchemaElem() *schema.Resource {
+
+func dashboardWidgetLineSchemaElem() *schema.Resource {
+	s := dashboardWidgetSchemaBase()
+
+	s["nrql_query"] = &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		Elem:     dashboardWidgetNRQLQuerySchemaElem(),
+	}
+
+	s["linked_entity_guids"] = dashboardWidgetLinkedEntityGUIDsSchema()
+
 	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"id": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "The ID of the widget.",
-			},
-			"column": {
-				Type:     schema.TypeInt,
-				Required: true,
-			},
-			"height": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      3,
-				ValidateFunc: validation.IntAtLeast(1),
-			},
-			"row": {
-				Type:     schema.TypeInt,
-				Required: true,
-			},
-			"width": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      4,
-				ValidateFunc: validation.IntBetween(1, 12),
-			},
-			"text": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "",
-			},
-			"title": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "A title for the widget.",
-			},
+		Schema: s,
+	}
+}
+
+func dashboardWidgetPieSchemaElem() *schema.Resource {
+	s := dashboardWidgetSchemaBase()
+
+	s["nrql_query"] = &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		Elem:     dashboardWidgetNRQLQuerySchemaElem(),
+	}
+
+	s["linked_entity_guids"] = dashboardWidgetLinkedEntityGUIDsSchema()
+
+	return &schema.Resource{
+		Schema: s,
+	}
+}
+
+func dashboardWidgetBillboardSchemaElem() *schema.Resource {
+	s := dashboardWidgetSchemaBase()
+
+	s["nrql_query"] = &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		Elem:     dashboardWidgetNRQLQuerySchemaElem(),
+	}
+
+	s["critical"] = &schema.Schema{
+		Type:        schema.TypeFloat,
+		Optional:    true,
+		Description: "The critical threshold value.",
+	}
+
+	s["warning"] = &schema.Schema{
+		Type:        schema.TypeFloat,
+		Optional:    true,
+		Description: "The warning threshold value.",
+	}
+
+	return &schema.Resource{
+		Schema: s,
+	}
+}
+
+func dashboardWidgetMarkdownSchemaElem() *schema.Resource {
+	s := dashboardWidgetSchemaBase()
+
+	s["text"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		Default:  "",
+	}
+
+	return &schema.Resource{
+		Schema: s,
+	}
+}
+
+func dashboardWidgetLinkedEntityGUIDsSchema() *schema.Schema {
+	return &schema.Schema{
+		Type: schema.TypeList,
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
 		},
+		Optional:    true,
+		Description: "Related entities. Currently only supports Dashboard entities, but may allow other cases in the future.",
 	}
 }
 

--- a/newrelic/resource_newrelic_one_dashboard_test.go
+++ b/newrelic/resource_newrelic_one_dashboard_test.go
@@ -143,7 +143,7 @@ func testAccCheckNewRelicOneDashboardConfig_PageFull(pageName string, accountID 
     name = "` + pageName + `"
 
     widget_area {
-      title = "Area 51"
+      title = "area widget"
       row = 1
       column = 1
       height = 3
@@ -152,21 +152,22 @@ func testAccCheckNewRelicOneDashboardConfig_PageFull(pageName string, accountID 
       nrql_query {
         account_id = ` + accountID + `
         query      = "FROM Transaction SELECT 51 TIMESERIES"
-      }
+			}
     }
 
     widget_bar {
-      title = "foo"
+      title = "bar widget"
       row = 4
       column = 1
       nrql_query {
         account_id = ` + accountID + `
         query      = "FROM Transaction SELECT count(*) FACET name"
-      }
+			}
+			linked_entity_guids =["MjUyMDUyOHxWSVp8REFTSEJPQVJEfDE2NDYzMDQ"]
     }
 
     widget_billboard {
-      title = "top 40"
+      title = "billboard widget"
       row = 4
       column = 5
       nrql_query {
@@ -175,11 +176,11 @@ func testAccCheckNewRelicOneDashboardConfig_PageFull(pageName string, accountID 
       }
 
       warning = 1
-      critical = 2
+			critical = 2
     }
 
     widget_line {
-      title = "over the"
+      title = "line widget"
       row = 4
       column = 9
       nrql_query {
@@ -189,34 +190,36 @@ func testAccCheckNewRelicOneDashboardConfig_PageFull(pageName string, accountID 
       nrql_query {
         account_id = ` + accountID + `
         query      = "FROM Transaction SELECT 2 TIMESERIES"
-      }
+			}
+			linked_entity_guids =["MjUyMDUyOHxWSVp8REFTSEJPQVJEfDE2NDYzMDQ"]
     }
 
     widget_markdown {
-      title = "My cool widget"
+      title = "markdown widget"
       row = 7
       column = 1
-      text = "# Header text"
+			text = "# Header text"
     }
 
     widget_pie {
-      title = "3.14"
+      title = "3.14 widget"
       row = 7
       column = 5
       nrql_query {
         account_id = ` + accountID + `
         query      = "FROM Transaction SELECT count(*) FACET name"
-      }
+			}
+			linked_entity_guids =["MjUyMDUyOHxWSVp8REFTSEJPQVJEfDE2NDYzMDQ"]
     }
 
     widget_table {
-      title = "Round"
+      title = "table widget"
       row = 7
       column = 9
       nrql_query {
         account_id = ` + accountID + `
         query      = "FROM Transaction SELECT *"
-      }
+			}
     }
   }
 `

--- a/newrelic/structures_newrelic_one_dashboard.go
+++ b/newrelic/structures_newrelic_one_dashboard.go
@@ -323,10 +323,6 @@ func expandDashboardWidgetInput(w map[string]interface{}) (dashboards.DashboardW
 		widget.Title = i.(string)
 	}
 
-	// log.Print("\n\n **************************** \n")
-	// log.Printf("\n Expand Widget t:  %+v \n", w["title"])
-	// log.Printf("\n Expand Widget:    %+v \n", w)
-
 	if i, ok := w["linked_entity_guids"]; ok {
 		widget.LinkedEntityGUIDs = expandLinkedEntityGUIDs(i.([]interface{}))
 	}
@@ -340,11 +336,6 @@ func expandLinkedEntityGUIDs(guids []interface{}) []entities.EntityGUID {
 	for i := range out {
 		out[i] = entities.EntityGUID(guids[i].(string))
 	}
-
-	// log.Printf("\n LinkedEntities Count:  %+v \n", len(out))
-	// log.Printf("\n LinkedEntities :       %+v \n", out)
-	// log.Print("\n **************************** \n\n")
-	// time.Sleep(2 * time.Second)
 
 	return out
 }
@@ -510,7 +501,6 @@ func flattenDashboardWidget(in *entities.DashboardWidget) map[string]interface{}
 		out["linked_entity_guids"] = flattenLinkedEntityGUIDs(in.LinkedEntities)
 	}
 
-	// Note: Linked Entities is only supported by faceted widgets - bar, line, pie.
 	switch in.Visualization.ID {
 	case "viz.area":
 		if len(in.Configuration.Area.NRQLQueries) > 0 {

--- a/newrelic/structures_newrelic_one_dashboard.go
+++ b/newrelic/structures_newrelic_one_dashboard.go
@@ -483,6 +483,7 @@ func flattenLinkedEntityGUIDs(linkedEntities []entities.EntityOutlineInterface) 
 	return out
 }
 
+// nolint:gocyclo
 func flattenDashboardWidget(in *entities.DashboardWidget) map[string]interface{} {
 	out := make(map[string]interface{})
 

--- a/newrelic/structures_newrelic_one_dashboard.go
+++ b/newrelic/structures_newrelic_one_dashboard.go
@@ -323,7 +323,30 @@ func expandDashboardWidgetInput(w map[string]interface{}) (dashboards.DashboardW
 		widget.Title = i.(string)
 	}
 
+	// log.Print("\n\n **************************** \n")
+	// log.Printf("\n Expand Widget t:  %+v \n", w["title"])
+	// log.Printf("\n Expand Widget:    %+v \n", w)
+
+	if i, ok := w["linked_entity_guids"]; ok {
+		widget.LinkedEntityGUIDs = expandLinkedEntityGUIDs(i.([]interface{}))
+	}
+
 	return widget, nil
+}
+
+func expandLinkedEntityGUIDs(guids []interface{}) []entities.EntityGUID {
+	out := make([]entities.EntityGUID, len(guids))
+
+	for i := range out {
+		out[i] = entities.EntityGUID(guids[i].(string))
+	}
+
+	// log.Printf("\n LinkedEntities Count:  %+v \n", len(out))
+	// log.Printf("\n LinkedEntities :       %+v \n", out)
+	// log.Print("\n **************************** \n\n")
+	// time.Sleep(2 * time.Second)
+
+	return out
 }
 
 func expandDashboardWidgetNRQLQueryInput(queries []interface{}) ([]dashboards.DashboardWidgetNRQLQueryInput, error) {
@@ -459,6 +482,16 @@ func flattenDashboardPage(in *[]entities.DashboardPage) []interface{} {
 	return out
 }
 
+func flattenLinkedEntityGUIDs(linkedEntities []entities.EntityOutlineInterface) []string {
+	out := make([]string, len(linkedEntities))
+
+	for i, entity := range linkedEntities {
+		out[i] = string(entity.GetGUID())
+	}
+
+	return out
+}
+
 func flattenDashboardWidget(in *entities.DashboardWidget) map[string]interface{} {
 	out := make(map[string]interface{})
 
@@ -471,6 +504,13 @@ func flattenDashboardWidget(in *entities.DashboardWidget) map[string]interface{}
 		out["title"] = in.Title
 	}
 
+	// NOTE: The widget types that currently support linked entities
+	// are faceted widgets - i.e. bar, line, pie
+	if len(in.LinkedEntities) > 0 {
+		out["linked_entity_guids"] = flattenLinkedEntityGUIDs(in.LinkedEntities)
+	}
+
+	// Note: Linked Entities is only supported by faceted widgets - bar, line, pie.
 	switch in.Visualization.ID {
 	case "viz.area":
 		if len(in.Configuration.Area.NRQLQueries) > 0 {

--- a/website/docs/r/one_dashboard.html.markdown
+++ b/website/docs/r/one_dashboard.html.markdown
@@ -37,6 +37,9 @@ resource "newrelic_one_dashboard" "exampledash" {
         account_id = <Your Account ID>
         query       = "FROM Transaction SELECT average(duration) FACET appName"
       }
+
+      # Must be another dashboard GUID
+      linked_entity_guids = ["abc123"]
     }
 
     widget_markdown {
@@ -102,7 +105,10 @@ All nested `widget` blocks support the following common arguments:
 
 Each widget type supports an additional set of arguments:
 
-  * `widget_area`, `widget_bar`, `widget_line`, `widget_pie`, `widget_table`
+  * `widget_bar`, `widget_line`, `widget_pie`
+    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql-query-blocks) below for details.
+    * `linked_entity_guids`: (Optional) Related entities. Currently only supports Dashboard entities.
+  * `widget_table`
     * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql-query-blocks) below for details.
   * `widget_billboard`
     * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql-query-blocks) below for details.
@@ -145,6 +151,9 @@ resource "newrelic_one_dashboard" "multi_page_dashboard" {
         account_id = <Your Account ID>
         query      = "FROM Transaction SELECT count(*) FACET name"
       }
+
+      # Must be another dashboard GUID
+      linked_entity_guids = ["abc123"]
     }
   }
 
@@ -176,4 +185,3 @@ New Relic dashboards can be imported using their GUID, e.g.
 ```
 $ terraform import newrelic_one_dashboard.my_dashboard <Dashboard GUID>
 ```
-

--- a/website/docs/r/one_dashboard.html.markdown
+++ b/website/docs/r/one_dashboard.html.markdown
@@ -107,7 +107,7 @@ Each widget type supports an additional set of arguments:
 
   * `widget_bar`, `widget_line`, `widget_pie`
     * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql-query-blocks) below for details.
-    * `linked_entity_guids`: (Optional) Related entities. Currently only supports Dashboard entities.
+    * `linked_entity_guids`: (Optional) Related entity GUIDs. Currently only supports Dashboard entity GUIDs.
   * `widget_table`
     * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql-query-blocks) below for details.
   * `widget_billboard`


### PR DESCRIPTION
Fixes: #1128 

As it stands right now, the new `linked_entity_guids` attribute will only be supported by the following widgets: `bar`, `line`, and `pie`.

Checklist
- [x] add `linked_entity_guids` to docs
- [x] ensure the correct widgets support `linkedEntities` (faceted widgets only )