### PR TITLE
fix: Remove condition name length validation

### DIFF
--- a/newrelic/resource_newrelic_alert_condition.go
+++ b/newrelic/resource_newrelic_alert_condition.go
@@ -93,10 +93,9 @@ func resourceNewRelicAlertCondition() *schema.Resource {
 				Description: "The ID of the policy where this condition should be used.",
 			},
 			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 128),
-				Description:  "The title of the condition. Must be between 1 and 128 characters, inclusive.",
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The title of the condition. Must be between 1 and 128 characters, inclusive.",
 			},
 			"enabled": {
 				Type:        schema.TypeBool,

--- a/newrelic/resource_newrelic_alert_condition_unit_test.go
+++ b/newrelic/resource_newrelic_alert_condition_unit_test.go
@@ -46,22 +46,6 @@ func TestAccNewRelicAlertCondition_LongTermDuration(t *testing.T) {
 	})
 }
 
-func TestAccNewRelicAlertCondition_LongName(t *testing.T) {
-	avoidEmptyAccountID()
-	expectedErrorMsg, _ := regexp.Compile(`expected length of name to be in the range \(1 \- 128\)`)
-	resource.ParallelTest(t, resource.TestCase{
-		IsUnitTest:   true,
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckNewRelicAlertConditionDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccNewRelicAlertConditionConfig("really-long-name-longer-than-one-hundred-and-twenty-eight-characters-so-it-causes-an-error-because-really-long-name-causes-an-error"),
-				ExpectError: expectedErrorMsg,
-			},
-		},
-	})
-}
-
 func TestAccNewRelicAlertCondition_EmptyName(t *testing.T) {
 	avoidEmptyAccountID()
 	expectedErrorMsg, _ := regexp.Compile(`name must not be empty`)


### PR DESCRIPTION
The Terraform provider is currently validating the length of the condition name for `resource_newrelic_alert_condition`, but this validation also happens in the Condition API. We are removing the TF validation to defer to the Condition API validation instead. This makes `resource_newrelic_alert_condition` match the other alert condition types that do not have validation in TF.