### PR TITLE
feat: 0 violation TTL for Infra Conditions returns warning

### DIFF
--- a/newrelic/resource_newrelic_infra_alert_condition.go
+++ b/newrelic/resource_newrelic_infra_alert_condition.go
@@ -164,8 +164,8 @@ func resourceNewRelicInfraAlertCondition() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      24,
-				ValidateFunc: intInSlice([]int{0, 1, 2, 4, 8, 12, 24, 48, 72}),
-				Description:  "Determines how much time, in minutes, will pass before a violation is automatically closed. Setting the time limit to 0 prevents a violation from being force-closed. Valid values are 0, 1, 2, 4, 8, 12, 24, 48, or 72",
+				ValidateFunc: validateViolationCloseTimer(),
+				Description:  "Determines how much time, in hours, will pass before a violation is automatically closed. Valid values are 1, 2, 4, 8, 12, 24, 48, or 72",
 			},
 			"description": {
 				Type:        schema.TypeString,

--- a/newrelic/validation.go
+++ b/newrelic/validation.go
@@ -23,6 +23,26 @@ func float64Gte(gte float64) schema.SchemaValidateFunc {
 	}
 }
 
+func validateViolationCloseTimer() schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		val, ok := i.(int)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %s to be int", k))
+			return
+		}
+		switch val {
+		case 1, 2, 4, 8, 12, 24, 48, 72:
+		case 0:
+			warnings = append(warnings, "0 is no longer a valid value. Using the default value of 24")
+		default:
+			errors = append(errors, fmt.Errorf("expected %s to be one of %s, got %v", k, "1, 2, 4, 8, 12, 24, 48, 72", val))
+		}
+		return warnings, errors
+	}
+}
+
+
+
 func intInSlice(valid []int) schema.SchemaValidateFunc {
 	return func(i interface{}, k string) (s []string, es []error) {
 		v, ok := i.(int)

--- a/website/docs/r/infra_alert_condition.html.markdown
+++ b/website/docs/r/infra_alert_condition.html.markdown
@@ -103,7 +103,7 @@ The following arguments are supported:
   * `process_where` - (Optional) Any filters applied to processes; for example: `commandName = 'java'`.  Required by the `infra_process_running` condition type.
   * `integration_provider` - (Optional) For alerts on integrations, use this instead of `event`.  Supported by the `infra_metric` condition type.
   * `runbook_url` - (Optional) Runbook URL to display in notifications.
-  * `violation_close_timer` - (Optional) Determines how much time will pass before a violation is automatically closed. Setting the time limit to 0 prevents a violation from being force-closed.
+  * `violation_close_timer` - (Optional) Determines how much time will pass (in hours) before a violation is automatically closed. Valid values are `1 2 4 8 12 24 48 72`. Defaults to 24.
 
 ## Attributes Reference
 

--- a/website/docs/r/infra_alert_condition.html.markdown
+++ b/website/docs/r/infra_alert_condition.html.markdown
@@ -103,7 +103,7 @@ The following arguments are supported:
   * `process_where` - (Optional) Any filters applied to processes; for example: `commandName = 'java'`.  Required by the `infra_process_running` condition type.
   * `integration_provider` - (Optional) For alerts on integrations, use this instead of `event`.  Supported by the `infra_metric` condition type.
   * `runbook_url` - (Optional) Runbook URL to display in notifications.
-  * `violation_close_timer` - (Optional) Determines how much time will pass (in hours) before a violation is automatically closed. Valid values are `1 2 4 8 12 24 48 72`. Defaults to 24.
+  * `violation_close_timer` - (Optional) Determines how much time will pass before a violation is automatically closed. Setting the time limit to 0 prevents a violation from being force-closed.
 
 ## Attributes Reference
 


### PR DESCRIPTION
1. Updated `resource_newrelic_infra_alert_condition` to return a warning if a `0` is supplied. `0` is no longer valid.
2. If a `0` is applied, we will replace the value with the default, which is 24.
3. Updated `violation_close_timer` text in the docs.  A TTL will be required moving forward.
4. Added valid values and unit of measure (hours)
5. Added default value