### PR TITLE
docs(nrql_alert_condition): Amends threshold_duration constraints for NRQL alert conditions

### DIFF
--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -69,7 +69,7 @@ func termSchema() *schema.Resource {
 			"threshold_duration": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Description: "The duration of time, in seconds, that the threshold must violate for in order to create a violation. Value must be a multiple of 60 and within 120-3600 seconds for baseline conditions and 120-7200 seconds for static conditions.",
+				Description: "The duration, in seconds, that the threshold must violate in order to create a violation. Value must be a multiple of the 'aggregation_window' (which has a default of 60 seconds). Value must be within 120-3600 seconds for baseline and outlier conditions, within 120-7200 seconds for static conditions with the sum value function, and within 60-7200 seconds for static conditions with the single_value value function.",
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					v := val.(int)
 					minVal := 60
@@ -81,7 +81,8 @@ func termSchema() *schema.Resource {
 					}
 
 					// This validation is a top-level validation check.
-					// Static conditions must be within range [60, 7200].
+					// Static conditions with a single_value value function must be within range [60, 7200].
+					// Static conditions with a sum value function must be within range [120, 7200].
 					// Baseline conditions must be within range [120, 3600].
 					// Outlier conditions must be within range [120, 3600].
 					if v < minVal || v > maxVal {

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -118,9 +118,10 @@ The `term` block the following arguments:
 - `operator` - (Optional) Valid values are `above`, `below`, or `equals` (case insensitive). Defaults to `equals`. Note that when using a `type` of `outlier`, the only valid option here is `above`.
 - `priority` - (Optional) `critical` or `warning`. Defaults to `critical`.
 - `threshold` - (Required) The value which will trigger a violation. Must be `0` or greater.
-- `threshold_duration` - (Optional) The duration of time, in seconds, that the threshold must violate for in order to create a violation. Value must be a multiple of 60.
-<br>For _baseline_ NRQL alert conditions, the value must be within 120-3600 seconds (inclusive).
-<br>For _static_ NRQL alert conditions, the value must be within 120-7200 seconds (inclusive).
+- `threshold_duration` - (Optional) The duration, in seconds, that the threshold must violate in order to create a violation. Value must be a multiple of the `aggregation_window` (which has a default of 60 seconds).
+<br>For _baseline_ and _outlier_ NRQL alert conditions, the value must be within 120-3600 seconds (inclusive).
+<br>For _static_ NRQL alert conditions with the `sum` value function, the value must be within 120-7200 seconds (inclusive).
+<br>For _static_ NRQL alert conditions with the `single_value` value function, the value must be within 60-7200 seconds (inclusive).
 
 - `threshold_occurrences` - (Optional) The criteria for how many data points must be in violation for the specified threshold duration. Valid values are: `all` or `at_least_once` (case insensitive).
 - `duration` - (Optional) **DEPRECATED:** Use `threshold_duration` instead. The duration of time, in _minutes_, that the threshold must violate for in order to create a violation. Must be within 1-120 (inclusive).


### PR DESCRIPTION
### Goals :soccer:
Better align the documentation about NRQL condition terms threshold validation with how they are being validated by the downstream service that registers them.

### Implementation Details :construction:
- _Only_ updates documentation; no "code" changes
- Calls out that:
  - Terms thresholds are validated against the aggregation window
  - That different NRQL condition types have different validation applied to their durations

**Open question:** this raises a question about whether the [`ValidateFunc` for `threshold_duration`](https://github.com/newrelic/terraform-provider-newrelic/blob/bcf78ca22ff40f5a398e99cd3ac833fe938c1d52/newrelic/resource_newrelic_nrql_alert_condition.go#L73,L92) is generating false positives _and_ false negatives during the `plan` phase. I'm a newcomer to Terraform, so I may be misinterpreting what's happening in that function, but I wanted to ask about it while otherwise submitting more accurate documentation strings.