### PR TITLE
feat(alert_muting_rule): add schedule support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
 	github.com/newrelic/go-agent/v3 v3.10.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go v0.57.1
+	github.com/newrelic/newrelic-client-go v0.57.2
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -411,6 +411,8 @@ github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fz
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
 github.com/newrelic/newrelic-client-go v0.57.1 h1:NnMETNhk7XY2cPE/6dK9u3IZHiFCqXI06DIxUoDrvLA=
 github.com/newrelic/newrelic-client-go v0.57.1/go.mod h1:k6e8L+H4I1n7oimYAwAe1b07wyutjNTkFpw0yGIEbug=
+github.com/newrelic/newrelic-client-go v0.57.2 h1:33pPUEoS9nYmlW2V8m5ai9762TtnWMMkaoPZFKggKrQ=
+github.com/newrelic/newrelic-client-go v0.57.2/go.mod h1:k6e8L+H4I1n7oimYAwAe1b07wyutjNTkFpw0yGIEbug=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=

--- a/newrelic/data_source_newrelic_entity_test.go
+++ b/newrelic/data_source_newrelic_entity_test.go
@@ -18,7 +18,7 @@ func TestExpandEntityTag(t *testing.T) {
 	}
 
 	expected := []entities.EntitySearchQueryBuilderTag{
-		entities.EntitySearchQueryBuilderTag{
+		{
 			Key:   "my-key",
 			Value: "my-value",
 		},

--- a/newrelic/resource_newrelic_alert_muting_rule_test.go
+++ b/newrelic/resource_newrelic_alert_muting_rule_test.go
@@ -14,14 +14,64 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
+func TestValidateNaiveDateTime_Validates(t *testing.T) {
+	validDate := "2021-02-21T15:30:00"
+	resourceName := "schedule.0.end_repeat"
+
+	warns, errs := validateNaiveDateTime(validDate, resourceName)
+
+	require.Equal(t, []string([]string(nil)), warns)
+	require.Equal(t, []error([]error(nil)), errs)
+
+}
+
+func TestValidateNaiveDateTime_RejectsNumericOffset(t *testing.T) {
+	// It should reject any 8601 time with an offset
+	invalidDate := "2021-02-21T15:30:00-08:00"
+	resourceName := "schedule.0.end_repeat"
+
+	warns, errs := validateNaiveDateTime(invalidDate, resourceName)
+	expectedErrs := []error{errors.New("\"schedule.0.end_repeat\" of \"2021-02-21T15:30:00-08:00\" must be in the format 2006-01-02T15:04:05")}
+
+	require.Equal(t, []string([]string(nil)), warns)
+	require.Equal(t, expectedErrs, errs)
+
+}
+
+func TestValidateNaiveDateTime_RejectsGMTOffset(t *testing.T) {
+	// It should reject an 8601 time with GMT designation
+	invalidDate := "2021-02-21T15:30:00Z"
+	resourceName := "schedule.0.end_repeat"
+
+	warns, errs := validateNaiveDateTime(invalidDate, resourceName)
+	expectedErrs := []error{errors.New("\"schedule.0.end_repeat\" of \"2021-02-21T15:30:00Z\" must be in the format 2006-01-02T15:04:05")}
+
+	require.Equal(t, []string([]string(nil)), warns)
+	require.Equal(t, expectedErrs, errs)
+
+}
+
+func TestValidateNaiveDateTime_RejectsUnixDateTime(t *testing.T) {
+	// It should reject an 8601 time with GMT designation
+	invalidDate := "123456789123456"
+	resourceName := "schedule.0.end_repeat"
+
+	warns, errs := validateNaiveDateTime(invalidDate, resourceName)
+	expectedErrs := []error{errors.New("\"schedule.0.end_repeat\" of \"123456789123456\" must be in the format 2006-01-02T15:04:05")}
+
+	require.Equal(t, []string([]string(nil)), warns)
+	require.Equal(t, expectedErrs, errs)
+
+}
+
 func TestAccNewRelicAlertMutingRule_Basic(t *testing.T) {
 	resourceName := "newrelic_alert_muting_rule.foo"
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		// CheckDestroy: testAccCheckNewRelicAlertMutingRuleDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertMutingRuleDestroy,
 		Steps: []resource.TestStep{
 			// Test: Create
 			{
@@ -42,6 +92,99 @@ func TestAccNewRelicAlertMutingRule_Basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true},
+		},
+	})
+}
+
+func TestAccNewRelicAlertMutingRule_WithSchedule(t *testing.T) {
+	resourceName := "newrelic_alert_muting_rule.foo"
+	rName := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertMutingRuleDestroy,
+		Steps: []resource.TestStep{
+			// Test: Create
+			{
+				Config: testAccNewRelicAlertMutingRuleWithSchedule(
+					rName,
+					"new muting rule",
+					"product",
+					"EQUALS",
+					"APM",
+					`
+						start_time         = "2021-01-21T15:30:00"
+						end_time           = "2021-01-21T16:30:00"
+						time_zone          = "America/Los_Angeles"
+						repeat             = "WEEKLY"
+						end_repeat         = "2022-06-11T12:00:00"
+						weekly_repeat_days = ["FRIDAY", "TUESDAY"]
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicAlertMutingRuleExists(resourceName),
+				),
+			},
+			//Test: Update to null out schedule completely
+			{
+				Config: testAccNewRelicAlertMutingRuleBasic(
+					rName,
+					"updated without schedule",
+					"conditionName",
+					"EQUALS",
+					"My cool condition",
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicAlertMutingRuleExists(resourceName),
+				),
+			},
+			{
+				//Test: Update to add a schedule with default WEEKLY repeat (empty slice of days)
+				Config: testAccNewRelicAlertMutingRuleWithSchedule(rName,
+					"updated muting rule with schedule",
+					"conditionType",
+					"NOT_EQUALS",
+					"baseline",
+					`
+						start_time         = "2021-02-21T15:30:00"
+						end_time           = "2021-02-21T16:30:00"
+						end_repeat         = "2022-06-11T12:00:00"
+						repeat             = "WEEKLY"
+						time_zone          = "America/Los_Angeles"
+						weekly_repeat_days = []
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicAlertMutingRuleExists(resourceName),
+				),
+			},
+			{
+				//Test: Update to add a schedule with DAILY repeat, new timezone & repeat_count
+				Config: testAccNewRelicAlertMutingRuleWithSchedule(rName,
+					"updated muting rule with schedule daily repeat, 42 times",
+					"conditionType",
+					"NOT_EQUALS",
+					"baseline",
+					`
+						start_time         = "2021-02-21T15:30:00"
+						end_time           = "2021-02-21T16:30:00"
+						repeat_count       = 42
+						repeat             = "DAILY"
+						time_zone          = "Asia/Bangkok"
+					`,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicAlertMutingRuleExists(resourceName),
+				),
+			},
+
+			//Test: Import
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -74,6 +217,39 @@ resource "newrelic_alert_muting_rule" "foo" {
 	}
 }
 `, name, description, attribute, operator, values)
+}
+
+func testAccNewRelicAlertMutingRuleWithSchedule(
+	name string,
+	description string,
+	attribute string,
+	operator string,
+	values string,
+	schedule string,
+) string {
+	return fmt.Sprintf(`
+
+resource "newrelic_alert_muting_rule" "foo" {
+	name = "tf-test-%[1]s"
+	enabled = true
+	description = "%[2]s"
+	condition {
+		conditions {
+			attribute 	= "%[3]s"
+			operator 	= "EQUALS"
+			values 		= ["%[5]s"]
+		}
+		conditions {
+			attribute 	= "conditionType"
+			operator 	= "%[4]s"
+			values 		= ["static"]
+		}
+		operator = "AND"
+	}
+	schedule { 
+		%[6]s
+	}
+}`, name, description, attribute, operator, values, schedule)
 }
 
 func testAccCheckNewRelicAlertMutingRuleExists(n string) resource.TestCheckFunc {

--- a/newrelic/structures_newrelic_alert_muting_rule.go
+++ b/newrelic/structures_newrelic_alert_muting_rule.go
@@ -1,11 +1,15 @@
 package newrelic
 
 import (
+	"fmt"
+	"strings"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/newrelic/newrelic-client-go/pkg/alerts"
 )
 
-func expandMutingRuleCreateInput(d *schema.ResourceData) alerts.MutingRuleCreateInput {
+func expandMutingRuleCreateInput(d *schema.ResourceData) (alerts.MutingRuleCreateInput, error) {
 	createInput := alerts.MutingRuleCreateInput{
 		Enabled:     d.Get("enabled").(bool),
 		Name:        d.Get("name").(string),
@@ -16,10 +20,177 @@ func expandMutingRuleCreateInput(d *schema.ResourceData) alerts.MutingRuleCreate
 		createInput.Condition = expandMutingRuleConditionGroup(e.([]interface{})[0].(map[string]interface{}))
 	}
 
-	return createInput
+	if e, ok := d.GetOk("schedule"); ok {
+		schedule, err := expandMutingRuleCreateSchedule(e.([]interface{})[0].(map[string]interface{}))
+		if err != nil {
+			return alerts.MutingRuleCreateInput{}, err
+		}
+		createInput.Schedule = &schedule
+	}
+
+	return createInput, nil
 }
 
-func expandMutingRuleUpdateInput(d *schema.ResourceData) alerts.MutingRuleUpdateInput {
+func expandMutingRuleCreateSchedule(cfg map[string]interface{}) (alerts.MutingRuleScheduleCreateInput, error) {
+	schedule := alerts.MutingRuleScheduleCreateInput{}
+
+	if startTime, ok := cfg["start_time"]; ok {
+		rawStartTime := startTime.(string)
+		if rawStartTime != "" {
+			formattedStartTime, err := time.Parse("2006-01-02T15:04:05", rawStartTime)
+			if err != nil {
+				return alerts.MutingRuleScheduleCreateInput{}, err
+			}
+			schedule.StartTime = &alerts.NaiveDateTime{Time: formattedStartTime}
+		}
+	}
+
+	if endTime, ok := cfg["end_time"]; ok {
+		rawEndTime := endTime.(string)
+		if rawEndTime != "" {
+			formattedEndTime, err := time.Parse("2006-01-02T15:04:05", rawEndTime)
+			if err != nil {
+				return alerts.MutingRuleScheduleCreateInput{}, err
+			}
+			schedule.EndTime = &alerts.NaiveDateTime{Time: formattedEndTime}
+		}
+	}
+
+	if timeZone, ok := cfg["time_zone"]; ok {
+		schedule.TimeZone = timeZone.(string)
+	}
+
+	repeat, ok := cfg["repeat"]
+	if ok {
+		r := repeat.(string)
+		if r != "" {
+			sr := alerts.MutingRuleScheduleRepeat(strings.ToUpper(r))
+			schedule.Repeat = &sr
+
+		}
+	}
+
+	if endRepeat, ok := cfg["end_repeat"]; ok {
+		rawEndRepeat := endRepeat.(string)
+		if rawEndRepeat != "" {
+			formattedEndRepeat, err := time.Parse("2006-01-02T15:04:05", rawEndRepeat)
+			if err != nil {
+				return alerts.MutingRuleScheduleCreateInput{}, err
+			}
+			schedule.EndRepeat = &alerts.NaiveDateTime{Time: formattedEndRepeat}
+		}
+
+	}
+
+	if repeatCount, ok := cfg["repeat_count"]; ok {
+		r := repeatCount.(int)
+		if r > 0 {
+			schedule.RepeatCount = &r
+		}
+	}
+
+	if weeklyRepeatDays, ok := cfg["weekly_repeat_days"]; ok {
+		repeatDaysAsList := weeklyRepeatDays.(*schema.Set).List()
+		rdLen := len(repeatDaysAsList)
+		if rdLen > 0 || repeat == "WEEKLY" {
+			// start with slice of len 0
+			repeatDays := []alerts.DayOfWeek{}
+			for _, day := range repeatDaysAsList {
+				repeatDays = append(repeatDays, alerts.DayOfWeek(strings.ToUpper(day.(string))))
+			}
+			schedule.WeeklyRepeatDays = &repeatDays
+		} else {
+			schedule.WeeklyRepeatDays = nil
+		}
+	}
+	return schedule, nil
+}
+
+func expandMutingRuleUpdateSchedule(cfg map[string]interface{}) (alerts.MutingRuleScheduleUpdateInput, error) {
+	schedule := alerts.MutingRuleScheduleUpdateInput{}
+
+	if startTime, ok := cfg["start_time"]; ok {
+		rawStartTime := startTime.(string)
+		if rawStartTime != "" {
+			formattedStartTime, err := time.Parse("2006-01-02T15:04:05", rawStartTime)
+			if err != nil {
+				return alerts.MutingRuleScheduleUpdateInput{}, err
+			}
+			schedule.StartTime = &alerts.NaiveDateTime{Time: formattedStartTime}
+		} else {
+			schedule.StartTime = nil
+		}
+	}
+
+	if endTime, ok := cfg["end_time"]; ok {
+		rawEndTime := endTime.(string)
+		if rawEndTime != "" {
+			formattedEndTime, err := time.Parse("2006-01-02T15:04:05", rawEndTime)
+			if err != nil {
+				return alerts.MutingRuleScheduleUpdateInput{}, err
+			}
+			schedule.EndTime = &alerts.NaiveDateTime{Time: formattedEndTime}
+		} else {
+			schedule.EndTime = nil
+		}
+	}
+
+	if timeZone, ok := cfg["time_zone"]; ok {
+		if rawTimeZone := timeZone.(string); rawTimeZone != "" {
+			schedule.TimeZone = &rawTimeZone
+		}
+	}
+	repeat, ok := cfg["repeat"]
+	if ok {
+		r := repeat.(string)
+		if r != "" {
+			sr := alerts.MutingRuleScheduleRepeat(strings.ToUpper(r))
+			schedule.Repeat = &sr
+		} else {
+			schedule.Repeat = nil
+		}
+	}
+
+	if endRepeat, ok := cfg["end_repeat"]; ok {
+		rawEndRepeat := endRepeat.(string)
+		if rawEndRepeat != "" {
+			formattedEndRepeat, err := time.Parse("2006-01-02T15:04:05", rawEndRepeat)
+			if err != nil {
+				return alerts.MutingRuleScheduleUpdateInput{}, err
+			}
+			schedule.EndRepeat = &alerts.NaiveDateTime{Time: formattedEndRepeat}
+		} else {
+			schedule.EndRepeat = nil
+		}
+	}
+
+	if repeatCount, ok := cfg["repeat_count"]; ok {
+		r := repeatCount.(int)
+		if r > 0 {
+			schedule.RepeatCount = &r
+		} else {
+			schedule.RepeatCount = nil
+		}
+	}
+
+	if weeklyRepeatDays, ok := cfg["weekly_repeat_days"]; ok {
+		repeatDaysAsList := weeklyRepeatDays.(*schema.Set).List()
+		rdLen := len(repeatDaysAsList)
+		if rdLen > 0 || repeat == "WEEKLY" {
+			// start with slice of len 0
+			repeatDays := []alerts.DayOfWeek{}
+			for _, day := range repeatDaysAsList {
+				repeatDays = append(repeatDays, alerts.DayOfWeek(strings.ToUpper(day.(string))))
+			}
+			schedule.WeeklyRepeatDays = &repeatDays
+		} else {
+			schedule.WeeklyRepeatDays = nil
+		}
+	}
+	return schedule, nil
+}
+
+func expandMutingRuleUpdateInput(d *schema.ResourceData) (alerts.MutingRuleUpdateInput, error) {
 	updateInput := alerts.MutingRuleUpdateInput{
 		Enabled:     d.Get("enabled").(bool),
 		Name:        d.Get("name").(string),
@@ -32,7 +203,15 @@ func expandMutingRuleUpdateInput(d *schema.ResourceData) alerts.MutingRuleUpdate
 		updateInput.Condition = &x
 	}
 
-	return updateInput
+	if e, ok := d.GetOk("schedule"); ok {
+		schedule, err := expandMutingRuleUpdateSchedule(e.([]interface{})[0].(map[string]interface{}))
+		if err != nil {
+			return alerts.MutingRuleUpdateInput{}, err
+		}
+		updateInput.Schedule = &schedule
+	}
+
+	return updateInput, nil
 }
 
 func expandMutingRuleConditionGroup(cfg map[string]interface{}) alerts.MutingRuleConditionGroup {
@@ -85,11 +264,11 @@ func expandMutingRuleValues(values []interface{}) []string {
 
 func flattenMutingRule(mutingRule *alerts.MutingRule, d *schema.ResourceData) error {
 
-	x, ok := d.GetOk("condition")
+	x := d.Get("condition")
 	configuredCondition := x.([]interface{})
 
 	d.Set("enabled", mutingRule.Enabled)
-	err := d.Set("condition", flattenMutingRuleConditionGroup(mutingRule.Condition, configuredCondition, ok))
+	err := d.Set("condition", flattenMutingRuleConditionGroup(mutingRule.Condition, configuredCondition))
 	if err != nil {
 		return nil
 	}
@@ -97,10 +276,16 @@ func flattenMutingRule(mutingRule *alerts.MutingRule, d *schema.ResourceData) er
 	d.Set("description", mutingRule.Description)
 	d.Set("name", mutingRule.Name)
 
+	if mutingRule.Schedule != nil {
+		if err := d.Set("schedule", flattenSchedule(mutingRule.Schedule)); err != nil {
+			return fmt.Errorf("[Error] Error setting `schedule`: %v", err)
+		}
+	}
+
 	return nil
 }
 
-func flattenMutingRuleConditionGroup(in alerts.MutingRuleConditionGroup, configuredCondition []interface{}, ok bool) []map[string]interface{} {
+func flattenMutingRuleConditionGroup(in alerts.MutingRuleConditionGroup, configuredCondition []interface{}) []map[string]interface{} {
 
 	condition := []map[string]interface{}{
 		{
@@ -119,6 +304,7 @@ func flattenMutingRuleConditionGroup(in alerts.MutingRuleConditionGroup, configu
 
 	return condition
 }
+
 func handleImportFlattenCondition(conditions []alerts.MutingRuleCondition) []map[string]interface{} {
 	var condition []map[string]interface{}
 
@@ -133,6 +319,7 @@ func handleImportFlattenCondition(conditions []alerts.MutingRuleCondition) []map
 
 	return condition
 }
+
 func flattenMutingRuleCondition(conditions []interface{}) []map[string]interface{} {
 	var condition []map[string]interface{}
 
@@ -147,8 +334,55 @@ func flattenMutingRuleCondition(conditions []interface{}) []map[string]interface
 			}
 			condition = append(condition, dst)
 		}
-
 	}
 
 	return condition
+}
+
+func flattenSchedule(schedule *alerts.MutingRuleSchedule) []interface{} {
+	out := map[string]interface{}{}
+
+	if schedule.StartTime != nil {
+		out["start_time"] = schedule.StartTime.Format("2006-01-02T15:04:05")
+	}
+
+	if schedule.EndTime != nil {
+		out["end_time"] = schedule.EndTime.Format("2006-01-02T15:04:05")
+	}
+
+	if schedule.EndRepeat != nil {
+		out["end_repeat"] = schedule.EndRepeat.Format("2006-01-02T15:04:05")
+	}
+
+	if schedule.Repeat != nil {
+		out["repeat"] = string(*schedule.Repeat)
+	}
+
+	if schedule.TimeZone != "" {
+		out["time_zone"] = schedule.TimeZone
+	}
+
+	if schedule.RepeatCount != nil {
+		out["repeat_count"] = *schedule.RepeatCount
+	}
+
+	if schedule.WeeklyRepeatDays != nil {
+		out["weekly_repeat_days"] = flattenWeeklyRepeatDays(*schedule.WeeklyRepeatDays)
+	} else if *schedule.Repeat == "WEEKLY" {
+		out["weekly_repeat_days"] = []string{}
+	} else {
+		out["weekly_repeat_days"] = nil
+	}
+
+	return []interface{}{out}
+}
+
+func flattenWeeklyRepeatDays(daysOfWeek []alerts.DayOfWeek) []string {
+	out := []string{}
+
+	for _, d := range daysOfWeek {
+		out = append(out, string(d))
+	}
+
+	return out
 }

--- a/newrelic/structures_newrelic_alert_muting_rule_test.go
+++ b/newrelic/structures_newrelic_alert_muting_rule_test.go
@@ -1,0 +1,350 @@
+// +build integration
+
+package newrelic
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"testing"
+	"time"
+
+	"github.com/newrelic/newrelic-client-go/pkg/alerts"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlattenSchedule(t *testing.T) {
+	t.Parallel()
+
+	timestamp, _ := time.Parse(time.RFC3339, "2021-01-21T15:30:00+08:00")
+
+	repeat := alerts.MutingRuleScheduleRepeat("WEEKLY")
+
+	mockMutingRuleSchedule := alerts.MutingRuleSchedule{
+		StartTime: &timestamp,
+		EndTime:   &timestamp,
+		TimeZone:  "America/Los_Angeles",
+		Repeat:    &repeat,
+		EndRepeat: &timestamp,
+		WeeklyRepeatDays: &[]alerts.DayOfWeek{
+			"MONDAY",
+			"TUESDAY",
+		},
+	}
+
+	mockScheduleConfig := map[string]interface{}{
+		"start_time": "2021-01-21T15:30:00",
+		"end_time":   "2021-01-21T15:30:00",
+		"end_repeat": "2021-01-21T15:30:00",
+		"time_zone":  "America/Los_Angeles",
+		"repeat":     "WEEKLY",
+		"weekly_repeat_days": []string{
+			"MONDAY",
+			"TUESDAY",
+		},
+	}
+
+	result := flattenSchedule(&mockMutingRuleSchedule)
+
+	require.Equal(t, []interface{}{mockScheduleConfig}, result)
+}
+
+func TestFlattenSchedule_EmptyDaysOfWeekWithWeeklyRepeat(t *testing.T) {
+	// Flatten should send an empty slice for weekly_repeat_days if repeat is set to WEEKLY
+	t.Parallel()
+
+	timestamp, _ := time.Parse(time.RFC3339, "2021-01-21T15:30:00+08:00")
+
+	repeat := alerts.MutingRuleScheduleRepeat("WEEKLY")
+
+	mockMutingRuleSchedule := alerts.MutingRuleSchedule{
+		StartTime:        &timestamp,
+		EndTime:          &timestamp,
+		TimeZone:         "America/Los_Angeles",
+		Repeat:           &repeat,
+		EndRepeat:        &timestamp,
+		WeeklyRepeatDays: &[]alerts.DayOfWeek{},
+	}
+
+	mockScheduleConfig := map[string]interface{}{
+		"start_time":         "2021-01-21T15:30:00",
+		"end_time":           "2021-01-21T15:30:00",
+		"end_repeat":         "2021-01-21T15:30:00",
+		"time_zone":          "America/Los_Angeles",
+		"repeat":             "WEEKLY",
+		"weekly_repeat_days": []string{},
+	}
+
+	result := flattenSchedule(&mockMutingRuleSchedule)
+
+	require.Equal(t, []interface{}{mockScheduleConfig}, result)
+}
+
+func TestFlattenSchedule_NilWeeklyRepeatDaysWeeklyRepeat(t *testing.T) {
+	// Flatten should not null out weekly_repeat_days if repeat is set to WEEKLY
+
+	t.Parallel()
+
+	timestamp, _ := time.Parse(time.RFC3339, "2021-01-21T15:30:00+08:00")
+
+	repeat := alerts.MutingRuleScheduleRepeat("WEEKLY")
+
+	mockMutingRuleSchedule := alerts.MutingRuleSchedule{
+		StartTime:        &timestamp,
+		EndTime:          &timestamp,
+		TimeZone:         "America/Los_Angeles",
+		Repeat:           &repeat,
+		EndRepeat:        &timestamp,
+		WeeklyRepeatDays: nil,
+	}
+
+	mockScheduleConfig := map[string]interface{}{
+		"start_time":         "2021-01-21T15:30:00",
+		"end_time":           "2021-01-21T15:30:00",
+		"end_repeat":         "2021-01-21T15:30:00",
+		"time_zone":          "America/Los_Angeles",
+		"repeat":             "WEEKLY",
+		"weekly_repeat_days": []string{},
+	}
+
+	result := flattenSchedule(&mockMutingRuleSchedule)
+
+	require.Equal(t, []interface{}{mockScheduleConfig}, result)
+}
+
+func TestFlattenSchedule_NilWeeklyRepeatDaysDailyRepeat(t *testing.T) {
+	// Flatten should null out weekly_repeat_days if repeat is set to DAILY
+
+	t.Parallel()
+
+	timestamp, _ := time.Parse(time.RFC3339, "2021-01-21T15:30:00+08:00")
+
+	repeat := alerts.MutingRuleScheduleRepeat("DAILY")
+
+	mockMutingRuleSchedule := alerts.MutingRuleSchedule{
+		StartTime:        &timestamp,
+		EndTime:          &timestamp,
+		TimeZone:         "America/Los_Angeles",
+		Repeat:           &repeat,
+		EndRepeat:        &timestamp,
+		WeeklyRepeatDays: nil,
+	}
+
+	mockScheduleConfig := map[string]interface{}{
+		"start_time":         "2021-01-21T15:30:00",
+		"end_time":           "2021-01-21T15:30:00",
+		"end_repeat":         "2021-01-21T15:30:00",
+		"time_zone":          "America/Los_Angeles",
+		"repeat":             "DAILY",
+		"weekly_repeat_days": nil,
+	}
+
+	result := flattenSchedule(&mockMutingRuleSchedule)
+
+	require.Equal(t, []interface{}{mockScheduleConfig}, result)
+}
+
+func TestExpandScheduleUpdate_Basic(t *testing.T) {
+	t.Parallel()
+	ts, _ := time.Parse("2006-01-02T15:04:05", "2021-01-21T15:30:00")
+	timestamp := alerts.NaiveDateTime{Time: ts}
+	timeZone := "America/Los_Angeles"
+	repeat := alerts.MutingRuleScheduleRepeatTypes.WEEKLY
+
+	testSchema := &schema.Set{F: schema.HashString}
+	testSchema.Add("MONDAY")
+	testSchema.Add("TUESDAY")
+
+	mockScheduleConfig := map[string]interface{}{
+		"start_time":         "2021-01-21T15:30:00",
+		"end_time":           "2021-01-21T15:30:00",
+		"end_repeat":         "2021-01-21T15:30:00",
+		"time_zone":          "America/Los_Angeles",
+		"repeat":             "WEEKLY",
+		"weekly_repeat_days": testSchema,
+	}
+
+	result, _ := expandMutingRuleUpdateSchedule(mockScheduleConfig)
+
+	expected := alerts.MutingRuleScheduleUpdateInput{
+		StartTime: &timestamp,
+		EndTime:   &timestamp,
+		TimeZone:  &timeZone,
+		Repeat:    &repeat,
+		EndRepeat: &timestamp,
+		WeeklyRepeatDays: &[]alerts.DayOfWeek{
+			"TUESDAY",
+			"MONDAY",
+		},
+	}
+
+	require.Equal(t, expected, result)
+
+}
+
+func TestExpandScheduleCreate_Basic(t *testing.T) {
+	t.Parallel()
+	ts, _ := time.Parse("2006-01-02T15:04:05", "2021-01-21T15:30:00")
+	timestamp := alerts.NaiveDateTime{Time: ts}
+	timeZone := "America/Los_Angeles"
+	repeat := alerts.MutingRuleScheduleRepeatTypes.WEEKLY
+
+	testSchema := &schema.Set{F: schema.HashString}
+	testSchema.Add("MONDAY")
+	testSchema.Add("TUESDAY")
+
+	mockScheduleConfig := map[string]interface{}{
+		"start_time":         "2021-01-21T15:30:00",
+		"end_time":           "2021-01-21T15:30:00",
+		"end_repeat":         "2021-01-21T15:30:00",
+		"time_zone":          "America/Los_Angeles",
+		"repeat":             "WEEKLY",
+		"weekly_repeat_days": testSchema,
+	}
+
+	result, _ := expandMutingRuleCreateSchedule(mockScheduleConfig)
+
+	expected := alerts.MutingRuleScheduleCreateInput{
+		StartTime: &timestamp,
+		EndTime:   &timestamp,
+		TimeZone:  timeZone,
+		Repeat:    &repeat,
+		EndRepeat: &timestamp,
+		WeeklyRepeatDays: &[]alerts.DayOfWeek{
+			"TUESDAY",
+			"MONDAY",
+		},
+	}
+
+	require.Equal(t, expected, result)
+
+}
+
+func TestExpandScheduleUpdate_EmptyFields(t *testing.T) {
+	// similar to Basic, but assert that empty ("") fields are converted to nil
+	t.Parallel()
+	ts, _ := time.Parse("2006-01-02T15:04:05", "2021-01-21T15:30:00")
+	timestamp := alerts.NaiveDateTime{Time: ts}
+	timeZone := "America/Los_Angeles"
+	repeat := alerts.MutingRuleScheduleRepeatTypes.WEEKLY
+
+	testSchema := &schema.Set{F: schema.HashString}
+	testSchema.Add("MONDAY")
+	testSchema.Add("TUESDAY")
+
+	mockScheduleConfig := map[string]interface{}{
+		"start_time":         "2021-01-21T15:30:00",
+		"end_time":           "",
+		"end_repeat":         "",
+		"time_zone":          "America/Los_Angeles",
+		"repeat":             "WEEKLY",
+		"weekly_repeat_days": testSchema,
+	}
+
+	result, _ := expandMutingRuleUpdateSchedule(mockScheduleConfig)
+
+	expected := alerts.MutingRuleScheduleUpdateInput{
+		StartTime: &timestamp,
+		EndTime:   nil,
+		TimeZone:  &timeZone,
+		Repeat:    &repeat,
+		EndRepeat: nil,
+		WeeklyRepeatDays: &[]alerts.DayOfWeek{
+			"TUESDAY",
+			"MONDAY",
+		},
+	}
+
+	require.Equal(t, expected, result)
+}
+
+func TestExpandScheduleCreate_EmptyFields(t *testing.T) {
+	// similar to Basic, but assert that empty ("") and omitted fields are left out
+
+	t.Parallel()
+	ts, _ := time.Parse("2006-01-02T15:04:05", "2021-01-21T15:30:00")
+	timestamp := alerts.NaiveDateTime{Time: ts}
+	timeZone := "America/Los_Angeles"
+
+	mockScheduleConfig := map[string]interface{}{
+		"start_time": "2021-01-21T15:30:00",
+		"end_time":   "2021-01-21T15:30:00",
+		"end_repeat": "",
+		"time_zone":  "America/Los_Angeles",
+	}
+
+	result, _ := expandMutingRuleCreateSchedule(mockScheduleConfig)
+
+	expected := alerts.MutingRuleScheduleCreateInput{
+		StartTime: &timestamp,
+		EndTime:   &timestamp,
+		TimeZone:  timeZone,
+	}
+
+	require.Equal(t, expected, result)
+
+}
+
+func TestExpandScheduleCreate_EmptyWeeklyRepeat(t *testing.T) {
+	// similar to Basic, but assert that we can pass through an explicit empty slice of days
+
+	t.Parallel()
+	ts, _ := time.Parse("2006-01-02T15:04:05", "2021-01-21T15:30:00")
+	timestamp := alerts.NaiveDateTime{Time: ts}
+	timeZone := "America/Los_Angeles"
+	repeat := alerts.MutingRuleScheduleRepeatTypes.WEEKLY
+
+	testSchema := &schema.Set{F: schema.HashString}
+
+	mockScheduleConfig := map[string]interface{}{
+		"start_time":         "2021-01-21T15:30:00",
+		"time_zone":          "America/Los_Angeles",
+		"repeat":             "WEEKLY",
+		"weekly_repeat_days": testSchema,
+	}
+
+	result, _ := expandMutingRuleCreateSchedule(mockScheduleConfig)
+
+	expected := alerts.MutingRuleScheduleCreateInput{
+		StartTime:        &timestamp,
+		EndTime:          nil,
+		TimeZone:         timeZone,
+		Repeat:           &repeat,
+		EndRepeat:        nil,
+		WeeklyRepeatDays: &[]alerts.DayOfWeek{},
+	}
+
+	require.Equal(t, expected, result)
+
+}
+
+func TestExpandScheduleUpdate_EmptyWeeklyRepeat(t *testing.T) {
+	// similar to Basic, but assert that we can pass through an explicit empty slice of days
+
+	t.Parallel()
+	ts, _ := time.Parse("2006-01-02T15:04:05", "2021-01-21T15:30:00")
+	timestamp := alerts.NaiveDateTime{Time: ts}
+	timeZone := "America/Los_Angeles"
+	repeat := alerts.MutingRuleScheduleRepeatTypes.WEEKLY
+
+	testSchema := &schema.Set{F: schema.HashString}
+
+	mockScheduleConfig := map[string]interface{}{
+		"start_time":         "2021-01-21T15:30:00",
+		"time_zone":          "America/Los_Angeles",
+		"repeat":             "WEEKLY",
+		"weekly_repeat_days": testSchema,
+	}
+
+	result, _ := expandMutingRuleUpdateSchedule(mockScheduleConfig)
+
+	expected := alerts.MutingRuleScheduleUpdateInput{
+		StartTime:        &timestamp,
+		EndTime:          nil,
+		TimeZone:         &timeZone,
+		Repeat:           &repeat,
+		EndRepeat:        nil,
+		WeeklyRepeatDays: &[]alerts.DayOfWeek{},
+	}
+
+	require.Equal(t, expected, result)
+
+}

--- a/website/docs/r/alert_muting_rule.html.markdown
+++ b/website/docs/r/alert_muting_rule.html.markdown
@@ -34,6 +34,14 @@ resource "newrelic_alert_muting_rule" "foo" {
 		}
 		operator = "AND"
 	}
+    schedule {
+      start_time = "2021-01-28T15:30:00"
+      end_time = "2021-01-28T16:30:00"
+      time_zone = "America/Los_Angeles"
+      repeat = "WEEKLY"
+      weekly_repeat_days = ["MONDAY", "WEDNESDAY", "FRIDAY"]
+      repeat_count = 42
+    }
 }
 ```
 
@@ -45,6 +53,7 @@ The following arguments are supported:
   * `enabled` - (Required) Whether the MutingRule is enabled.
   * `name` - The name of the MutingRule.
   * `description` - The description of the MutingRule.
+  * `schedule` - (Optional) Specify a schedule for enabling the MutingRule. See [Schedule](#schedule) below for details
 
 
 ### Nested `condition` blocks
@@ -59,6 +68,14 @@ All nested `condition` blocks support the following arguments:
 * `operator` - (Required) The operator used to compare the attribute's value with the supplied value(s)
 * `values` - (Required) The value(s) to compare against the attribute's value.
 
+### Schedule
+* `start_time` (Optional) The datetime stamp that represents when the muting rule starts. This is in local ISO 8601 format without an offset. Example: '2020-07-08T14:30:00'
+* `end_time` (Optional) The datetime stamp that represents when the muting rule ends. This is in local ISO 8601 format without an offset. Example: '2020-07-15T14:30:00'
+* `timeZone` (Required) The time zone that applies to the muting rule schedule. Example: 'America/Los_Angeles'. See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+* `repeat` (Optional) The frequency the muting rule schedule repeats. If it does not repeat, omit this field. Options are DAILY, WEEKLY, MONTHLY
+* `end_repeat` (Optional) The datetime stamp when the muting rule schedule stops repeating. This is in local ISO 8601 format without an offset. Example: '2020-07-10T15:00:00'. Conflicts with `repeat_count`
+* `repeat_count` (Optional) The number of times the muting rule schedule repeats. This includes the original schedule. For example, a repeatCount of 2 will recur one time. Conflicts with `end_repeat`
+* `weekly_repeat_days` (Optional) The day(s) of the week that a muting rule should repeat when the repeat field is set to 'WEEKLY'. Example: ['MONDAY', 'WEDNESDAY']
 
 ## Import
 Alert conditions can be imported using a composite ID of `<account_id>:<muting_rule_id>`, e.g.
@@ -67,4 +84,3 @@ Alert conditions can be imported using a composite ID of `<account_id>:<muting_r
 $ terraform import newrelic_alert_muting_rule.foo 538291:6789035
 
 ```
-


### PR DESCRIPTION
### Goals :soccer:
Add support for configuration of `newrelic_alert_muting_rule schedule` fields with Terraform. 
Closes #1156

### Dependencies
Requires https://github.com/newrelic/newrelic-client-go/pull/652. 
I've bumped the client version here to .57.2, so this should also close out #1162 

### Implementation Details :construction:
Add new MutingRuleScheduleSchema struct & field validation:
    * Add validateNaiveDateTime struct for testing conversion from go's time.time to an "offsetless" NaiveDateTime in NerdGraph

Add expand and flatten funcs for the schedule. Please note the following idiosyncracies which were accounted for in the funcs:
* Nerdgraph only accepts a NaiveDateTime but returns a full 8601 dateTime with an offset. To prevent drift, this offset must be removed before any of these dateTime fields are stored in state

* It's possible to configure a WEEKLY repeat with an empty list of `weekly_repeat_days`. This will initiate a once-weekly repeat on the day of the week for which the rule is first scheduled.
* To accomplish this, we need to serialize an empty slice instead of `nil` when weekly_repeat_days len is 0 but repeat is set to WEEKLY.

Update website docs to reflect new schedule fields.

### Testing Details :mag:
Add integration tests for creating, updating, and importing muting rules with schedule. These tests cover adding and removing different schedule components as well as adding and removing the entire schedule field.
Add unit tests for flatten and expand funcs. 