### PR TITLE
fix: correct violation_time_limit if none is provided

### DIFF
--- a/newrelic/structures_newrelic_nrql_alert_condition.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition.go
@@ -611,9 +611,6 @@ func flattenNrqlAlertCondition(accountID int, condition *alerts.NrqlAlertConditi
 		_ = d.Set("violation_time_limit_seconds", condition.ViolationTimeLimitSeconds)
 	} else if _, ok := d.GetOk("violation_time_limit"); ok {
 		_ = d.Set("violation_time_limit", condition.ViolationTimeLimit)
-	} else {
-		// If neither field is already set, use `violation_time_limit_seconds`
-		_ = d.Set("violation_time_limit_seconds", condition.ViolationTimeLimitSeconds)
 	}
 
 	if err := flattenExpiration(d, condition.Expiration); err != nil {


### PR DESCRIPTION
Updating changes made in https://github.com/newrelic/terraform-provider-newrelic/pull/1564

The previous change was causing an acceptance test to fail, and had unexpected state differences if a NRQL condition is created without providing `violation_time_limit` or `violation_time_limit_seconds`. Running `terraform plan` without providing either value would result in a change being detected on `violation_time_limit_seconds` and the field would be updated even though nothing actually changed. Removing the `else` clause here corrects this issue while also still supporting the original scenario that the previous PR fixed.