### PR TITLE
feat(Alerts): Add streaming methods fields to nrql alert conditions

### DIFF
--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -167,7 +167,7 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 							Required: true,
 						},
 						"since_value": {
-							Deprecated:    "use `evaluation_offset` attribute instead",
+							Deprecated:    "use `signal.aggregation_method` attribute instead",
 							Type:          schema.TypeString,
 							Optional:      true,
 							Description:   "NRQL queries are evaluated in one-minute time windows. The start time depends on the value you provide in the NRQL condition's `since_value`.",
@@ -184,8 +184,9 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 								return
 							},
 						},
-						// New attribute in NerdGraph. Equivalent to `since_value`.
+						// Equivalent to `since_value`.
 						"evaluation_offset": {
+							Deprecated:    "use `signal.aggregation_method` attribute instead",
 							Type:          schema.TypeInt,
 							Optional:      true,
 							Description:   "NRQL queries are evaluated in one-minute time windows. The start time depends on the value you provide in the NRQL condition's `evaluation_offset`.",
@@ -328,6 +329,24 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 				Description:  "If using the 'static' fill option, this value will be used for filling gaps in the signal.",
 				RequiredWith: []string{"fill_option"},
 			},
+			"aggregation_method": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"CADENCE", "EVENT_FLOW", "EVENT_TIMER"}, true),
+				Description:  "The method that determines when we consider an aggregation window to be complete so that we can evaluate the signal for violations. Default is CADENCE.",
+			},
+			"aggregation_delay": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Description:  "How long we wait for data that belongs in each aggregation window. Depending on your data, a longer delay may increase accuracy but delay notifications. Use aggregationDelay with the EVENT_FLOW and CADENCE aggregation methods.",
+				RequiredWith: []string{"aggregation_method"},
+			},
+			"aggregation_timer": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Description:  "How long we wait after each data point arrives to make sure we've processed the whole batch. Use aggregationTimer with the EVENT_TIMER aggregation method.",
+				RequiredWith: []string{"aggregation_method"},
+			},
 			// Baseline ONLY
 			"baseline_direction": {
 				Type:          schema.TypeString,
@@ -357,7 +376,7 @@ func resourceNewRelicNrqlAlertConditionCreate(ctx context.Context, d *schema.Res
 	accountID := selectAccountID(providerConfig, d)
 	policyID := strconv.Itoa(d.Get("policy_id").(int))
 
-	conditionInput, err := expandNrqlAlertConditionInput(d)
+	conditionInput, err := expandNrqlAlertConditionCreateInput(d)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -437,7 +456,7 @@ func resourceNewRelicNrqlAlertConditionUpdate(ctx context.Context, d *schema.Res
 
 	conditionID := strconv.Itoa(ids[1])
 
-	conditionInput, err := expandNrqlAlertConditionInput(d)
+	conditionInput, err := expandNrqlAlertConditionUpdateInput(d)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -398,6 +398,100 @@ func TestAccNewRelicNrqlAlertCondition_NerdGraphOutlier(t *testing.T) {
 	})
 }
 
+func TestAccNewRelicNrqlAlertCondition_NerdGraphStreamingMethods(t *testing.T) {
+	resourceName := "newrelic_nrql_alert_condition.foo"
+	rName := acctest.RandString(5)
+	delay := "null"
+	timer := "null"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
+		Steps: []resource.TestStep{
+			// Test: Create (NerdGraph) condition with streaming method cadence
+			{
+				Config: testAccNewRelicNrqlAlertConditionStreamingMethodsNerdGraphConfig(
+					rName,
+					"cadence",
+					"60",
+					timer,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),
+				),
+			},
+			// Test: Update (NerdGraph) condition with streaming method event_timer
+			{
+				Config: testAccNewRelicNrqlAlertConditionStreamingMethodsNerdGraphConfig(
+					rName,
+					"event_timer",
+					delay,
+					"120",
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNewRelicNrqlAlertCondition_NerdGraphNrqlEvaluationOffset(t *testing.T) {
+	resourceName := "newrelic_nrql_alert_condition.foo"
+	rName := acctest.RandString(5)
+	delay := "null"
+	timer := "null"
+	method := "null"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
+		Steps: []resource.TestStep{
+			// Test: Create (NerdGraph) condition with nrql.evaluationOffset
+			{
+				Config: testAccNewRelicNrqlAlertConditionNrqlEvaluationOffsetNerdGraphConfig(
+					rName,
+					method,
+					delay,
+					timer,
+					20,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),
+				),
+			},
+			// Test: Update (NerdGraph) condition to remove nrql.evaluationOffset and replace with streaming methods
+			{
+				Config: testAccNewRelicNrqlAlertConditionStreamingMethodsNerdGraphConfig(
+					rName,
+					"event_timer",
+					delay,
+					"120",
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),
+				),
+			},
+			//Test: Import
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// Ignore items with deprecated fields because
+				// we don't set deprecated fields on import
+				ImportStateVerifyIgnore: []string{
+					"term",                 // contains nested attributes that are deprecated
+					"nrql",                 // contains nested attributes that are deprecated
+					"violation_time_limit", // deprecated in favor of violation_time_limit_seconds
+				},
+				ImportStateIdFunc: testAccImportStateIDFunc(resourceName, "static"),
+			},
+		},
+	})
+}
+
 func testAccCheckNewRelicNrqlAlertConditionDestroy(s *terraform.State) error {
 	providerConfig := testAccProvider.Meta().(*ProviderConfig)
 	client := providerConfig.NewClient
@@ -685,4 +779,91 @@ resource "newrelic_nrql_alert_condition" "foo" {
 	%[5]s
 }
 `, name, conditionType, nrqlEvalOffset, termDuration, conditionalAttr, facetClause)
+}
+
+func testAccNewRelicNrqlAlertConditionStreamingMethodsNerdGraphConfig(
+	name string,
+	method string,
+	delay string,
+	timer string,
+) string {
+	return fmt.Sprintf(`
+resource "newrelic_alert_policy" "foo" {
+	name = "tf-test-%[1]s"
+}
+
+resource "newrelic_nrql_alert_condition" "foo" {
+	policy_id   = newrelic_alert_policy.foo.id
+
+	name                           = "tf-test-%[1]s"
+	type                           = "static"
+	runbook_url                    = "https://foo.example.com"
+	enabled                        = false
+	description                    = "test description"
+	violation_time_limit_seconds   = 3600
+	close_violations_on_expiration = true
+	open_violation_on_expiration   = true
+	expiration_duration            = 120
+	aggregation_window             = 60
+	value_function 				   = "single_value"
+
+	nrql {
+		query             = "SELECT uniqueCount(hostname) FROM ComputeSample"
+	}
+
+	critical {
+    operator              = "above"
+    threshold             = 0
+		threshold_duration    = 120
+		threshold_occurrences = "ALL"
+	}
+	aggregation_method = "%[2]s"
+	aggregation_delay = %[3]s
+	aggregation_timer = %[4]s
+}
+`, name, method, delay, timer)
+}
+
+func testAccNewRelicNrqlAlertConditionNrqlEvaluationOffsetNerdGraphConfig(
+	name string,
+	method string,
+	delay string,
+	timer string,
+	nrqlEvalOffset int,
+) string {
+	return fmt.Sprintf(`
+resource "newrelic_alert_policy" "foo" {
+	name = "tf-test-%[1]s"
+}
+
+resource "newrelic_nrql_alert_condition" "foo" {
+	policy_id   = newrelic_alert_policy.foo.id
+
+	name                           = "tf-test-%[1]s"
+	type                           = "static"
+	runbook_url                    = "https://foo.example.com"
+	enabled                        = false
+	description                    = "test description"
+	violation_time_limit_seconds   = 3600
+	close_violations_on_expiration = true
+	open_violation_on_expiration   = true
+	expiration_duration            = 120
+	aggregation_window             = 60
+	value_function 				   = "single_value"
+
+	nrql {
+		query             = "SELECT uniqueCount(hostname) FROM ComputeSample"
+		evaluation_offset = %[5]d
+	}
+
+	critical {
+    operator              = "above"
+    threshold             = 0
+		threshold_duration    = 120
+		threshold_occurrences = "ALL"
+	}
+	aggregation_delay = %[3]s
+	aggregation_timer = %[4]s
+}
+`, name, method, delay, timer, nrqlEvalOffset)
 }

--- a/newrelic/structures_newrelic_nrql_alert_condition.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition.go
@@ -35,12 +35,26 @@ var (
 		alerts.AlertsFillOptionTypes.LAST_VALUE: "last_value",
 		alerts.AlertsFillOptionTypes.STATIC:     "static",
 	}
+
+	// old:new
+	aggregationMethodMap = map[string]*alerts.NrqlConditionAggregationMethod{
+		"cadence":     &alerts.NrqlConditionAggregationMethodTypes.Cadence,
+		"event_flow":  &alerts.NrqlConditionAggregationMethodTypes.EventFlow,
+		"event_timer": &alerts.NrqlConditionAggregationMethodTypes.EventTimer,
+	}
+
+	// new:old
+	aggregationMethodMapNewOld = map[alerts.NrqlConditionAggregationMethod]string{
+		alerts.NrqlConditionAggregationMethodTypes.Cadence:    "cadence",
+		alerts.NrqlConditionAggregationMethodTypes.EventFlow:  "event_flow",
+		alerts.NrqlConditionAggregationMethodTypes.EventTimer: "event_timer",
+	}
 )
 
 // NerdGraph
-func expandNrqlAlertConditionInput(d *schema.ResourceData) (*alerts.NrqlConditionInput, error) {
-	input := alerts.NrqlConditionInput{
-		NrqlConditionBase: alerts.NrqlConditionBase{
+func expandNrqlAlertConditionCreateInput(d *schema.ResourceData) (*alerts.NrqlConditionCreateInput, error) {
+	input := alerts.NrqlConditionCreateInput{
+		NrqlConditionCreateBase: alerts.NrqlConditionCreateBase{
 			Description: d.Get("description").(string),
 			Enabled:     d.Get("enabled").(bool),
 			Name:        d.Get("name").(string),
@@ -105,7 +119,7 @@ func expandNrqlAlertConditionInput(d *schema.ResourceData) (*alerts.NrqlConditio
 		input.ViolationTimeLimit = alerts.NrqlConditionViolationTimeLimit(strings.ToUpper(violationTimeLimit.(string)))
 	}
 
-	nrql, err := expandNrql(d, input)
+	nrql, err := expandCreateNrql(d, input)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +137,99 @@ func expandNrqlAlertConditionInput(d *schema.ResourceData) (*alerts.NrqlConditio
 		return nil, err
 	}
 
-	if input.Signal, err = expandSignal(d); err != nil {
+	if input.Signal, err = expandCreateSignal(d); err != nil {
+		return nil, err
+	}
+
+	return &input, nil
+}
+
+func expandNrqlAlertConditionUpdateInput(d *schema.ResourceData) (*alerts.NrqlConditionUpdateInput, error) {
+	input := alerts.NrqlConditionUpdateInput{
+		NrqlConditionUpdateBase: alerts.NrqlConditionUpdateBase{
+			Description: d.Get("description").(string),
+			Enabled:     d.Get("enabled").(bool),
+			Name:        d.Get("name").(string),
+		},
+	}
+
+	conditionType := strings.ToLower(d.Get("type").(string))
+
+	if conditionType == "baseline" {
+		if attr, ok := d.GetOk("baseline_direction"); ok {
+			direction := alerts.NrqlBaselineDirection(strings.ToUpper(attr.(string)))
+			input.BaselineDirection = &direction
+		} else {
+			return nil, fmt.Errorf("attribute `%s` is required for nrql alert conditions of type `%+v`", "baseline_direction", conditionType)
+		}
+	}
+
+	if conditionType == "static" {
+		if attr, ok := d.GetOk("value_function"); ok {
+			valFn := alerts.NrqlConditionValueFunction(strings.ToUpper(attr.(string)))
+			input.ValueFunction = &valFn
+		} else {
+			return nil, fmt.Errorf("attribute `%s` is required for nrql alert conditions of type `%+v`", "value_function", conditionType)
+		}
+	}
+
+	if conditionType == "outlier" {
+		defaultExpectedGroups := 1
+		if expectedGroups, ok := d.GetOk("expected_groups"); ok {
+			expectedGroupsValue := expectedGroups.(int)
+			input.ExpectedGroups = &expectedGroupsValue
+		} else {
+			input.ExpectedGroups = &defaultExpectedGroups
+		}
+
+		var openViolationOnOverlap bool
+		if violationOnOverlap, ok := d.GetOkExists("open_violation_on_group_overlap"); ok {
+			openViolationOnOverlap = violationOnOverlap.(bool)
+
+			if *input.ExpectedGroups < 2 && openViolationOnOverlap {
+				return nil, fmt.Errorf("attribute `%s` must be set to false when `expected_groups` is 1", "open_violation_on_group_overlap")
+			}
+		} else if ignoreOverlap, ok := d.GetOkExists("ignore_overlap"); ok {
+			// Note: ignore_overlap is the inverse of open_violation_on_group_overlap
+			openViolationOnOverlap = !ignoreOverlap.(bool)
+
+			if *input.ExpectedGroups < 2 && openViolationOnOverlap {
+				return nil, fmt.Errorf("attribute `%s` must be set to true when `expected_groups` is 1", "ignore_overlap")
+			}
+		}
+
+		input.OpenViolationOnGroupOverlap = &openViolationOnOverlap
+	}
+
+	if runbookURL, ok := d.GetOk("runbook_url"); ok {
+		input.RunbookURL = runbookURL.(string)
+	}
+
+	if violationTimeLimitSec, ok := d.GetOk("violation_time_limit_seconds"); ok {
+		input.ViolationTimeLimitSeconds = violationTimeLimitSec.(int)
+	} else if violationTimeLimit, ok := d.GetOk("violation_time_limit"); ok {
+		input.ViolationTimeLimit = alerts.NrqlConditionViolationTimeLimit(strings.ToUpper(violationTimeLimit.(string)))
+	}
+
+	nrql, err := expandUpdateNrql(d, input)
+	if err != nil {
+		return nil, err
+	}
+
+	input.Nrql = *nrql
+
+	terms, err := expandNrqlTerms(d, conditionType)
+	if err != nil {
+		return nil, err
+	}
+
+	input.Terms = terms
+
+	if input.Expiration, err = expandExpiration(d); err != nil {
+		return nil, err
+	}
+
+	if input.Signal, err = expandUpdateSignal(d); err != nil {
 		return nil, err
 	}
 
@@ -131,8 +237,8 @@ func expandNrqlAlertConditionInput(d *schema.ResourceData) (*alerts.NrqlConditio
 }
 
 // NerdGraph
-func expandNrql(d *schema.ResourceData, condition alerts.NrqlConditionInput) (*alerts.NrqlConditionQuery, error) {
-	var nrql alerts.NrqlConditionQuery
+func expandCreateNrql(d *schema.ResourceData, condition alerts.NrqlConditionCreateInput) (*alerts.NrqlConditionCreateQuery, error) {
+	var nrql alerts.NrqlConditionCreateQuery
 
 	if nrqlQuery, ok := d.GetOk("nrql.0.query"); ok {
 		nrql.Query = nrqlQuery.(string)
@@ -144,11 +250,33 @@ func expandNrql(d *schema.ResourceData, condition alerts.NrqlConditionInput) (*a
 			return nil, err
 		}
 
-		nrql.EvaluationOffset = sv
+		nrql.EvaluationOffset = &sv
 	} else if evalOffset, ok := d.GetOk("nrql.0.evaluation_offset"); ok {
-		nrql.EvaluationOffset = evalOffset.(int)
-	} else {
-		return nil, fmt.Errorf("one of `since_value` or `evaluation_offset` must be configured for block `nrql`")
+		eo := evalOffset.(int)
+		nrql.EvaluationOffset = &eo
+	}
+
+	return &nrql, nil
+}
+
+// NerdGraph
+func expandUpdateNrql(d *schema.ResourceData, condition alerts.NrqlConditionUpdateInput) (*alerts.NrqlConditionUpdateQuery, error) {
+	var nrql alerts.NrqlConditionUpdateQuery
+
+	if nrqlQuery, ok := d.GetOk("nrql.0.query"); ok {
+		nrql.Query = nrqlQuery.(string)
+	}
+
+	if sinceValue, ok := d.GetOk("nrql.0.since_value"); ok {
+		sv, err := strconv.Atoi(sinceValue.(string))
+		if err != nil {
+			return nil, err
+		}
+
+		nrql.EvaluationOffset = &sv
+	} else if evalOffset, ok := d.GetOk("nrql.0.evaluation_offset"); ok {
+		eo := evalOffset.(int)
+		nrql.EvaluationOffset = &eo
 	}
 
 	return &nrql, nil
@@ -321,8 +449,8 @@ func expandExpiration(d *schema.ResourceData) (*alerts.AlertsNrqlConditionExpira
 }
 
 // NerdGraph
-func expandSignal(d *schema.ResourceData) (*alerts.AlertsNrqlConditionSignal, error) {
-	signal := alerts.AlertsNrqlConditionSignal{
+func expandCreateSignal(d *schema.ResourceData) (*alerts.AlertsNrqlConditionCreateSignal, error) {
+	signal := alerts.AlertsNrqlConditionCreateSignal{
 		FillOption: fillOptionMap[strings.ToLower(d.Get("fill_option").(string))],
 	}
 
@@ -338,6 +466,65 @@ func expandSignal(d *schema.ResourceData) (*alerts.AlertsNrqlConditionSignal, er
 	if aggregationWindow, ok := d.GetOk("aggregation_window"); ok {
 		v := aggregationWindow.(int)
 		signal.AggregationWindow = &v
+	}
+
+	if _, ok := d.GetOk("aggregation_method"); ok {
+		v := aggregationMethodMap[strings.ToLower(d.Get("aggregation_method").(string))]
+
+		signal.AggregationMethod = v
+	}
+
+	if aggregationDelay, ok := d.GetOk("aggregation_delay"); ok {
+		v := aggregationDelay.(int)
+
+		signal.AggregationDelay = &v
+	}
+
+	if aggregationTimer, ok := d.GetOk("aggregation_timer"); ok {
+		v := aggregationTimer.(int)
+
+		signal.AggregationTimer = &v
+	}
+
+	return &signal, nil
+}
+
+// NerdGraph
+func expandUpdateSignal(d *schema.ResourceData) (*alerts.AlertsNrqlConditionUpdateSignal, error) {
+	signal := alerts.AlertsNrqlConditionUpdateSignal{
+		FillOption: fillOptionMap[strings.ToLower(d.Get("fill_option").(string))],
+	}
+
+	// Due to the way that nulls are handled as zeros in Terraform 0.11, add another check that a 0 fill_value
+	// can only be applied when the fill_option is static
+	if fillValue, ok := d.GetOkExists("fill_value"); ok {
+		v := fillValue.(float64)
+		if v != 0 || (signal.FillOption != nil && *signal.FillOption == alerts.AlertsFillOptionTypes.STATIC) {
+			signal.FillValue = &v
+		}
+	}
+
+	if aggregationWindow, ok := d.GetOk("aggregation_window"); ok {
+		v := aggregationWindow.(int)
+		signal.AggregationWindow = &v
+	}
+
+	if _, ok := d.GetOk("aggregation_method"); ok {
+		v := aggregationMethodMap[strings.ToLower(d.Get("aggregation_method").(string))]
+
+		signal.AggregationMethod = v
+	}
+
+	if aggregationDelay, ok := d.GetOk("aggregation_delay"); ok {
+		v := aggregationDelay.(int)
+
+		signal.AggregationDelay = &v
+	}
+
+	if aggregationTimer, ok := d.GetOk("aggregation_timer"); ok {
+		v := aggregationTimer.(int)
+
+		signal.AggregationTimer = &v
 	}
 
 	return &signal, nil
@@ -478,6 +665,24 @@ func flattenSignal(d *schema.ResourceData, signal *alerts.AlertsNrqlConditionSig
 		}
 	}
 
+	if signal.AggregationMethod != nil {
+		if err := d.Set("aggregation_method", aggregationMethodMapNewOld[*signal.AggregationMethod]); err != nil {
+			return fmt.Errorf("[DEBUG] Error setting nrql alert condition `aggregation_method`: %v", err)
+		}
+	}
+
+	if signal.AggregationDelay != nil {
+		if err := d.Set("aggregation_delay", signal.AggregationDelay); err != nil {
+			return fmt.Errorf("[DEBUG] Error setting nrql alert condition `aggregation_delay`: %v", err)
+		}
+	}
+
+	if signal.AggregationTimer != nil {
+		if err := d.Set("aggregation_timer", signal.AggregationTimer); err != nil {
+			return fmt.Errorf("[DEBUG] Error setting nrql alert condition `aggregation_timer`: %v", err)
+		}
+	}
+
 	return nil
 }
 
@@ -491,7 +696,8 @@ func flattenNrql(nrql alerts.NrqlConditionQuery, configNrql map[string]interface
 
 	// Handle deprecated
 	if svRaw != nil && svRaw.(string) != "" {
-		out["since_value"] = strconv.Itoa(nrql.EvaluationOffset)
+		evalOffset := nrql.EvaluationOffset
+		out["since_value"] = strconv.Itoa(*evalOffset)
 	} else {
 		out["evaluation_offset"] = nrql.EvaluationOffset
 	}

--- a/newrelic/structures_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition_test.go
@@ -41,21 +41,17 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 		"operator":              alerts.AlertsNRQLConditionTermsOperatorTypes.BELOW,
 	})
 
-	expectedNrql := &alerts.NrqlConditionInput{}
+	expectedNrql := &alerts.NrqlConditionCreateInput{}
 	expectedNrql.Nrql.Query = nrql["query"].(string)
-	expectedNrql.Nrql.EvaluationOffset = nrql["evaluation_offset"].(int)
+	evalOffset := nrql["evaluation_offset"].(int)
+	expectedNrql.Nrql.EvaluationOffset = &evalOffset
 
 	cases := map[string]struct {
 		Data         map[string]interface{}
 		ExpectErr    bool
 		ExpectReason string
-		Expanded     *alerts.NrqlConditionInput
+		Expanded     *alerts.NrqlConditionCreateInput
 	}{
-		"invalid nrql": {
-			Data:         map[string]interface{}{},
-			ExpectErr:    true,
-			ExpectReason: "one of `since_value` or `evaluation_offset` must be configured for block `nrql`",
-		},
 		"valid nrql": {
 			Data: map[string]interface{}{
 				"nrql": []interface{}{nrql},
@@ -79,7 +75,7 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 			},
 			ExpectErr:    false,
 			ExpectReason: "",
-			Expanded: &alerts.NrqlConditionInput{
+			Expanded: &alerts.NrqlConditionCreateInput{
 				BaselineDirection: &alerts.NrqlBaselineDirections.LowerOnly,
 			},
 		},
@@ -99,7 +95,7 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 			},
 			ExpectErr:    false,
 			ExpectReason: "",
-			Expanded: &alerts.NrqlConditionInput{
+			Expanded: &alerts.NrqlConditionCreateInput{
 				ValueFunction: &alerts.NrqlConditionValueFunctions.SingleValue,
 			},
 		},
@@ -112,8 +108,8 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 			},
 			ExpectErr:    false,
 			ExpectReason: "",
-			Expanded: func() *alerts.NrqlConditionInput {
-				x := alerts.NrqlConditionInput{
+			Expanded: func() *alerts.NrqlConditionCreateInput {
+				x := alerts.NrqlConditionCreateInput{
 					ValueFunction: &alerts.NrqlConditionValueFunctions.SingleValue,
 				}
 				x.Terms = []alerts.NrqlConditionTerm{
@@ -139,8 +135,8 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 			},
 			ExpectErr:    false,
 			ExpectReason: "",
-			Expanded: func() *alerts.NrqlConditionInput {
-				x := alerts.NrqlConditionInput{
+			Expanded: func() *alerts.NrqlConditionCreateInput {
+				x := alerts.NrqlConditionCreateInput{
 					ValueFunction: &alerts.NrqlConditionValueFunctions.SingleValue,
 				}
 				x.Terms = []alerts.NrqlConditionTerm{
@@ -168,9 +164,9 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 				"nrql":               []interface{}{nrql},
 				"aggregation_window": 60,
 			},
-			Expanded: &alerts.NrqlConditionInput{
-				NrqlConditionBase: alerts.NrqlConditionBase{
-					Signal: &alerts.AlertsNrqlConditionSignal{
+			Expanded: &alerts.NrqlConditionCreateInput{
+				NrqlConditionCreateBase: alerts.NrqlConditionCreateBase{
+					Signal: &alerts.AlertsNrqlConditionCreateSignal{
 						AggregationWindow: &[]int{60}[0],
 					},
 				},
@@ -181,9 +177,9 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 				"nrql":               []interface{}{nrql},
 				"aggregation_window": nil,
 			},
-			Expanded: &alerts.NrqlConditionInput{
-				NrqlConditionBase: alerts.NrqlConditionBase{
-					Signal: &alerts.AlertsNrqlConditionSignal{},
+			Expanded: &alerts.NrqlConditionCreateInput{
+				NrqlConditionCreateBase: alerts.NrqlConditionCreateBase{
+					Signal: &alerts.AlertsNrqlConditionCreateSignal{},
 				},
 			},
 		},
@@ -193,9 +189,9 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 				"fill_option": "static",
 				"fill_value":  1.0,
 			},
-			Expanded: &alerts.NrqlConditionInput{
-				NrqlConditionBase: alerts.NrqlConditionBase{
-					Signal: &alerts.AlertsNrqlConditionSignal{
+			Expanded: &alerts.NrqlConditionCreateInput{
+				NrqlConditionCreateBase: alerts.NrqlConditionCreateBase{
+					Signal: &alerts.AlertsNrqlConditionCreateSignal{
 						FillOption: &alerts.AlertsFillOptionTypes.STATIC,
 						FillValue:  &[]float64{1.0}[0],
 					},
@@ -208,9 +204,9 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 				"fill_option": "static",
 				"fill_value":  0.0,
 			},
-			Expanded: &alerts.NrqlConditionInput{
-				NrqlConditionBase: alerts.NrqlConditionBase{
-					Signal: &alerts.AlertsNrqlConditionSignal{
+			Expanded: &alerts.NrqlConditionCreateInput{
+				NrqlConditionCreateBase: alerts.NrqlConditionCreateBase{
+					Signal: &alerts.AlertsNrqlConditionCreateSignal{
 						FillOption: &alerts.AlertsFillOptionTypes.STATIC,
 						FillValue:  &[]float64{0.0}[0],
 					},
@@ -223,9 +219,9 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 				"fill_option": "sTaTiC",
 				"fill_value":  0.0,
 			},
-			Expanded: &alerts.NrqlConditionInput{
-				NrqlConditionBase: alerts.NrqlConditionBase{
-					Signal: &alerts.AlertsNrqlConditionSignal{
+			Expanded: &alerts.NrqlConditionCreateInput{
+				NrqlConditionCreateBase: alerts.NrqlConditionCreateBase{
+					Signal: &alerts.AlertsNrqlConditionCreateSignal{
 						FillOption: &alerts.AlertsFillOptionTypes.STATIC,
 						FillValue:  &[]float64{0.0}[0],
 					},
@@ -237,9 +233,9 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 				"nrql":        []interface{}{nrql},
 				"fill_option": "last_value",
 			},
-			Expanded: &alerts.NrqlConditionInput{
-				NrqlConditionBase: alerts.NrqlConditionBase{
-					Signal: &alerts.AlertsNrqlConditionSignal{
+			Expanded: &alerts.NrqlConditionCreateInput{
+				NrqlConditionCreateBase: alerts.NrqlConditionCreateBase{
+					Signal: &alerts.AlertsNrqlConditionCreateSignal{
 						FillOption: &alerts.AlertsFillOptionTypes.LAST_VALUE,
 					},
 				},
@@ -250,9 +246,9 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 				"nrql":        []interface{}{nrql},
 				"fill_option": "none",
 			},
-			Expanded: &alerts.NrqlConditionInput{
-				NrqlConditionBase: alerts.NrqlConditionBase{
-					Signal: &alerts.AlertsNrqlConditionSignal{
+			Expanded: &alerts.NrqlConditionCreateInput{
+				NrqlConditionCreateBase: alerts.NrqlConditionCreateBase{
+					Signal: &alerts.AlertsNrqlConditionCreateSignal{
 						FillOption: &alerts.AlertsFillOptionTypes.NONE,
 					},
 				},
@@ -265,13 +261,85 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 				"open_violation_on_expiration":   true,
 				"close_violations_on_expiration": true,
 			},
-			Expanded: &alerts.NrqlConditionInput{
-				NrqlConditionBase: alerts.NrqlConditionBase{
+			Expanded: &alerts.NrqlConditionCreateInput{
+				NrqlConditionCreateBase: alerts.NrqlConditionCreateBase{
 					Expiration: &alerts.AlertsNrqlConditionExpiration{
 						ExpirationDuration:          &[]int{120}[0],
 						CloseViolationsOnExpiration: true,
 						OpenViolationOnExpiration:   true,
 					},
+				},
+			},
+		},
+		"aggregation method exists": {
+			Data: map[string]interface{}{
+				"nrql":               []interface{}{nrql},
+				"aggregation_method": "cadence",
+			},
+			Expanded: &alerts.NrqlConditionCreateInput{
+				NrqlConditionCreateBase: alerts.NrqlConditionCreateBase{
+					Signal: &alerts.AlertsNrqlConditionCreateSignal{
+						AggregationMethod: &alerts.NrqlConditionAggregationMethodTypes.Cadence,
+					},
+				},
+			},
+		},
+		"aggregation method nil": {
+			Data: map[string]interface{}{
+				"nrql":               []interface{}{nrql},
+				"aggregation_method": nil,
+			},
+			Expanded: &alerts.NrqlConditionCreateInput{
+				NrqlConditionCreateBase: alerts.NrqlConditionCreateBase{
+					Signal: &alerts.AlertsNrqlConditionCreateSignal{},
+				},
+			},
+		},
+		"aggregation delay not nil": {
+			Data: map[string]interface{}{
+				"nrql":              []interface{}{nrql},
+				"aggregation_delay": 60,
+			},
+			Expanded: &alerts.NrqlConditionCreateInput{
+				NrqlConditionCreateBase: alerts.NrqlConditionCreateBase{
+					Signal: &alerts.AlertsNrqlConditionCreateSignal{
+						AggregationDelay: &[]int{60}[0],
+					},
+				},
+			},
+		},
+		"aggregation delay nil": {
+			Data: map[string]interface{}{
+				"nrql":              []interface{}{nrql},
+				"aggregation_delay": nil,
+			},
+			Expanded: &alerts.NrqlConditionCreateInput{
+				NrqlConditionCreateBase: alerts.NrqlConditionCreateBase{
+					Signal: &alerts.AlertsNrqlConditionCreateSignal{},
+				},
+			},
+		},
+		"aggregation timer not nil": {
+			Data: map[string]interface{}{
+				"nrql":              []interface{}{nrql},
+				"aggregation_timer": 60,
+			},
+			Expanded: &alerts.NrqlConditionCreateInput{
+				NrqlConditionCreateBase: alerts.NrqlConditionCreateBase{
+					Signal: &alerts.AlertsNrqlConditionCreateSignal{
+						AggregationTimer: &[]int{60}[0],
+					},
+				},
+			},
+		},
+		"aggregation timer nil": {
+			Data: map[string]interface{}{
+				"nrql":              []interface{}{nrql},
+				"aggregation_timer": nil,
+			},
+			Expanded: &alerts.NrqlConditionCreateInput{
+				NrqlConditionCreateBase: alerts.NrqlConditionCreateBase{
+					Signal: &alerts.AlertsNrqlConditionCreateSignal{},
 				},
 			},
 		},
@@ -300,7 +368,7 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 				}
 			}
 
-			expanded, err := expandNrqlAlertConditionInput(d)
+			expanded, err := expandNrqlAlertConditionCreateInput(d)
 
 			if tc.ExpectErr {
 				require.NotNil(t, err)
@@ -324,7 +392,7 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 					require.Equal(t, tc.Expanded.Nrql.Query, expanded.Nrql.Query)
 				}
 
-				if tc.Expanded.Nrql.EvaluationOffset > 0 {
+				if tc.Expanded.Nrql.EvaluationOffset != nil {
 					require.Equal(t, tc.Expanded.Nrql.EvaluationOffset, expanded.Nrql.EvaluationOffset)
 				}
 
@@ -346,6 +414,7 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 
 func TestFlattenNrqlAlertCondition(t *testing.T) {
 	r := resourceNewRelicNrqlAlertCondition()
+	evalOffset := 3
 
 	nrqlCondition := alerts.NrqlAlertCondition{
 		ID:       "1234567",
@@ -356,7 +425,7 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 			Name:        "name-test",
 			Nrql: alerts.NrqlConditionQuery{
 				Query:            "SELECT average(duration) from Transaction where appName='Dummy App'",
-				EvaluationOffset: 3,
+				EvaluationOffset: &evalOffset,
 			},
 			RunbookURL: "test.com",
 			Terms: []alerts.NrqlConditionTerm{
@@ -377,7 +446,10 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 			},
 			ViolationTimeLimit: alerts.NrqlConditionViolationTimeLimits.OneHour,
 			Signal: &alerts.AlertsNrqlConditionSignal{
-				FillOption: &alerts.AlertsFillOptionTypes.LAST_VALUE,
+				FillOption:        &alerts.AlertsFillOptionTypes.LAST_VALUE,
+				AggregationMethod: &alerts.NrqlConditionAggregationMethodTypes.Cadence,
+				AggregationDelay:  &[]int{60}[0],
+				AggregationTimer:  &[]int{60}[0],
 			},
 			Expiration: &alerts.AlertsNrqlConditionExpiration{
 				ExpirationDuration:          &[]int{120}[0],
@@ -391,8 +463,11 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 	nrqlConditionBaseline := nrqlCondition
 	zero := 0.0
 	nrqlConditionBaseline.Signal = &alerts.AlertsNrqlConditionSignal{
-		FillOption: &alerts.AlertsFillOptionTypes.STATIC,
-		FillValue:  &zero,
+		FillOption:        &alerts.AlertsFillOptionTypes.STATIC,
+		FillValue:         &zero,
+		AggregationMethod: &alerts.NrqlConditionAggregationMethodTypes.Cadence,
+		AggregationDelay:  &[]int{60}[0],
+		AggregationTimer:  &[]int{60}[0],
 	}
 	nrqlConditionBaseline.Type = alerts.NrqlConditionTypes.Baseline
 	nrqlConditionBaseline.BaselineDirection = &alerts.NrqlBaselineDirections.LowerOnly
@@ -410,7 +485,10 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 	nrqlConditionOutlier.ExpectedGroups = &expectedGroups
 	nrqlConditionOutlier.OpenViolationOnGroupOverlap = &openViolationOnOverlap
 	nrqlConditionOutlier.Signal = &alerts.AlertsNrqlConditionSignal{
-		FillOption: &alerts.AlertsFillOptionTypes.NONE,
+		FillOption:        &alerts.AlertsFillOptionTypes.NONE,
+		AggregationMethod: &alerts.NrqlConditionAggregationMethodTypes.Cadence,
+		AggregationDelay:  &[]int{60}[0],
+		AggregationTimer:  &[]int{60}[0],
 	}
 	nrqlConditionOutlier.Expiration = nil
 
@@ -481,6 +559,9 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 			require.True(t, d.Get("close_violations_on_expiration").(bool))
 			require.Equal(t, "static", d.Get("fill_option").(string))
 			require.Equal(t, 0.0, d.Get("fill_value").(float64))
+			require.Equal(t, "cadence", d.Get("aggregation_method").(string))
+			require.Equal(t, 60, d.Get("aggregation_delay").(int))
+			require.Equal(t, 60, d.Get("aggregation_timer").(int))
 
 		case alerts.NrqlConditionTypes.Static:
 			require.Equal(t, string(alerts.NrqlConditionValueFunctions.Sum), d.Get("value_function").(string))
@@ -492,6 +573,9 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 			require.True(t, d.Get("close_violations_on_expiration").(bool))
 			require.Equal(t, "last_value", d.Get("fill_option").(string))
 			require.Zero(t, d.Get("fill_value").(float64))
+			require.Equal(t, "cadence", d.Get("aggregation_method").(string))
+			require.Equal(t, 60, d.Get("aggregation_delay").(int))
+			require.Equal(t, 60, d.Get("aggregation_timer").(int))
 
 		case alerts.NrqlConditionTypes.Outlier:
 			require.Equal(t, 2, d.Get("expected_groups").(int))
@@ -504,6 +588,9 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 			require.Zero(t, d.Get("close_violations_on_expiration").(bool))
 			require.Equal(t, "none", d.Get("fill_option").(string))
 			require.Zero(t, d.Get("fill_value").(float64))
+			require.Equal(t, "cadence", d.Get("aggregation_method").(string))
+			require.Equal(t, 60, d.Get("aggregation_delay").(int))
+			require.Equal(t, 60, d.Get("aggregation_timer").(int))
 		}
 	}
 }

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -32,18 +32,17 @@ resource "newrelic_nrql_alert_condition" "foo" {
   enabled                      = true
   violation_time_limit_seconds = 3600
   value_function               = "single_value"
-
   fill_option          = "static"
   fill_value           = 1.0
-
   aggregation_window             = 60
+  aggregation_method = "event_flow"
+  aggregation_delay = 120
   expiration_duration            = 120
   open_violation_on_expiration   = true
   close_violations_on_expiration = true
 
   nrql {
     query             = "SELECT average(duration) FROM Transaction where appName = 'Your App'"
-    evaluation_offset = 3
   }
 
   critical {
@@ -95,17 +94,17 @@ The following arguments are supported:
 - `expiration_duration` - (Optional) The amount of time (in seconds) to wait before considering the signal expired.
 - `open_violation_on_expiration` - (Optional) Whether to create a new violation to capture that the signal expired.
 - `close_violations_on_expiration` - (Optional) Whether to close all open violations when the signal expires.
+- `aggregation_method` - (Optional) Determines when we consider an aggregation window to be complete so that we can evaluate the signal for violations. Possible values are `cadence`, `event_flow` or `event_timer`. `aggregation_method` cannot be set with `nrql.evaluation_offset`.
+- `aggregation_delay` - (Optional) How long we wait for data that belongs in each aggregation window. Depending on your data, a longer delay may increase accuracy but delay notifications. Use `aggregation_delay` with the `event_flow` and `cadence` methods. The maximum delay is 1200 seconds (20 minutes) when using `event_flow` and 3600 seconds (60 minutes) when using `cadence`. In both cases, the minimum delay is 0 seconds and the default is 120 seconds. `aggregation_delay` cannot be set with `nrql.evaluation_offset`.
+- `aggregation_timer` - (Optional) How long we wait after each data point arrives to make sure we've processed the whole batch. Use `aggregation_timer` with the `event_timer` method. The timer value can range from 0 seconds to 1200 seconds (20 minutes); the default is 60 seconds. `aggregation_timer` cannot be set with `nrql.evaluation_offset`.
 
 ## NRQL
 
 The `nrql` block supports the following arguments:
 
 - `query` - (Required) The NRQL query to execute for the condition.
-- `evaluation_offset` - (Optional*) Represented in minutes and must be within 1-20 minutes (inclusive). NRQL queries are evaluated in one-minute time windows. The start time depends on this value. It's recommended to set this to 3 minutes. An offset of less than 3 minutes will trigger violations sooner, but you may see more false positives and negatives due to data latency. With `evaluation_offset` set to 3 minutes, the NRQL time window applied to your query will be: `SINCE 3 minutes ago UNTIL 2 minutes ago`.<br>
-<small>\***Note**: One of `evaluation_offset` _or_ `since_value` must be set, but not both.</small>
-
-- `since_value` - (Optional*)  **DEPRECATED:** Use `evaluation_offset` instead. The value to be used in the `SINCE <X> minutes ago` clause for the NRQL query. Must be between 1-20 (inclusive). <br>
-<small>\***Note**: One of `evaluation_offset` _or_ `since_value` must be set, but not both.</small>
+- `evaluation_offset` - (Optional) Represented in minutes and must be within 1-20 minutes (inclusive). NRQL queries are evaluated in one-minute time windows. The start time depends on this value. It's recommended to set this to 3 minutes. An offset of less than 3 minutes will trigger violations sooner, but you may see more false positives and negatives due to data latency. With `evaluation_offset` set to 3 minutes, the NRQL time window applied to your query will be: `SINCE 3 minutes ago UNTIL 2 minutes ago`. `evaluation_offset` cannot be set with `aggregation_method`, `aggregation_delay`, or `aggregation_timer`.<br>
+- `since_value` - (Optional)  **DEPRECATED:** Use `evaluation_offset` instead. The value to be used in the `SINCE <X> minutes ago` clause for the NRQL query. Must be between 1-20 (inclusive). <br>
 
 ## Terms
 
@@ -154,13 +153,14 @@ resource "newrelic_nrql_alert_condition" "foo" {
   enabled                      = true
   runbook_url                  = "https://www.example.com"
   violation_time_limit_seconds = 3600
+  aggregation_method = "event_flow"
+  aggregation_delay = 120
 
   # baseline type only
   baseline_direction = "upper_only"
 
   nrql {
     query             = "SELECT percentile(duration, 95) FROM Transaction WHERE appName = 'ExampleAppName'"
-    evaluation_offset = 3
   }
 
   critical {
@@ -199,6 +199,8 @@ resource "newrelic_nrql_alert_condition" "foo" {
   enabled                      = true
   runbook_url                  = "https://www.example.com"
   violation_time_limit_seconds = 3600
+  aggregation_method = "event_flow"
+  aggregation_delay = 120
 
   # Outlier only
   expected_groups = 2
@@ -208,7 +210,6 @@ resource "newrelic_nrql_alert_condition" "foo" {
 
   nrql {
     query             = "SELECT percentile(duration, 95) FROM Transaction WHERE appName = 'ExampleAppName' FACET host"
-    evaluation_offset = 3
   }
 
   critical {
@@ -276,7 +277,6 @@ resource "newrelic_nrql_alert_condition" "z" {
 
   nrql {
     query             = "SELECT count(*) FROM TransactionError WHERE appName like '%Dummy App%' FACET appName"
-    evaluation_offset = 2
   }
 }
 ```
@@ -305,7 +305,6 @@ resource "newrelic_nrql_alert_condition" "z" {
 
   nrql {
     query       = "SELECT count(*) FROM TransactionError WHERE appName like '%Dummy App%' FACET appName"
-    since_value = 3
   }
 }
 ```


### PR DESCRIPTION
[Jira Ticket](https://newrelic.atlassian.net/browse/AINTER-7816)
[Docs Update Ticket](https://newrelic.atlassian.net/browse/AINTER-7817)

-----

[Corresponding Go Client PR](https://github.com/newrelic/newrelic-client-go/pull/805)

**Description:**

This ticket adds [Streaming Methods](https://nerdlife.datanerd.us/new-relic/two-new-aggregation-methods-in-incident-detection-3d2007fb-e9b5-42b2-9001-3abbe242e4bf) support to Alerts NRQL conditions including three new fields: `AggregationMethod`, `AggregationDelay`, and `AggregationTimer`.

It also maintains backwards compatibility for `nrql.evaluationOffset`

Example TF Config to create a condition with streaming methods:
```
resource "newrelic_nrql_alert_condition" "streaming-methods-condition" {
  name = "Streaming methods"
  policy_id = 1220119
  nrql {
    query = "SELECT count(*) FROM Transaction"
  }
  critical {
    operator = "above"
    threshold = 0
    threshold_duration = 60
    threshold_occurrences = "all"
  }
  close_violations_on_expiration = true
  value_function = "single_value"
  violation_time_limit_seconds = 86400
  aggregation_method = "cadence"
  aggregation_delay = 5
  type = "static"
  expiration_duration = 180
}
```

**Implementation Notes:**

-[ In the Go Client](https://github.com/newrelic/newrelic-client-go/pull/805/files#r717911405), I had to update `nrql.EvaluationOffset` to be a pointer, so that it is nullable.  It must be nullable to support the use case when a user wants to update an existing condition that has an evaluation offset to instead use streaming methods.


**Testing:**

I've added tests to support the following use cases.  I've also manually tested these:

- A user should be able to create a NRQL condition with any valid streaming methods configuration (e.g. `aggregation_method = "cadence"` and `aggregation_delay = 5`)
- A user should be able to update an existing NRQL condition with streaming methods (e.g. take the above condition an update it to use `aggregation_method = "event_timer"` and `aggregation_timer = 5`)
- A user should be able to create a condition with `nrql.evaluationOffset` and no streaming methods
- A user should be able to update an existing condition with with `nrql.evaluationOffset` to instead user streaming methods
