### PR TITLE
fix(nrql_alert_condition): validate operator based on condition type

### DIFF
--- a/newrelic/structures_newrelic_nrql_alert_condition.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition.go
@@ -171,6 +171,15 @@ func expandNrqlConditionTerm(term map[string]interface{}, conditionType, priorit
 		return nil, fmt.Errorf("one of `duration` or `threshold_duration` must be configured for block `term`, but not both")
 	}
 
+	operator := alerts.AlertsNRQLConditionTermsOperator(strings.ToUpper(term["operator"].(string)))
+
+	switch conditionType {
+	case "baseline", "outlier":
+		if operator != alerts.AlertsNRQLConditionTermsOperatorTypes.ABOVE {
+			return nil, fmt.Errorf("only ABOVE operator is allowed for `baseline` and `outlier` condition types")
+		}
+	}
+
 	var duration int
 	if durationIn > 0 {
 		duration = durationIn * 60 // convert min to sec
@@ -196,7 +205,7 @@ func expandNrqlConditionTerm(term map[string]interface{}, conditionType, priorit
 	}
 
 	return &alerts.NrqlConditionTerm{
-		Operator:             alerts.AlertsNRQLConditionTermsOperator(strings.ToUpper(term["operator"].(string))),
+		Operator:             operator,
 		Priority:             alerts.NrqlConditionPriority(strings.ToUpper(priority)),
 		Threshold:            &threshold,
 		ThresholdDuration:    duration,

--- a/newrelic/structures_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition_test.go
@@ -605,6 +605,32 @@ func TestExpandNrqlConditionTerm(t *testing.T) {
 				ThresholdOccurrences: "ALL",
 			},
 		},
+		"non-ABOVE operator when using baseline condition": {
+			Priority:      "warning",
+			ConditionType: "baseline",
+			Term: map[string]interface{}{
+				"threshold":             10.9,
+				"threshold_duration":    9,
+				"threshold_occurrences": "ALL",
+				"operator":              "equals",
+				"priority":              "critical",
+			},
+			ExpectErr:    true,
+			ExpectReason: "only ABOVE operator is allowed for `baseline` and `outlier` condition types",
+		},
+		"non-ABOVE operator when using outlier condition": {
+			Priority:      "warning",
+			ConditionType: "outlier",
+			Term: map[string]interface{}{
+				"threshold":             10.9,
+				"threshold_duration":    9,
+				"threshold_occurrences": "ALL",
+				"operator":              "equals",
+				"priority":              "critical",
+			},
+			ExpectErr:    true,
+			ExpectReason: "only ABOVE operator is allowed for `baseline` and `outlier` condition types",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
fixes #1157

Without this change, we attempt to set an invalid operator on baseline and
outlier conditions.  This looks to be a change in the upstream API to perform
more validation, which is then surfaced as an API error to the Terraform user,
but without the needed context about why the call was invalid.  Here we catch
this condition during the expandNrqlConditionTerm code to ensure that we don't
attempt to make the call, and give back a reasonable error to the user.