### PR TITLE
chore(nrql_alert_condition) add eol warning for outlier type

### DIFF
--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -148,11 +148,21 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 			},
 			// Note: The "outlier" type does NOT exist in NerdGraph yet
 			"type": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      "static",
-				Description:  "The type of NRQL alert condition to create. Valid values are: 'static', 'outlier', 'baseline'.",
-				ValidateFunc: validation.StringInSlice([]string{"static", "outlier", "baseline"}, false),
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "static",
+				Description: "The type of NRQL alert condition to create. Valid values are: 'static', 'baseline', 'outlier' (deprecated).",
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					valueString := val.(string)
+
+					v := validation.StringInSlice([]string{"static", "outlier", "baseline"}, false)
+					warns, errs = v(valueString, key)
+
+					if valueString == "outlier" {
+						warns = append(warns, "We're removing outlier conditions Feb 1, 2022. More Info: https://discuss.newrelic.com/t/nrql-outlier-alert-conditions-end-of-life/164167")
+					}
+					return
+				},
 			},
 			"nrql": {
 				Type:        schema.TypeList,

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -71,7 +71,7 @@ The following arguments are supported:
 - `description` - (Optional) The description of the NRQL alert condition.
 - `policy_id` - (Required) The ID of the policy where this condition should be used.
 - `name` - (Required) The title of the condition.
-- `type` - (Optional) The type of the condition. Valid values are `static`, `baseline`, or `outlier`. Defaults to `static`.
+- `type` - (Optional) The type of the condition. Valid values are `static`, `baseline`, or `outlier` (deprecated). Defaults to `static`.
 - `runbook_url` - (Optional) Runbook URL to display in notifications.
 - `enabled` - (Optional) Whether to enable the alert condition. Valid values are `true` and `false`. Defaults to `true`.
 - `nrql` - (Required) A NRQL query. See [NRQL](#nrql) below for details.


### PR DESCRIPTION
Outlier conditions are deprecated. All outlier conditions will be removed Feb 1, 2022.

This PR adds a warning to notify users to this upcoming deadline, with a link to an informational post.

Anyone interacting with an `outlier` condition type will see this message:
<img width="1674" alt="Screen Shot 2021-11-02 at 12 18 39 PM" src="https://user-images.githubusercontent.com/17018863/139934159-a580e028-ce04-46bf-898f-d9b6490371f8.png">

This also updates the docs and resource description. See AINTER-8224 for more details