### PR TITLE
[one_dashboard]: Inherit nrql_query account_id from parent dashboard

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -409,8 +409,6 @@ github.com/newrelic/go-agent/v3 v3.10.0 h1:qHcDwtC1DjOTI0r0nCtf8jT2LfEoNQ6gSo2tc
 github.com/newrelic/go-agent/v3 v3.10.0/go.mod h1:1A1dssWBwzB7UemzRU6ZVaGDsI+cEn5/bNxI0wiYlIc=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go v0.57.1 h1:NnMETNhk7XY2cPE/6dK9u3IZHiFCqXI06DIxUoDrvLA=
-github.com/newrelic/newrelic-client-go v0.57.1/go.mod h1:k6e8L+H4I1n7oimYAwAe1b07wyutjNTkFpw0yGIEbug=
 github.com/newrelic/newrelic-client-go v0.57.2 h1:33pPUEoS9nYmlW2V8m5ai9762TtnWMMkaoPZFKggKrQ=
 github.com/newrelic/newrelic-client-go v0.57.2/go.mod h1:k6e8L+H4I1n7oimYAwAe1b07wyutjNTkFpw0yGIEbug=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=

--- a/newrelic/resource_newrelic_alert_muting_rule.go
+++ b/newrelic/resource_newrelic_alert_muting_rule.go
@@ -2,13 +2,15 @@ package newrelic
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	"log"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/newrelic/newrelic-client-go/pkg/errors"
-	"log"
-	"time"
 )
 
 func validateMutingRuleConditionAttribute(val interface{}, key string) (warns []string, errs []error) {

--- a/newrelic/resource_newrelic_alert_muting_rule_test.go
+++ b/newrelic/resource_newrelic_alert_muting_rule_test.go
@@ -5,9 +5,10 @@ package newrelic
 import (
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/newrelic/resource_newrelic_one_dashboard.go
+++ b/newrelic/resource_newrelic_one_dashboard.go
@@ -176,7 +176,8 @@ func dashboardWidgetNRQLQuerySchemaElem() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"account_id": {
 				Type:        schema.TypeInt,
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
 				Description: "The account id used for the NRQL query.",
 			},
 			"query": {
@@ -312,7 +313,10 @@ func resourceNewRelicOneDashboardCreate(d *schema.ResourceData, meta interface{}
 	client := providerConfig.NewClient
 	accountID := selectAccountID(providerConfig, d)
 
-	dashboard, err := expandDashboardInput(d)
+	defaultInfo := map[string]interface{}{
+		"account_id": accountID,
+	}
+	dashboard, err := expandDashboardInput(d, defaultInfo)
 	if err != nil {
 		return err
 	}
@@ -362,8 +366,12 @@ func resourceNewRelicOneDashboardUpdate(d *schema.ResourceData, meta interface{}
 	}
 
 	client := providerConfig.NewClient
+	accountID := selectAccountID(providerConfig, d)
 
-	dashboard, err := expandDashboardInput(d)
+	defaultInfo := map[string]interface{}{
+		"account_id": accountID,
+	}
+	dashboard, err := expandDashboardInput(d, defaultInfo)
 	if err != nil {
 		return err
 	}

--- a/newrelic/structures_newrelic_alert_muting_rule_test.go
+++ b/newrelic/structures_newrelic_alert_muting_rule_test.go
@@ -3,9 +3,10 @@
 package newrelic
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
 	"github.com/newrelic/newrelic-client-go/pkg/alerts"
 	"github.com/stretchr/testify/require"

--- a/newrelic/structures_newrelic_one_dashboard.go
+++ b/newrelic/structures_newrelic_one_dashboard.go
@@ -13,14 +13,14 @@ import (
 
 // Assemble the *dashboards.DashboardInput struct.
 // Used by the newrelic_one_dashboard Create function.
-func expandDashboardInput(d *schema.ResourceData) (*dashboards.DashboardInput, error) {
+func expandDashboardInput(d *schema.ResourceData, meta interface{}) (*dashboards.DashboardInput, error) {
 	var err error
 
 	dash := dashboards.DashboardInput{
 		Name: d.Get("name").(string),
 	}
 
-	dash.Pages, err = expandDashboardPageInput(d.Get("page").([]interface{}))
+	dash.Pages, err = expandDashboardPageInput(d.Get("page").([]interface{}), meta)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func expandDashboardInput(d *schema.ResourceData) (*dashboards.DashboardInput, e
 
 // TODO: Reduce the cyclomatic complexity of this func
 // nolint:gocyclo
-func expandDashboardPageInput(pages []interface{}) ([]dashboards.DashboardPageInput, error) {
+func expandDashboardPageInput(pages []interface{}, meta interface{}) ([]dashboards.DashboardPageInput, error) {
 	if len(pages) < 1 {
 		return []dashboards.DashboardPageInput{}, nil
 	}
@@ -69,12 +69,12 @@ func expandDashboardPageInput(pages []interface{}) ([]dashboards.DashboardPageIn
 		if widgets, ok := p["widget_area"]; ok {
 			for _, v := range widgets.([]interface{}) {
 				// Get generic properties set
-				widget, err := expandDashboardWidgetInput(v.(map[string]interface{}))
+				widget, err := expandDashboardWidgetInput(v.(map[string]interface{}), meta)
 				if err != nil {
 					return nil, err
 				}
 
-				widget.Configuration.Area, err = expandDashboardAreaWidgetConfigurationInput(v.(map[string]interface{}))
+				widget.Configuration.Area, err = expandDashboardAreaWidgetConfigurationInput(v.(map[string]interface{}), meta)
 				if err != nil {
 					return nil, err
 				}
@@ -85,12 +85,12 @@ func expandDashboardPageInput(pages []interface{}) ([]dashboards.DashboardPageIn
 		if widgets, ok := p["widget_bar"]; ok {
 			for _, v := range widgets.([]interface{}) {
 				// Get generic properties set
-				widget, err := expandDashboardWidgetInput(v.(map[string]interface{}))
+				widget, err := expandDashboardWidgetInput(v.(map[string]interface{}), meta)
 				if err != nil {
 					return nil, err
 				}
 
-				widget.Configuration.Bar, err = expandDashboardBarWidgetConfigurationInput(v.(map[string]interface{}))
+				widget.Configuration.Bar, err = expandDashboardBarWidgetConfigurationInput(v.(map[string]interface{}), meta)
 				if err != nil {
 					return nil, err
 				}
@@ -101,12 +101,12 @@ func expandDashboardPageInput(pages []interface{}) ([]dashboards.DashboardPageIn
 		if widgets, ok := p["widget_billboard"]; ok {
 			for _, v := range widgets.([]interface{}) {
 				// Get generic properties set
-				widget, err := expandDashboardWidgetInput(v.(map[string]interface{}))
+				widget, err := expandDashboardWidgetInput(v.(map[string]interface{}), meta)
 				if err != nil {
 					return nil, err
 				}
 
-				widget.Configuration.Billboard, err = expandDashboardBillboardWidgetConfigurationInput(v.(map[string]interface{}))
+				widget.Configuration.Billboard, err = expandDashboardBillboardWidgetConfigurationInput(v.(map[string]interface{}), meta)
 				if err != nil {
 					return nil, err
 				}
@@ -117,12 +117,12 @@ func expandDashboardPageInput(pages []interface{}) ([]dashboards.DashboardPageIn
 		if widgets, ok := p["widget_line"]; ok {
 			for _, v := range widgets.([]interface{}) {
 				// Get generic properties set
-				widget, err := expandDashboardWidgetInput(v.(map[string]interface{}))
+				widget, err := expandDashboardWidgetInput(v.(map[string]interface{}), meta)
 				if err != nil {
 					return nil, err
 				}
 
-				widget.Configuration.Line, err = expandDashboardLineWidgetConfigurationInput(v.(map[string]interface{}))
+				widget.Configuration.Line, err = expandDashboardLineWidgetConfigurationInput(v.(map[string]interface{}), meta)
 				if err != nil {
 					return nil, err
 				}
@@ -133,12 +133,12 @@ func expandDashboardPageInput(pages []interface{}) ([]dashboards.DashboardPageIn
 		if widgets, ok := p["widget_markdown"]; ok {
 			for _, v := range widgets.([]interface{}) {
 				// Get generic properties set
-				widget, err := expandDashboardWidgetInput(v.(map[string]interface{}))
+				widget, err := expandDashboardWidgetInput(v.(map[string]interface{}), meta)
 				if err != nil {
 					return nil, err
 				}
 
-				widget.Configuration.Markdown, err = expandDashboardMarkdownWidgetConfigurationInput(v.(map[string]interface{}))
+				widget.Configuration.Markdown, err = expandDashboardMarkdownWidgetConfigurationInput(v.(map[string]interface{}), meta)
 				if err != nil {
 					return nil, err
 				}
@@ -149,12 +149,12 @@ func expandDashboardPageInput(pages []interface{}) ([]dashboards.DashboardPageIn
 		if widgets, ok := p["widget_pie"]; ok {
 			for _, v := range widgets.([]interface{}) {
 				// Get generic properties set
-				widget, err := expandDashboardWidgetInput(v.(map[string]interface{}))
+				widget, err := expandDashboardWidgetInput(v.(map[string]interface{}), meta)
 				if err != nil {
 					return nil, err
 				}
 
-				widget.Configuration.Pie, err = expandDashboardPieWidgetConfigurationInput(v.(map[string]interface{}))
+				widget.Configuration.Pie, err = expandDashboardPieWidgetConfigurationInput(v.(map[string]interface{}), meta)
 				if err != nil {
 					return nil, err
 				}
@@ -165,12 +165,12 @@ func expandDashboardPageInput(pages []interface{}) ([]dashboards.DashboardPageIn
 		if widgets, ok := p["widget_table"]; ok {
 			for _, v := range widgets.([]interface{}) {
 				// Get generic properties set
-				widget, err := expandDashboardWidgetInput(v.(map[string]interface{}))
+				widget, err := expandDashboardWidgetInput(v.(map[string]interface{}), meta)
 				if err != nil {
 					return nil, err
 				}
 
-				widget.Configuration.Table, err = expandDashboardTableWidgetConfigurationInput(v.(map[string]interface{}))
+				widget.Configuration.Table, err = expandDashboardTableWidgetConfigurationInput(v.(map[string]interface{}), meta)
 				if err != nil {
 					return nil, err
 				}
@@ -185,13 +185,13 @@ func expandDashboardPageInput(pages []interface{}) ([]dashboards.DashboardPageIn
 	return expanded, nil
 }
 
-func expandDashboardAreaWidgetConfigurationInput(i map[string]interface{}) (*dashboards.DashboardAreaWidgetConfigurationInput, error) {
+func expandDashboardAreaWidgetConfigurationInput(i map[string]interface{}, meta interface{}) (*dashboards.DashboardAreaWidgetConfigurationInput, error) {
 	var cfg dashboards.DashboardAreaWidgetConfigurationInput
 	var err error
 
 	// just has queries
 	if q, ok := i["nrql_query"]; ok {
-		cfg.NRQLQueries, err = expandDashboardWidgetNRQLQueryInput(q.([]interface{}))
+		cfg.NRQLQueries, err = expandDashboardWidgetNRQLQueryInput(q.([]interface{}), meta)
 		if err != nil {
 			return nil, err
 		}
@@ -199,13 +199,13 @@ func expandDashboardAreaWidgetConfigurationInput(i map[string]interface{}) (*das
 	}
 	return nil, nil
 }
-func expandDashboardBarWidgetConfigurationInput(i map[string]interface{}) (*dashboards.DashboardBarWidgetConfigurationInput, error) {
+func expandDashboardBarWidgetConfigurationInput(i map[string]interface{}, meta interface{}) (*dashboards.DashboardBarWidgetConfigurationInput, error) {
 	var cfg dashboards.DashboardBarWidgetConfigurationInput
 	var err error
 
 	// just has queries
 	if q, ok := i["nrql_query"]; ok {
-		cfg.NRQLQueries, err = expandDashboardWidgetNRQLQueryInput(q.([]interface{}))
+		cfg.NRQLQueries, err = expandDashboardWidgetNRQLQueryInput(q.([]interface{}), meta)
 		if err != nil {
 			return nil, err
 		}
@@ -214,12 +214,12 @@ func expandDashboardBarWidgetConfigurationInput(i map[string]interface{}) (*dash
 	return nil, nil
 }
 
-func expandDashboardBillboardWidgetConfigurationInput(i map[string]interface{}) (*dashboards.DashboardBillboardWidgetConfigurationInput, error) {
+func expandDashboardBillboardWidgetConfigurationInput(i map[string]interface{}, meta interface{}) (*dashboards.DashboardBillboardWidgetConfigurationInput, error) {
 	var cfg dashboards.DashboardBillboardWidgetConfigurationInput
 	var err error
 
 	if q, ok := i["nrql_query"]; ok {
-		cfg.NRQLQueries, err = expandDashboardWidgetNRQLQueryInput(q.([]interface{}))
+		cfg.NRQLQueries, err = expandDashboardWidgetNRQLQueryInput(q.([]interface{}), meta)
 		if err != nil {
 			return nil, err
 		}
@@ -244,13 +244,13 @@ func expandDashboardBillboardWidgetConfigurationInput(i map[string]interface{}) 
 	return &cfg, nil
 }
 
-func expandDashboardLineWidgetConfigurationInput(i map[string]interface{}) (*dashboards.DashboardLineWidgetConfigurationInput, error) {
+func expandDashboardLineWidgetConfigurationInput(i map[string]interface{}, meta interface{}) (*dashboards.DashboardLineWidgetConfigurationInput, error) {
 	var cfg dashboards.DashboardLineWidgetConfigurationInput
 	var err error
 
 	// just has queries
 	if q, ok := i["nrql_query"]; ok {
-		cfg.NRQLQueries, err = expandDashboardWidgetNRQLQueryInput(q.([]interface{}))
+		cfg.NRQLQueries, err = expandDashboardWidgetNRQLQueryInput(q.([]interface{}), meta)
 		if err != nil {
 			return nil, err
 		}
@@ -258,7 +258,7 @@ func expandDashboardLineWidgetConfigurationInput(i map[string]interface{}) (*das
 	}
 	return nil, nil
 }
-func expandDashboardMarkdownWidgetConfigurationInput(i map[string]interface{}) (*dashboards.DashboardMarkdownWidgetConfigurationInput, error) {
+func expandDashboardMarkdownWidgetConfigurationInput(i map[string]interface{}, meta interface{}) (*dashboards.DashboardMarkdownWidgetConfigurationInput, error) {
 	var cfg dashboards.DashboardMarkdownWidgetConfigurationInput
 
 	if t, ok := i["text"]; ok {
@@ -270,13 +270,13 @@ func expandDashboardMarkdownWidgetConfigurationInput(i map[string]interface{}) (
 	}
 	return nil, nil
 }
-func expandDashboardPieWidgetConfigurationInput(i map[string]interface{}) (*dashboards.DashboardPieWidgetConfigurationInput, error) {
+func expandDashboardPieWidgetConfigurationInput(i map[string]interface{}, meta interface{}) (*dashboards.DashboardPieWidgetConfigurationInput, error) {
 	var cfg dashboards.DashboardPieWidgetConfigurationInput
 	var err error
 
 	// just has queries
 	if q, ok := i["nrql_query"]; ok {
-		cfg.NRQLQueries, err = expandDashboardWidgetNRQLQueryInput(q.([]interface{}))
+		cfg.NRQLQueries, err = expandDashboardWidgetNRQLQueryInput(q.([]interface{}), meta)
 		if err != nil {
 			return nil, err
 		}
@@ -284,13 +284,13 @@ func expandDashboardPieWidgetConfigurationInput(i map[string]interface{}) (*dash
 	}
 	return nil, nil
 }
-func expandDashboardTableWidgetConfigurationInput(i map[string]interface{}) (*dashboards.DashboardTableWidgetConfigurationInput, error) {
+func expandDashboardTableWidgetConfigurationInput(i map[string]interface{}, meta interface{}) (*dashboards.DashboardTableWidgetConfigurationInput, error) {
 	var cfg dashboards.DashboardTableWidgetConfigurationInput
 	var err error
 
 	// just has queries
 	if q, ok := i["nrql_query"]; ok {
-		cfg.NRQLQueries, err = expandDashboardWidgetNRQLQueryInput(q.([]interface{}))
+		cfg.NRQLQueries, err = expandDashboardWidgetNRQLQueryInput(q.([]interface{}), meta)
 		if err != nil {
 			return nil, err
 		}
@@ -301,7 +301,7 @@ func expandDashboardTableWidgetConfigurationInput(i map[string]interface{}) (*da
 
 // expandDashboardWidgetInput expands the common items in WidgetInput, but not the configuration
 // which is specific to the widgets
-func expandDashboardWidgetInput(w map[string]interface{}) (dashboards.DashboardWidgetInput, error) {
+func expandDashboardWidgetInput(w map[string]interface{}, meta interface{}) (dashboards.DashboardWidgetInput, error) {
 	var widget dashboards.DashboardWidgetInput
 
 	if i, ok := w["id"]; ok {
@@ -340,7 +340,7 @@ func expandLinkedEntityGUIDs(guids []interface{}) []entities.EntityGUID {
 	return out
 }
 
-func expandDashboardWidgetNRQLQueryInput(queries []interface{}) ([]dashboards.DashboardWidgetNRQLQueryInput, error) {
+func expandDashboardWidgetNRQLQueryInput(queries []interface{}, meta interface{}) ([]dashboards.DashboardWidgetNRQLQueryInput, error) {
 	if len(queries) < 1 {
 		return []dashboards.DashboardWidgetNRQLQueryInput{}, nil
 	}
@@ -355,6 +355,13 @@ func expandDashboardWidgetNRQLQueryInput(queries []interface{}) ([]dashboards.Da
 			query.AccountID = acct.(int)
 		}
 
+		if query.AccountID < 1 {
+			defs := meta.(map[string]interface{})
+			if acct, ok := defs["account_id"]; ok {
+				query.AccountID = acct.(int)
+			}
+		}
+
 		if nrql, ok := q["query"]; ok {
 			query.Query = nrdb.NRQL(nrql.(string))
 		}
@@ -367,7 +374,7 @@ func expandDashboardWidgetNRQLQueryInput(queries []interface{}) ([]dashboards.Da
 
 // Unpack the *dashboards.Dashboard variable and set resource data.
 //
-// Used by the newrelic_dashboard Read function (resourceNewRelicDashboardRead)
+// Used by the newrelic_one_dashboard Read function (resourceNewRelicOneDashboardRead)
 func flattenDashboardEntity(dashboard *entities.DashboardEntity, d *schema.ResourceData) error {
 	d.Set("account_id", dashboard.AccountID)
 	d.Set("guid", dashboard.GUID)
@@ -391,7 +398,7 @@ func flattenDashboardEntity(dashboard *entities.DashboardEntity, d *schema.Resou
 
 // Unpack the *dashboards.Dashboard variable and set resource data.
 //
-// Used by the newrelic_dashboard Read function (resourceNewRelicDashboardRead)
+// Used by the newrelic_one_dashboard Read function (resourceNewRelicOneDashboardRead)
 func flattenDashboardUpdateResult(result *dashboards.DashboardUpdateResult, d *schema.ResourceData) error {
 	if result == nil {
 		return fmt.Errorf("can not flatten nil DashboardUpdateResult")

--- a/website/docs/r/one_dashboard.html.markdown
+++ b/website/docs/r/one_dashboard.html.markdown
@@ -23,7 +23,6 @@ resource "newrelic_one_dashboard" "exampledash" {
       column = 1
 
       nrql_query {
-        account_id = <Your Account ID>
         query       = "FROM Transaction SELECT rate(count(*), 1 minute)"
       }
     }
@@ -34,7 +33,7 @@ resource "newrelic_one_dashboard" "exampledash" {
       column = 5
 
       nrql_query {
-        account_id = <Your Account ID>
+        account_id = <Another Account ID>
         query       = "FROM Transaction SELECT average(duration) FACET appName"
       }
 
@@ -123,7 +122,7 @@ Nested `nrql_query` blocks allow you to make one or more NRQL queries within a w
 
 The following arguments are supported:
 
-  * `account_id` - (Required) The New Relic account ID to issue the query against.
+  * `account_id` - (Optional) The New Relic account ID to issue the query against. Defaults to the Account ID where the dashboard was created.
   * `query` - (Required) Valid NRQL query string. See [Writing NRQL Queries](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/using-nrql/introduction-nrql) for help.
 
 ## Additional Examples
@@ -148,7 +147,6 @@ resource "newrelic_one_dashboard" "multi_page_dashboard" {
       column = 1
 
       nrql_query {
-        account_id = <Your Account ID>
         query      = "FROM Transaction SELECT count(*) FACET name"
       }
 


### PR DESCRIPTION
Currently you must specify the `account_id` for every `nrql_query`.  This change follows the rest of the provider in allowing that value to be inherited from the `account_id` of the dashboard (which is inherited from the API key used).

Resolves #1174