### PR TITLE
feat: 0 violation TTL for Infra Conditions returns warning

### DIFF
--- a/newrelic/resource_newrelic_infra_alert_condition.go
+++ b/newrelic/resource_newrelic_infra_alert_condition.go
@@ -166,8 +166,8 @@ func resourceNewRelicInfraAlertCondition() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      24,
-				ValidateFunc: intInSlice([]int{0, 1, 2, 4, 8, 12, 24, 48, 72}),
-				Description:  "Determines how much time, in minutes, will pass before a violation is automatically closed. Setting the time limit to 0 prevents a violation from being force-closed. Valid values are 0, 1, 2, 4, 8, 12, 24, 48, or 72",
+				ValidateFunc: validateViolationCloseTimer(),
+				Description:  "Determines how much time, in hours, will pass before a violation is automatically closed. Valid values are 1, 2, 4, 8, 12, 24, 48, or 72",
 			},
 			"description": {
 				Type:        schema.TypeString,

--- a/newrelic/validation.go
+++ b/newrelic/validation.go
@@ -6,6 +6,24 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+func validateViolationCloseTimer() schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		val, ok := i.(int)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %s to be int", k))
+			return
+		}
+		switch val {
+		case 1, 2, 4, 8, 12, 24, 48, 72:
+		case 0:
+			warnings = append(warnings, "0 is no longer a valid value. Using the default value of 24")
+		default:
+			errors = append(errors, fmt.Errorf("expected %s to be one of %s, got %v", k, "1, 2, 4, 8, 12, 24, 48, 72", val))
+		}
+		return warnings, errors
+	}
+}
+
 func float64Gte(gte float64) schema.SchemaValidateFunc {
 	return func(i interface{}, k string) (s []string, es []error) {
 		v, ok := i.(float64)

--- a/newrelic/validation_test.go
+++ b/newrelic/validation_test.go
@@ -10,9 +10,37 @@ import (
 )
 
 type testCase struct {
-	val         interface{}
-	f           schema.SchemaValidateFunc
-	expectedErr *regexp.Regexp
+	val          interface{}
+	f            schema.SchemaValidateFunc
+	expectedErr  *regexp.Regexp
+	val          interface{}
+	f            schema.SchemaValidateFunc
+	expectedErr  *regexp.Regexp
+	expectedWarn *regexp.Regexp
+}
+
+func TestValidationValidateViolationCloseTimer(t *testing.T) {
+	runTestCases(t, []testCase{
+		{
+			val:          0,
+			f:            validateViolationCloseTimer(),
+			expectedWarn: regexp.MustCompile(`0 is no longer a valid value. Using the default value of 24`),
+		},
+		{
+			val: 2,
+			f:   validateViolationCloseTimer(),
+		},
+		{
+			val:         13,
+			f:           validateViolationCloseTimer(),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be one of 1, 2, 4, 8, 12, 24, 48, 72, got 13`),
+		},
+		{
+			val:         "foo",
+			f:           intInSlice([]int{1, 2, 3}),
+			expectedErr: regexp.MustCompile(`expected type of [\w]+ to be int`),
+		},
+	})
 }
 
 func TestValidationIntInInSlice(t *testing.T) {
@@ -88,12 +116,29 @@ func runTestCases(t *testing.T, cases []testCase) {
 				return true
 			}
 		}
+		return false
+	}
 
+	matchWarn := func(warnings []string, r *regexp.Regexp) bool {
+		// warning must match one provided
+		for _, warn := range warnings {
+			if r.MatchString(warn) {
+				return true
+			}
+		}
 		return false
 	}
 
 	for i, tc := range cases {
 		_, errs := tc.f(tc.val, "test_property")
+		warnings, errs := tc.f(tc.val, "test_property")
+		if len(warnings) == 0 && tc.expectedWarn == nil {
+			continue
+		}
+
+		if !matchWarn(warnings, tc.expectedWarn) {
+			t.Fatalf("expected test case %d to produce warning matching \"%s\", got %v", i, tc.expectedWarn, warnings)
+		}
 
 		if len(errs) == 0 && tc.expectedErr == nil {
 			continue

--- a/website/docs/r/infra_alert_condition.html.markdown
+++ b/website/docs/r/infra_alert_condition.html.markdown
@@ -110,7 +110,7 @@ The following arguments are supported:
   * `integration_provider` - (Optional) For alerts on integrations, use this instead of `event`.  Supported by the `infra_metric` condition type.
   * `description` - (Optional) The description of the Infrastructure alert condition.
   * `runbook_url` - (Optional) Runbook URL to display in notifications.
-  * `violation_close_timer` - (Optional) Determines how much time will pass before a violation is automatically closed. Setting the time limit to 0 prevents a violation from being force-closed.
+  * `violation_close_timer` - (Optional) Determines how much time will pass (in hours) before a violation is automatically closed. Valid values are `1 2 4 8 12 24 48 72`. Defaults to 24.
 
 ## Attributes Reference
 


### PR DESCRIPTION
1. Going forward, a violation close timer (TTL) must be set to a value > 0. The default will be 24 hours. 
2. Updated the documentation as well