### PR TITLE
chore: Add warning for tag(s).guid in Muting Rule

### DIFF
--- a/newrelic/resource_newrelic_alert_muting_rule.go
+++ b/newrelic/resource_newrelic_alert_muting_rule.go
@@ -20,11 +20,17 @@ func validateMutingRuleConditionAttribute(val interface{}, key string) (warns []
 	valueString := val.(string)
 	attemptedTagRegex := regexp.MustCompile(`^tags?`)
 	correctTagRegex := regexp.MustCompile(`^tags?\..+$`)
+	guidTagRegex := regexp.MustCompile(`^tags?\.guid$`)
 
 	// tag.SomeValue attempted but does not match allowed format
 	if attemptedTagRegex.Match([]byte(valueString)) {
 		if !correctTagRegex.Match([]byte(valueString)) {
 			errs = append(errs, fmt.Errorf("%#v of %#v must be in the format tag.tag_name", key, valueString))
+			return
+		}
+		// tag.guid is going away in the future. entity.guid should be used instead
+		if guidTagRegex.Match([]byte(valueString)) {
+			warns = append(warns, fmt.Sprintf("%#v has been deprecated for Muting Rules. Please use \"entity.guid\" instead for Muting Rules configurations ", valueString))
 			return
 		}
 		return


### PR DESCRIPTION
The ability to use `entity.guid` as the attribute in a Muting Rule was added in https://github.com/newrelic/terraform-provider-newrelic/pull/1507

`entity.guid` should always be used over `tag.guid` or `tags.guid` in Muting Rules going forward because the `tag.guid` will be removed from New Relic data in the near future. This PR adds a warning if a Muting Rule uses `tag(s).guid` to suggest switching to `entity.guid`, but does not currently block changes.