### PR TITLE
fix: muting rule with repeat = null crashes plugin

### DIFF
--- a/newrelic/structures_newrelic_alert_muting_rule.go
+++ b/newrelic/structures_newrelic_alert_muting_rule.go
@@ -368,7 +368,7 @@ func flattenSchedule(schedule *alerts.MutingRuleSchedule) []interface{} {
 
 	if schedule.WeeklyRepeatDays != nil {
 		out["weekly_repeat_days"] = flattenWeeklyRepeatDays(*schedule.WeeklyRepeatDays)
-	} else if *schedule.Repeat == "WEEKLY" {
+	} else if schedule.Repeat != nil && *schedule.Repeat == "WEEKLY" {
 		out["weekly_repeat_days"] = []string{}
 	} else {
 		out["weekly_repeat_days"] = nil


### PR DESCRIPTION
This resolves issue https://github.com/newrelic/terraform-provider-newrelic/issues/1542

If a Muting Rule has a `schedule` block and both `WeeklyRepeatDays` and `Repeat` are nil, this was crashing the plugin on `terraform apply`. The changes here prevent this from crashing by verifying that `Repeat` is not nil before checking the value.