### PR TITLE
fix(one_dashboard): Make billboard thresholds optional.

### DIFF
--- a/newrelic/resource_newrelic_one_dashboard.go
+++ b/newrelic/resource_newrelic_one_dashboard.go
@@ -3,6 +3,7 @@ package newrelic
 import (
 	"context"
 	"log"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -246,18 +247,13 @@ func dashboardWidgetBarSchemaElem() *schema.Resource {
 func dashboardWidgetBillboardSchemaElem() *schema.Resource {
 	s := dashboardWidgetSchemaBase()
 
-	s["critical"] = &schema.Schema{
-		Type:        schema.TypeFloat,
-		Optional:    true,
-		Description: "The critical threshold value.",
+	s["threshold"] = &schema.Schema{
+		Type:             schema.TypeMap,
+		Optional:         true,
+		Description:      "The thresholds to use billboard display.",
+		Elem:             &schema.Schema{Type: schema.TypeFloat},
+		ValidateDiagFunc: validation.MapKeyMatch(regexp.MustCompile("^(warning|critical)$"), "Expected 'warning' or 'critical' for threshold keys. Invalid threshold key"),
 	}
-
-	s["warning"] = &schema.Schema{
-		Type:        schema.TypeFloat,
-		Optional:    true,
-		Description: "The warning threshold value.",
-	}
-
 	return &schema.Resource{
 		Schema: s,
 	}

--- a/newrelic/resource_newrelic_one_dashboard_test.go
+++ b/newrelic/resource_newrelic_one_dashboard_test.go
@@ -215,8 +215,10 @@ func testAccCheckNewRelicOneDashboardConfig_PageFull(pageName string, accountID 
         query      = "FROM Transaction SELECT count(*)"
       }
 
-      warning = 0
-      critical = 2
+      threshold = {
+        warning = 0
+        critical = 2
+      }
     }
 
     widget_bullet {

--- a/newrelic/structures_newrelic_one_dashboard.go
+++ b/newrelic/structures_newrelic_one_dashboard.go
@@ -308,18 +308,21 @@ func expandDashboardBillboardWidgetConfigurationInput(i map[string]interface{}, 
 
 	// optional, order is important (API returns them sorted alpha)
 	cfg.Thresholds = []dashboards.DashboardBillboardWidgetThresholdInput{}
-	if t, ok := i["critical"]; ok {
-		cfg.Thresholds = append(cfg.Thresholds, dashboards.DashboardBillboardWidgetThresholdInput{
-			AlertSeverity: entities.DashboardAlertSeverityTypes.CRITICAL,
-			Value:         t.(float64),
-		})
-	}
+	if t, ok := i["threshold"]; ok {
+		t := t.(map[string]interface{})
+		if c, ok := t["critical"]; ok {
+			cfg.Thresholds = append(cfg.Thresholds, dashboards.DashboardBillboardWidgetThresholdInput{
+				AlertSeverity: entities.DashboardAlertSeverityTypes.CRITICAL,
+				Value:         c.(float64),
+			})
+		}
 
-	if t, ok := i["warning"]; ok {
-		cfg.Thresholds = append(cfg.Thresholds, dashboards.DashboardBillboardWidgetThresholdInput{
-			AlertSeverity: entities.DashboardAlertSeverityTypes.WARNING,
-			Value:         t.(float64),
-		})
+		if w, ok := t["warning"]; ok {
+			cfg.Thresholds = append(cfg.Thresholds, dashboards.DashboardBillboardWidgetThresholdInput{
+				AlertSeverity: entities.DashboardAlertSeverityTypes.WARNING,
+				Value:         w.(float64),
+			})
+		}
 	}
 
 	return &cfg, nil
@@ -673,12 +676,14 @@ func flattenDashboardWidget(in *entities.DashboardWidget) (string, map[string]in
 			out["nrql_query"] = flattenDashboardWidgetNRQLQuery(&in.Configuration.Billboard.NRQLQueries)
 		}
 		if len(in.Configuration.Billboard.Thresholds) > 0 {
+			t := make(map[string]interface{})
+			out["threshold"] = t
 			for _, v := range in.Configuration.Billboard.Thresholds {
 				switch v.AlertSeverity {
 				case entities.DashboardAlertSeverityTypes.CRITICAL:
-					out["critical"] = v.Value
+					t["critical"] = v.Value
 				case entities.DashboardAlertSeverityTypes.WARNING:
-					out["warning"] = v.Value
+					t["warning"] = v.Value
 				}
 			}
 		}


### PR DESCRIPTION
Currently, billboard widgets will default to having a warning and critical threshold of 0. This means that by default billboards with any value above 0 will display with a red "critical error" background.

**There is currently no way to specify "no critical / warning threshold" for billboards**

This PR changes the structure of billboards so that the thresholds are defined in a map. Example:

```terraform
resource "newrelic_one_dashboard" "exampledash" {
  name = "New Relic Terraform Example"
  page {
    name = "New Relic Terraform Example"
    widget_billboard {
      row    = 1
      column = 1
      title  = "Example"
      nrql_query { query = "FROM NrUsage SELECT count(*)" }
      threshold = {
        warning  = 1
        critical = 2
      }
    }
  }
}
```

![image](https://user-images.githubusercontent.com/6374032/131166375-030bcfa8-1b9b-43dc-bd9c-2d019efafbee.png)
