### PR TITLE
feat(docs): added documentation links to the dashboard migration guide

### DIFF
--- a/website/docs/guides/migration_guide_newrelic_dashboard.html.markdown
+++ b/website/docs/guides/migration_guide_newrelic_dashboard.html.markdown
@@ -17,6 +17,12 @@ For more information check out [this Github issue](https://github.com/newrelic/t
 * Latest version of the New Relic CLI: https://github.com/newrelic/newrelic-cli
 * Python 3
 
+### Documentation
+
+* [Transition to New Relic One from Insights](https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/core-concepts/transition-new-relic-one-insights/)
+* [Dashboard API migration: from Insights API to NerdGraph](https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/)
+* [Visualizations mapping table from Insights Dashboard to New Relic One dashboard](https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/#visualization-mapping-table)
+
 ### Process
 
 To help you migrate your `newrelic_dashboard` to the new `newrelic_one_dashboard` resource we provide two options:


### PR DESCRIPTION
Added a couple of links to our docs that provide more information on how to migrate certain visualisations. 