### PR TITLE
fix: use violation_time_limit_seconds on condition import

### DIFF
--- a/newrelic/structures_newrelic_nrql_alert_condition.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition.go
@@ -609,8 +609,11 @@ func flattenNrqlAlertCondition(accountID int, condition *alerts.NrqlAlertConditi
 
 	if _, ok := d.GetOk("violation_time_limit_seconds"); ok {
 		_ = d.Set("violation_time_limit_seconds", condition.ViolationTimeLimitSeconds)
-	} else {
+	} else if _, ok := d.GetOk("violation_time_limit"); ok {
 		_ = d.Set("violation_time_limit", condition.ViolationTimeLimit)
+	} else {
+		// If neither field is already set, use `violation_time_limit_seconds`
+		_ = d.Set("violation_time_limit_seconds", condition.ViolationTimeLimitSeconds)
 	}
 
 	if err := flattenExpiration(d, condition.Expiration); err != nil {


### PR DESCRIPTION
Fixes issue #1433

When importing a condition, no resource exists in TF state and the check for `violation_time_limit_seconds` will always fail, causing the deprecated `violation_time_limit` field to be used instead. This change specifically checks for `violation_time_limit`, and if both fields are missing we will import the new field for `violation_time_limit_seconds`