### PR TITLE
fix: multilocation alert violation time

### DIFF
--- a/newrelic/resource_newrelic_synthetics_multilocation_alert_condition.go
+++ b/newrelic/resource_newrelic_synthetics_multilocation_alert_condition.go
@@ -80,8 +80,8 @@ func resourceNewRelicSyntheticsMultiLocationAlertCondition() *schema.Resource {
 			"violation_time_limit_seconds": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ValidateFunc: validation.IntInSlice([]int{0, 3600, 7200, 14400, 28800, 43200, 86400}),
-				Description:  "The maximum number of seconds a violation can remain open before being closed by the system.  Must be one of: 0, 3600, 7200, 14400, 28800, 43200, 86400",
+				ValidateFunc: validation.IntBetween(300, 2592000),
+				Description:  "The maximum number of seconds a violation can remain open before being closed by the system.  Must be between 5 minutes and 30 days (300, 2592000)",
 			},
 		},
 	}


### PR DESCRIPTION
Updated the multilocation alert violation time limit validation to match web UI
Previously it was using a set list rather than the 5 minute to 30 day time limit that the web UI allows.