### PR TITLE
fixing grammar error / missing word

### DIFF
--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -113,7 +113,7 @@ The `nrql` block supports the following arguments:
 
 NRQL alert conditions support up to two terms. At least one `term` must have `priority` set to `critical` and the second optional `term` must have `priority` set to `warning`.
 
-The `term` block the following arguments:
+The `term` block supports the following arguments:
 
 - `operator` - (Optional) Valid values are `above`, `below`, or `equals` (case insensitive). Defaults to `equals`. Note that when using a `type` of `outlier`, the only valid option here is `above`.
 - `priority` - (Optional) `critical` or `warning`. Defaults to `critical`.


### PR DESCRIPTION
Change: 

> The `term` block the following arguments:

to

> The `term` block supports the following arguments: