### PR TITLE
fix(build): fix compile-only and compile-all build targets to aid with local development

### DIFF
--- a/build/compile.mk
+++ b/build/compile.mk
@@ -6,16 +6,10 @@ GO              ?= go
 BUILD_DIR       ?= ./bin/
 PROJECT_MODULE  ?= $(shell $(GO) list -m)
 # $b replaced by the binary name in the compile loop, -s/w remove debug symbols
-LDFLAGS         ?= "-s -w -X main.version=$(PROJECT_VER) -X main.appName=$$b -X $(PROJECT_MODULE)/internal/client.version=$(PROJECT_VER)"
+LDFLAGS         ?= "-s -w -X main.version=$(PROJECT_VER) -X main.appName=newrelic -X $(PROJECT_MODULE)/internal/client.version=$(PROJECT_VER)"
 SRCDIR          ?= .
 COMPILE_OS      ?= darwin linux windows
-
-# Determine commands by looking into cmd/*
-COMMANDS   ?= $(wildcard ${SRCDIR}/cmd/*)
-
-# Determine binary names by stripping out the dir names
-BINS       := $(foreach cmd,${COMMANDS},$(notdir ${cmd}))
-
+BINARY ?= terraform-provider-newrelic
 
 compile-clean:
 	@echo "=== $(PROJECT_NAME) === [ compile-clean    ]: removing binaries..."
@@ -26,22 +20,18 @@ compile: deps compile-only
 compile-all: deps-only
 	@echo "=== $(PROJECT_NAME) === [ compile          ]: building commands:"
 	@mkdir -p $(BUILD_DIR)/$(GOOS)
-	@for b in $(BINS); do \
-		for os in $(COMPILE_OS); do \
-			echo "=== $(PROJECT_NAME) === [ compile          ]:     $(BUILD_DIR)$$os/$$b"; \
-			BUILD_FILES=`find $(SRCDIR)/cmd/$$b -type f -name "*.go"` ; \
-			GOOS=$$os $(GO) build -ldflags=$(LDFLAGS) -o $(BUILD_DIR)/$$os/$$b $$BUILD_FILES ; \
-		done \
+	for os in $(COMPILE_OS); do \
+		echo "=== $(PROJECT_NAME) === [ compile          ]:     $(BUILD_DIR)$$os/$(BINARY)"; \
+		BUILD_FILES=`find $(SRCDIR)/newrelic -type f -name "*.go"` ; \
+		GOOS=$$os $(GO) build -ldflags=$(LDFLAGS) -o $(BUILD_DIR)/$$os/$(BINARY) $$BUILD_FILES ; \
 	done
 
 compile-only: deps-only
 	@echo "=== $(PROJECT_NAME) === [ compile          ]: building commands:"
 	@mkdir -p $(BUILD_DIR)/$(GOOS)
-	@for b in $(BINS); do \
-		echo "=== $(PROJECT_NAME) === [ compile          ]:     $(BUILD_DIR)$(GOOS)/$$b"; \
-		BUILD_FILES=`find $(SRCDIR)/cmd/$$b -type f -name "*.go"` ; \
-		GOOS=$(GOOS) $(GO) build -ldflags=$(LDFLAGS) -o $(BUILD_DIR)/$(GOOS)/$$b $$BUILD_FILES ; \
-	done
+	echo "=== $(PROJECT_NAME) === [ compile          ]:     $(BUILD_DIR)$(GOOS)/$(BINARY)"; \
+	BUILD_FILES=`find $(SRCDIR)/newrelic -type f -name "*.go"` ; \
+	GOOS=$(GOOS) $(GO) build -ldflags=$(LDFLAGS) -o $(BUILD_DIR)/$(GOOS)/$(BINARY) $$BUILD_FILES ; \
 
 # Override GOOS for these specific targets
 compile-darwin: GOOS=darwin
@@ -52,6 +42,5 @@ compile-linux: deps-only compile-only
 
 compile-windows: GOOS=windows
 compile-windows: deps-only compile-only
-
 
 .PHONY: clean-compile compile compile-darwin compile-linux compile-only compile-windows


### PR DESCRIPTION
The `compile-only` and `compile-all` targets were not working for this repo.  This PR fixes them so that they can be used to build a local binary that can be used during development with a `.terraformrc` file that looks like this:

```
provider_installation {
  dev_overrides {
    "newrelic/newrelic" = "/path/to/src/terraform-provider-newrelic/bin/darwin"
  }

  direct {}
}
```