### PR TITLE
Correct the HMAC calculation using VSE password

### DIFF
--- a/newrelic/resource_newrelic_synthetics_monitor_script.go
+++ b/newrelic/resource_newrelic_synthetics_monitor_script.go
@@ -5,6 +5,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"log"
 
@@ -181,9 +182,10 @@ func expandMonitorScriptLocations(cfg []interface{}, d *schema.ResourceData) ([]
 			if h, ok := cfgLocation["hmac"]; ok && h != "" {
 				return nil, fmt.Errorf("only set one of either 'hmac' or 'vse_password'")
 			}
-			h := hmac.New(sha256.New, []byte(v.(string)))
-			h.Write([]byte(d.Get("text").(string)))
-			encoded := base64.StdEncoding.EncodeToString(h.Sum(nil))
+			mac := hmac.New(sha256.New, []byte(v.(string)))
+			mac.Write([]byte(d.Get("text").(string)))
+			h := hex.EncodeToString(mac.Sum(nil))
+			encoded := base64.StdEncoding.EncodeToString([]byte(h))
 			location.HMAC = encoded
 
 		} else if h, ok := cfgLocation["hmac"]; ok && h != "" {


### PR DESCRIPTION
According to the steps in the [documentation](https://newrelic.zendesk.com/hc/en-us/articles/1500005170762-Calculating-the-HMAC-value-for-a-VSE-Password-on-your-private-location) for computing the HMAC for use with Synthetic scripts, the algorithm for computing the HMAC requires base64 encoding the _hexadecimal encoded_ HMAC. The previously implemented algorithm skipped the hexadecimal encoding resulting in incorrect values.

Fixes #1578