### PR TITLE
chore(nrql_alert_condition)remove deprecated outlier type

### DIFF
--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -71,7 +71,7 @@ func termSchema() *schema.Resource {
 			"threshold_duration": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Description: "The duration, in seconds, that the threshold must violate in order to create a violation. Value must be a multiple of the 'aggregation_window' (which has a default of 60 seconds). Value must be within 120-3600 seconds for baseline and outlier conditions, within 120-7200 seconds for static conditions with the sum value function, and within 60-7200 seconds for static conditions with the single_value value function.",
+				Description: "The duration, in seconds, that the threshold must violate in order to create a violation. Value must be a multiple of the 'aggregation_window' (which has a default of 60 seconds). Value must be within 120-3600 seconds for baseline conditions, within 120-7200 seconds for static conditions with the sum value function, and within 60-7200 seconds for static conditions with the single_value value function.",
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					v := val.(int)
 					minVal := 60
@@ -86,7 +86,6 @@ func termSchema() *schema.Resource {
 					// Static conditions with a single_value value function must be within range [60, 7200].
 					// Static conditions with a sum value function must be within range [120, 7200].
 					// Baseline conditions must be within range [120, 3600].
-					// Outlier conditions must be within range [120, 3600].
 					if v < minVal || v > maxVal {
 						errs = append(errs, fmt.Errorf("%q must be between %d and %d inclusive, got: %d", key, minVal, maxVal, v))
 					}
@@ -146,21 +145,16 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 				Default:     true,
 				Description: "Whether or not to enable the alert condition.",
 			},
-			// Note: The "outlier" type does NOT exist in NerdGraph yet
 			"type": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "static",
-				Description: "The type of NRQL alert condition to create. Valid values are: 'static', 'baseline', 'outlier' (deprecated).",
+				Description: "The type of NRQL alert condition to create. Valid values are: 'static', 'baseline'",
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					valueString := val.(string)
 
-					v := validation.StringInSlice([]string{"static", "outlier", "baseline"}, false)
+					v := validation.StringInSlice([]string{"static", "baseline"}, false)
 					warns, errs = v(valueString, key)
-
-					if valueString == "outlier" {
-						warns = append(warns, "We're removing outlier conditions Feb 1, 2022. More Info: https://discuss.newrelic.com/t/nrql-outlier-alert-conditions-end-of-life/164167")
-					}
 					return
 				},
 			},
@@ -239,20 +233,6 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 				Elem:          termSchema(),
 				Description:   "A condition term with priority set to warning.",
 				ConflictsWith: []string{"term"},
-			},
-			// Outlier ONLY
-			"expected_groups": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "Number of expected groups when using outlier detection.",
-			},
-			// Outlier ONLY
-			"ignore_overlap": {
-				Deprecated:    "use `open_violation_on_group_overlap` attribute instead, but use the inverse of your boolean - e.g. if ignore_overlap = false, use open_violation_on_group_overlap = true",
-				Type:          schema.TypeBool,
-				Optional:      true,
-				Description:   "Whether to look for a convergence of groups when using outlier detection.",
-				ConflictsWith: []string{"open_violation_on_group_overlap"},
 			},
 			"violation_time_limit_seconds": {
 				Type:          schema.TypeInt,
@@ -382,13 +362,6 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 					return strings.EqualFold(old, new) // Case fold this attribute when diffing
 				},
 			},
-			// Outlier ONLY
-			"open_violation_on_group_overlap": {
-				Type:          schema.TypeBool,
-				Optional:      true,
-				Description:   "Whether overlapping groups should produce a violation.",
-				ConflictsWith: []string{"ignore_overlap"},
-			},
 		},
 	}
 }
@@ -414,8 +387,6 @@ func resourceNewRelicNrqlAlertConditionCreate(ctx context.Context, d *schema.Res
 		condition, err = client.Alerts.CreateNrqlConditionBaselineMutationWithContext(ctx, accountID, policyID, *conditionInput)
 	case "static":
 		condition, err = client.Alerts.CreateNrqlConditionStaticMutationWithContext(ctx, accountID, policyID, *conditionInput)
-	case "outlier":
-		condition, err = client.Alerts.CreateNrqlConditionOutlierMutationWithContext(ctx, accountID, policyID, *conditionInput)
 	}
 
 	var diags diag.Diagnostics
@@ -513,8 +484,6 @@ func resourceNewRelicNrqlAlertConditionUpdate(ctx context.Context, d *schema.Res
 		_, err = client.Alerts.UpdateNrqlConditionBaselineMutationWithContext(ctx, accountID, conditionID, *conditionInput)
 	case "static":
 		_, err = client.Alerts.UpdateNrqlConditionStaticMutationWithContext(ctx, accountID, conditionID, *conditionInput)
-	case "outlier":
-		_, err = client.Alerts.UpdateNrqlConditionOutlierMutationWithContext(ctx, accountID, conditionID, *conditionInput)
 	}
 
 	var diags diag.Diagnostics

--- a/newrelic/structures_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition_test.go
@@ -477,25 +477,9 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 	nrqlConditionStatic.Type = alerts.NrqlConditionTypes.Static
 	nrqlConditionStatic.ValueFunction = &alerts.NrqlConditionValueFunctions.Sum
 
-	// Outlier
-	expectedGroups := 2
-	openViolationOnOverlap := true
-	nrqlConditionOutlier := nrqlCondition
-	nrqlConditionOutlier.Type = "OUTLIER"
-	nrqlConditionOutlier.ExpectedGroups = &expectedGroups
-	nrqlConditionOutlier.OpenViolationOnGroupOverlap = &openViolationOnOverlap
-	nrqlConditionOutlier.Signal = &alerts.AlertsNrqlConditionSignal{
-		FillOption:        &alerts.AlertsFillOptionTypes.NONE,
-		AggregationMethod: &alerts.NrqlConditionAggregationMethodTypes.Cadence,
-		AggregationDelay:  &[]int{60}[0],
-		AggregationTimer:  &[]int{60}[0],
-	}
-	nrqlConditionOutlier.Expiration = nil
-
 	conditions := []*alerts.NrqlAlertCondition{
 		&nrqlConditionBaseline,
 		&nrqlConditionStatic,
-		&nrqlConditionOutlier,
 	}
 
 	// Use the API object above to construct a "user-configured" critical term.
@@ -552,8 +536,6 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 		case alerts.NrqlConditionTypes.Baseline:
 			require.Equal(t, string(alerts.NrqlBaselineDirections.LowerOnly), d.Get("baseline_direction").(string))
 			require.Zero(t, d.Get("value_function").(string))
-			require.Zero(t, d.Get("expected_groups").(int))
-			require.Zero(t, d.Get("open_violation_on_group_overlap").(bool))
 			require.Equal(t, 120, d.Get("expiration_duration").(int))
 			require.True(t, d.Get("open_violation_on_expiration").(bool))
 			require.True(t, d.Get("close_violations_on_expiration").(bool))
@@ -566,8 +548,6 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 		case alerts.NrqlConditionTypes.Static:
 			require.Equal(t, string(alerts.NrqlConditionValueFunctions.Sum), d.Get("value_function").(string))
 			require.Zero(t, d.Get("baseline_direction").(string))
-			require.Zero(t, d.Get("expected_groups").(int))
-			require.Zero(t, d.Get("open_violation_on_group_overlap").(bool))
 			require.Equal(t, 120, d.Get("expiration_duration").(int))
 			require.True(t, d.Get("open_violation_on_expiration").(bool))
 			require.True(t, d.Get("close_violations_on_expiration").(bool))
@@ -577,20 +557,6 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 			require.Equal(t, 60, d.Get("aggregation_delay").(int))
 			require.Equal(t, 60, d.Get("aggregation_timer").(int))
 
-		case alerts.NrqlConditionTypes.Outlier:
-			require.Equal(t, 2, d.Get("expected_groups").(int))
-			require.Zero(t, d.Get("ignore_overlap").(bool))
-			require.True(t, d.Get("open_violation_on_group_overlap").(bool))
-			require.Zero(t, d.Get("baseline_direction").(string))
-			require.Zero(t, d.Get("value_function").(string))
-			require.Zero(t, d.Get("expiration_duration").(int))
-			require.Zero(t, d.Get("open_violation_on_expiration").(bool))
-			require.Zero(t, d.Get("close_violations_on_expiration").(bool))
-			require.Equal(t, "none", d.Get("fill_option").(string))
-			require.Zero(t, d.Get("fill_value").(float64))
-			require.Equal(t, "cadence", d.Get("aggregation_method").(string))
-			require.Equal(t, 60, d.Get("aggregation_delay").(int))
-			require.Equal(t, 60, d.Get("aggregation_timer").(int))
 		}
 	}
 }
@@ -704,20 +670,7 @@ func TestExpandNrqlConditionTerm(t *testing.T) {
 				"priority":              "critical",
 			},
 			ExpectErr:    true,
-			ExpectReason: "only ABOVE operator is allowed for `baseline` and `outlier` condition types",
-		},
-		"non-ABOVE operator when using outlier condition": {
-			Priority:      "warning",
-			ConditionType: "outlier",
-			Term: map[string]interface{}{
-				"threshold":             10.9,
-				"threshold_duration":    9,
-				"threshold_occurrences": "ALL",
-				"operator":              "equals",
-				"priority":              "critical",
-			},
-			ExpectErr:    true,
-			ExpectReason: "only ABOVE operator is allowed for `baseline` and `outlier` condition types",
+			ExpectReason: "only ABOVE operator is allowed for `baseline` condition types",
 		},
 	}
 

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -71,17 +71,14 @@ The following arguments are supported:
 - `description` - (Optional) The description of the NRQL alert condition.
 - `policy_id` - (Required) The ID of the policy where this condition should be used.
 - `name` - (Required) The title of the condition.
-- `type` - (Optional) The type of the condition. Valid values are `static`, `baseline`, or `outlier` (deprecated). Defaults to `static`.
+- `type` - (Optional) The type of the condition. Valid values are `static` or `baseline` Defaults to `static`.
 - `runbook_url` - (Optional) Runbook URL to display in notifications.
 - `enabled` - (Optional) Whether to enable the alert condition. Valid values are `true` and `false`. Defaults to `true`.
 - `nrql` - (Required) A NRQL query. See [NRQL](#nrql) below for details.
 - `term` - (Optional) **DEPRECATED** Use `critical`, and `warning` instead.  A list of terms for this condition. See [Terms](#terms) below for details.
 - `critical` - (Required) A list containing the `critical` threshold values. See [Terms](#terms) below for details.
 - `warning` - (Optional) A list containing the `warning` threshold values. See [Terms](#terms) below for details.
-- `value_function` - (Required if `type` is `static`, omit when `type` is `baseline` or `outlier` ) Possible values are `single_value`, `sum` (case insensitive).
-- `expected_groups` - (Optional) Number of expected groups when using `outlier` detection.
-- `open_violation_on_group_overlap` - (Optional) Whether or not to trigger a violation when groups overlap. Set to `true` if you want to trigger a violation when groups overlap. This argument is only applicable in `outlier` conditions.
-- `ignore_overlap` - (Optional) **DEPRECATED:** Use `open_violation_on_group_overlap` instead, but use the inverse value of your boolean - e.g. if `ignore_overlap = false`, use `open_violation_on_group_overlap = true`. This argument sets whether to trigger a violation when groups overlap. If set to `true` overlapping groups will not trigger a violation. This argument is only applicable in `outlier` conditions.
+- `value_function` - (Required if `type` is `static`, omit when `type` is `baseline`) Possible values are `single_value`, `sum` (case insensitive).
 - `violation_time_limit` - (Optional) **DEPRECATED:** Use `violation_time_limit_seconds` instead. Sets a time limit, in hours, that will automatically force-close a long-lasting violation after the time limit you select. Possible values are `ONE_HOUR`, `TWO_HOURS`, `FOUR_HOURS`, `EIGHT_HOURS`, `TWELVE_HOURS`, `TWENTY_FOUR_HOURS`, `THIRTY_DAYS` (case insensitive).<br>
 <small>\***Note**: One of `violation_time_limit` _or_ `violation_time_limit_seconds` must be set, but not both.</small>
 
@@ -114,12 +111,12 @@ NRQL alert conditions support up to two terms. At least one `term` must have `pr
 
 The `term` block supports the following arguments:
 
-- `operator` - (Optional) Valid values are `above`, `below`, or `equals` (case insensitive). Defaults to `equals`. Note that when using a `type` of `outlier` or `baseline`, the only valid option here is `above`.
+- `operator` - (Optional) Valid values are `above`, `below`, or `equals` (case insensitive). Defaults to `equals`. Note that when using a `type` of `baseline`, the only valid option here is `above`.
 - `priority` - (Optional) `critical` or `warning`. Defaults to `critical`.
 - `threshold` - (Required) The value which will trigger a violation. Must be `0` or greater.
 <br>For _baseline_ NRQL alert conditions, the value must be in the range [1, 1000]. The value is the number of standard deviations from the baseline that the metric must exceed in order to create a violation.
 - `threshold_duration` - (Optional) The duration, in seconds, that the threshold must violate in order to create a violation. Value must be a multiple of the `aggregation_window` (which has a default of 60 seconds).
-<br>For _baseline_ and _outlier_ NRQL alert conditions, the value must be within 120-3600 seconds (inclusive).
+<br>For _baseline_ NRQL alert conditions, the value must be within 120-3600 seconds (inclusive).
 <br>For _static_ NRQL alert conditions with the `sum` value function, the value must be within 120-7200 seconds (inclusive).
 <br>For _static_ NRQL alert conditions with the `single_value` value function, the value must be within 60-7200 seconds (inclusive).
 
@@ -182,53 +179,6 @@ resource "newrelic_nrql_alert_condition" "foo" {
 
 <br>
 
-##### Type: `outlier`
-
-In software development and operations, it is common to have a group consisting of members you expect to behave approximately the same. [Outlier detection](https://docs.newrelic.com/docs/alerts/new-relic-alerts/defining-conditions/outlier-detection-nrql-alert) facilitates alerting when the behavior of one or more common members falls outside a specified range expectation.
-
-```hcl
-resource "newrelic_alert_policy" "foo" {
-  name = "foo"
-}
-
-resource "newrelic_nrql_alert_condition" "foo" {
-  type                         = "outlier"
-  account_id                   = <Your Account ID>
-  name                         = "foo"
-  policy_id                    = newrelic_alert_policy.foo.id
-  description                  = "Alert when outlier conditions occur"
-  enabled                      = true
-  runbook_url                  = "https://www.example.com"
-  violation_time_limit_seconds = 3600
-  aggregation_method           = "event_flow"
-  aggregation_delay            = 120
-
-  # Outlier only
-  expected_groups = 2
-
-  # Outlier only
-	open_violation_on_group_overlap = true
-
-  nrql {
-    query = "SELECT percentile(duration, 95) FROM Transaction WHERE appName = 'ExampleAppName' FACET host"
-  }
-
-  critical {
-    operator              = "above"
-    threshold             = 0.002
-    threshold_duration    = 600
-    threshold_occurrences = "all"
-  }
-
-  warning {
-    operator              = "above"
-    threshold             = 0.0015
-    threshold_duration    = 600
-    threshold_occurrences = "all"
-  }
-}
-```
-
 ## Import
 
 Alert conditions can be imported using a composite ID of `<policy_id>:<condition_id>:<conditionType>`, e.g.
@@ -240,11 +190,7 @@ $ terraform import newrelic_nrql_alert_condition.foo 538291:6789035:baseline
 // For `static` conditions
 $ terraform import newrelic_nrql_alert_condition.foo 538291:6789035:static
 
-// For `outlier` conditions
-$ terraform import newrelic_nrql_alert_condition.foo 538291:6789035:outlier
-```
-
-~> **NOTE:** The value of `conditionType` in the import composite ID must be a valid condition type - `static`, `baseline`, or `outlier.` Also note that deprecated arguments will *not* be set when importing.
+~> **NOTE:** The value of `conditionType` in the import composite ID must be a valid condition type - `static`, `baseline`. Also note that deprecated arguments will *not* be set when importing.
 
 The actual values for `policy_id` and `condition_id` can be retrieved from the following New Relic URL when viewing the NRQL alert condition you want to import:
 


### PR DESCRIPTION
This removes the deprecated "outlier" type from nrql_alert_conditions.  Creation of outlier conditions currently returns an error at the API level and Outlier conditions are slated to be removed Feb 1.

The previous provider version generates a warning whenever users interacted with this type. 

Marking this as a draft PR until Outlier conditions reach EOL