### PR TITLE
fix(newrelic_infra_alert_condition): Prevent index out of range

### DIFF
--- a/newrelic/structures_newrelic_infra_alert_condition.go
+++ b/newrelic/structures_newrelic_infra_alert_condition.go
@@ -56,6 +56,10 @@ func expandInfraAlertCondition(d *schema.ResourceData) (*alerts.InfrastructureCo
 }
 
 func expandInfraAlertThreshold(v interface{}) *alerts.InfrastructureConditionThreshold {
+	if len(v.([]interface{})) < 1 {
+		return nil
+	}
+
 	rah := v.([]interface{})[0].(map[string]interface{})
 
 	alertInfraThreshold := &alerts.InfrastructureConditionThreshold{

--- a/newrelic/structures_newrelic_infra_alert_condition_test.go
+++ b/newrelic/structures_newrelic_infra_alert_condition_test.go
@@ -10,6 +10,13 @@ import (
 )
 
 func TestExpandInfraAlertThreshold(t *testing.T) {
+	t.Parallel()
+
+	// Expand nothing
+	emptyExpand := expandInfraAlertThreshold([]interface{}{})
+	require.Nil(t, emptyExpand)
+
+	// Expand something
 	flattened := []interface{}{
 		map[string]interface{}{
 			"duration":      5,
@@ -32,6 +39,8 @@ func TestExpandInfraAlertThreshold(t *testing.T) {
 }
 
 func TestFlattenInfraAlertThreshold(t *testing.T) {
+	t.Parallel()
+
 	value := 1.5
 	expanded := alerts.InfrastructureConditionThreshold{
 		Duration: 5,


### PR DESCRIPTION
`expandInfraAlertThreshold` assumes we have data, so validate the length of data passed is greater than zero, otherwise return `nil`

Reported in #606 