### PR TITLE
fix (newrelic_alert_muting_rule): condition tag validation

### DIFF
--- a/newrelic/resource_newrelic_alert_muting_rule_test.go
+++ b/newrelic/resource_newrelic_alert_muting_rule_test.go
@@ -3,7 +3,9 @@
 package newrelic
 
 import (
+	"errors"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
 
@@ -151,4 +153,31 @@ func testAccCheckNewRelicAlertMutingRuleDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func TestValidateMutingRuleConditionAttribute_ValidTag(t *testing.T) {
+	// It should accept a dot-separated tag and value
+	validTag := "tag.EC2Timezone with sp aces"
+	resourceName := "condition.0.conditions.0.attribute"
+
+	warns, errs := validateMutingRuleConditionAttribute(validTag, resourceName)
+	expectedErrs := []error(nil)
+	expectedWarns := []string([]string(nil))
+
+	require.Equal(t, expectedWarns, warns)
+	require.Equal(t, expectedErrs, errs)
+
+}
+
+func TestValidateMutingRuleConditionAttribute_InvalidTag(t *testing.T) {
+	// It should reject "tag" without value
+	invalidTag := "tag"
+	resourceName := "condition.0.conditions.0.attribute"
+
+	warns, errs := validateMutingRuleConditionAttribute(invalidTag, resourceName)
+	expectedErrs := []error{errors.New("\"condition.0.attribute\" of \"tag\" must be in the format tag.tag_name")}
+	expectedWarns := []string([]string(nil))
+
+	require.Equal(t, expectedWarns, warns)
+	require.Equal(t, expectedErrs, errs)
 }


### PR DESCRIPTION
fixes [issue #1153](https://github.com/newrelic/terraform-provider-newrelic/issues/1153)

muting rule condition tags have a special format that's parsed out before matching. They need to be in the format of `tag.some_value`.

The StringInSlice validation was treating tags like a normal attribute name, so any correctly configured tag was failing, and only the incorrectly formatted condition of `tag` would pass.

More details and repro steps [in the issue](https://github.com/newrelic/terraform-provider-newrelic/issues/1153)