### PR TITLE
Fix: Issue 1409

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - fix tests
 - 0 violation TTL for Infra Conditions returns warning
 - **MonitorScript:** Add monitor script locations
-- **dashbaord_raw:** add newrelic_one_dashboard_raw
+- **dashboard_raw:** add newrelic_one_dashboard_raw
 - **docs:** added documentation links to the dashboard migration guide
 
 <a name="v2.23.0"></a>

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -60,8 +60,8 @@ func termSchema() *schema.Resource {
 			"threshold_occurrences": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Description:  "The criteria for how many data points must be in violation for the specified threshold duration. Valid values are: 'ALL' or 'AT_LEAST_ONCE' (case insensitive).",
-				ValidateFunc: validation.StringInSlice([]string{"ALL", "AT_LEAST_ONCE"}, true),
+				Description:  "The criteria for how many data points must be in violation for the specified threshold duration. Valid values are: 'ALL' or ANY' (case insensitive).",
+				ValidateFunc: validation.StringInSlice([]string{"ALL", "ANY"}, true),
 				StateFunc: func(v interface{}) string {
 					// Always store lowercase to prevent state drift
 					return strings.ToLower(v.(string))

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -513,14 +513,14 @@ resource "newrelic_nrql_alert_condition" "foo" {
     operator              = "above"
     threshold             = 0.75
     threshold_duration    = %[3]s
-    threshold_occurrences = "ANY"
+    threshold_occurrences = "all"
 	}
 
 	warning {
 		operator              = "equals"
 		threshold             = 0.5
 		threshold_duration    = 120
-		threshold_occurrences = "ALL"
+		threshold_occurrences = "ANY"
 	}
 
 	value_function  = "single_value"
@@ -578,7 +578,7 @@ resource "newrelic_nrql_alert_condition" "foo" {
 		operator      = "above"
 		priority      = "warning"
 		threshold     = 1.12
-		time_function = ""
+		time_function = "any"
 	}
 
 	violation_time_limit_seconds = 86400
@@ -628,14 +628,14 @@ resource "newrelic_nrql_alert_condition" "foo" {
     operator              = "above"
     threshold             = 1.25666
 		threshold_duration    = %[4]d
-		threshold_occurrences = "ANY"
+		threshold_occurrences = "ALL"
 	}
 
 	warning {
     operator              = "above"
     threshold             = 1.1666
 		threshold_duration    = %[4]d
-		threshold_occurrences = "All"
+		threshold_occurrences = "ANY"
 	}
 
 	# Will be baseline_direction or value_function depending on condition type
@@ -677,7 +677,7 @@ resource "newrelic_nrql_alert_condition" "foo" {
     operator              = "above"
     threshold             = 1.25
 		threshold_duration    = %[4]d
-		threshold_occurrences = "ANY"
+		threshold_occurrences = "ALL"
 	}
 
 	# Will be one of baseline_direction, value_function, expected_groups, or open_violation_on_group_overlap depending on condition type

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -513,14 +513,14 @@ resource "newrelic_nrql_alert_condition" "foo" {
     operator              = "above"
     threshold             = 0.75
     threshold_duration    = %[3]s
-    threshold_occurrences = "all"
+    threshold_occurrences = "ANY"
 	}
 
 	warning {
 		operator              = "equals"
 		threshold             = 0.5
 		threshold_duration    = 120
-		threshold_occurrences = "AT_LEAST_ONCE"
+		threshold_occurrences = "ALL"
 	}
 
 	value_function  = "single_value"
@@ -578,7 +578,7 @@ resource "newrelic_nrql_alert_condition" "foo" {
 		operator      = "above"
 		priority      = "warning"
 		threshold     = 1.12
-		time_function = "any"
+		time_function = ""
 	}
 
 	violation_time_limit_seconds = 86400
@@ -628,14 +628,14 @@ resource "newrelic_nrql_alert_condition" "foo" {
     operator              = "above"
     threshold             = 1.25666
 		threshold_duration    = %[4]d
-		threshold_occurrences = "ALL"
+		threshold_occurrences = "ANY"
 	}
 
 	warning {
     operator              = "above"
     threshold             = 1.1666
 		threshold_duration    = %[4]d
-		threshold_occurrences = "AT_LEAST_ONCE"
+		threshold_occurrences = "All"
 	}
 
 	# Will be baseline_direction or value_function depending on condition type
@@ -677,7 +677,7 @@ resource "newrelic_nrql_alert_condition" "foo" {
     operator              = "above"
     threshold             = 1.25
 		threshold_duration    = %[4]d
-		threshold_occurrences = "ALL"
+		threshold_occurrences = "ANY"
 	}
 
 	# Will be one of baseline_direction, value_function, expected_groups, or open_violation_on_group_overlap depending on condition type

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -123,7 +123,7 @@ The `term` block the following arguments:
 <br>For _static_ NRQL alert conditions with the `sum` value function, the value must be within 120-7200 seconds (inclusive).
 <br>For _static_ NRQL alert conditions with the `single_value` value function, the value must be within 60-7200 seconds (inclusive).
 
-- `threshold_occurrences` - (Optional) The criteria for how many data points must be in violation for the specified threshold duration. Valid values are: `all` or `at_least_once` (case insensitive).
+- `threshold_occurrences` - (Optional) The criteria for how many data points must be in violation for the specified threshold duration. Valid values are: `all` or `any` (case insensitive).
 - `duration` - (Optional) **DEPRECATED:** Use `threshold_duration` instead. The duration of time, in _minutes_, that the threshold must violate for in order to create a violation. Must be within 1-120 (inclusive).
 - `time_function` - (Optional) **DEPRECATED:** Use `threshold_occurrences` instead. The criteria for how many data points must be in violation for the specified threshold duration. Valid values are: `all` or `any`.
 
@@ -271,7 +271,7 @@ resource "newrelic_nrql_alert_condition" "z" {
     operator              = "above"
     threshold_duration    = 120
     threshold             = 3
-    threshold_occurrences = "AT_LEAST_ONCE"
+    threshold_occurrences = "any"
   }
 
   nrql {

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -271,7 +271,7 @@ resource "newrelic_nrql_alert_condition" "z" {
     operator              = "above"
     threshold_duration    = 120
     threshold             = 3
-    threshold_occurrences = "any"
+    threshold_occurrences = "ANY"
   }
 
   nrql {


### PR DESCRIPTION
Found an issue.

API: https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/rest-api-alerts/alerts-conditions-api-field-names/#terms_time_function

But in the client is: https://github.com/newrelic/newrelic-client-go/blob/main/pkg/alerts/nrql_conditions.go

	All:         "ALL",
	AtLeastOnce: "AT_LEAST_ONCE", 

which impacts: https://github.com/newrelic/terraform-provider-newrelic/issues/1409

Already created PR for newrelic-client-go:

https://github.com/newrelic/newrelic-client-go/pull/787