### PR TITLE
docs(servicelevel): Fix example in the docs

### DIFF
--- a/website/docs/r/service_level.html.markdown
+++ b/website/docs/r/service_level.html.markdown
@@ -42,8 +42,6 @@ resource "newrelic_service_level" "foo" {
     }
 
     objective {
-        name = "Realistic"
-        description = "A realistic objective."
         target = 99.00
         time_window {
             rolling {


### PR DESCRIPTION
- Remove name and description for the SLO in the example of the docs. It is not documented in the docs, it is ignored on the UI and it is not required in the API.