### PR TITLE
aggregation_method and aggregation_delay show diff when not provided and default values are used

### DIFF
--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -342,18 +342,34 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice([]string{"CADENCE", "EVENT_FLOW", "EVENT_TIMER"}, true),
 				Description:  "The method that determines when we consider an aggregation window to be complete so that we can evaluate the signal for violations. Default is CADENCE.",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// If a value is not provided and the condition uses the default value, don't show a diff
+					return (old == "event_flow" && new == "") || strings.EqualFold(old, new)
+				},
 			},
 			"aggregation_delay": {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Description:  "How long we wait for data that belongs in each aggregation window. Depending on your data, a longer delay may increase accuracy but delay notifications. Use aggregationDelay with the EVENT_FLOW and CADENCE aggregation methods.",
 				RequiredWith: []string{"aggregation_method"},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// If a value is not provided and the condition uses the default value, don't show a diff
+					oldInt, _ := strconv.ParseInt(old, 0, 8)
+					newInt, _ := strconv.ParseInt(new, 0, 8)
+					return oldInt == 120 && (newInt == 0)
+				},
 			},
 			"aggregation_timer": {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Description:  "How long we wait after each data point arrives to make sure we've processed the whole batch. Use aggregationTimer with the EVENT_TIMER aggregation method.",
 				RequiredWith: []string{"aggregation_method"},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// If a value is not provided and the condition uses the default value, don't show a diff
+					oldInt, _ := strconv.ParseInt(old, 0, 8)
+					newInt, _ := strconv.ParseInt(new, 0, 8)
+					return oldInt == 120 && (newInt == 0)
+				},
 			},
 			// Baseline ONLY
 			"baseline_direction": {

--- a/newrelic/structures_newrelic_nrql_alert_condition.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition.go
@@ -665,19 +665,19 @@ func flattenSignal(d *schema.ResourceData, signal *alerts.AlertsNrqlConditionSig
 		}
 	}
 
-	if _, ok := d.GetOk("aggregation_method"); ok && signal.AggregationMethod != nil {
+	if signal.AggregationMethod != nil {
 		if err := d.Set("aggregation_method", aggregationMethodMapNewOld[*signal.AggregationMethod]); err != nil {
 			return fmt.Errorf("[DEBUG] Error setting nrql alert condition `aggregation_method`: %v", err)
 		}
 	}
 
-	if _, ok := d.GetOk("aggregation_delay"); ok && signal.AggregationDelay != nil {
+	if signal.AggregationDelay != nil {
 		if err := d.Set("aggregation_delay", signal.AggregationDelay); err != nil {
 			return fmt.Errorf("[DEBUG] Error setting nrql alert condition `aggregation_delay`: %v", err)
 		}
 	}
 
-	if _, ok := d.GetOk("aggregation_timer"); ok && signal.AggregationTimer != nil {
+	if signal.AggregationTimer != nil {
 		if err := d.Set("aggregation_timer", signal.AggregationTimer); err != nil {
 			return fmt.Errorf("[DEBUG] Error setting nrql alert condition `aggregation_timer`: %v", err)
 		}

--- a/newrelic/structures_newrelic_nrql_alert_condition.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition.go
@@ -665,19 +665,19 @@ func flattenSignal(d *schema.ResourceData, signal *alerts.AlertsNrqlConditionSig
 		}
 	}
 
-	if signal.AggregationMethod != nil {
+	if _, ok := d.GetOk("aggregation_method"); ok && signal.AggregationMethod != nil {
 		if err := d.Set("aggregation_method", aggregationMethodMapNewOld[*signal.AggregationMethod]); err != nil {
 			return fmt.Errorf("[DEBUG] Error setting nrql alert condition `aggregation_method`: %v", err)
 		}
 	}
 
-	if signal.AggregationDelay != nil {
+	if _, ok := d.GetOk("aggregation_delay"); ok && signal.AggregationDelay != nil {
 		if err := d.Set("aggregation_delay", signal.AggregationDelay); err != nil {
 			return fmt.Errorf("[DEBUG] Error setting nrql alert condition `aggregation_delay`: %v", err)
 		}
 	}
 
-	if signal.AggregationTimer != nil {
+	if _, ok := d.GetOk("aggregation_timer"); ok && signal.AggregationTimer != nil {
 		if err := d.Set("aggregation_timer", signal.AggregationTimer); err != nil {
 			return fmt.Errorf("[DEBUG] Error setting nrql alert condition `aggregation_timer`: %v", err)
 		}


### PR DESCRIPTION
This fixes issue https://github.com/newrelic/terraform-provider-newrelic/issues/1544

When the `aggregation_method`, `aggregation_delay`, and `aggregation_timer` fields are not provided in Terraform config we use default values. This currently shows a diff when running `terraform plan` even though the values are not changing. This PR adds a check to see if those fields were provided in Terraform, and if not we do not show the difference.