### PR TITLE
docs(servicelevel): SLO periods now include complete weeks

### DIFF
--- a/newrelic/resource_newrelic_service_level.go
+++ b/newrelic/resource_newrelic_service_level.go
@@ -173,7 +173,7 @@ func rollingTimeWindowSchema() *schema.Resource {
 				Type:         schema.TypeInt,
 				Required:     true,
 				Description:  "",
-				ValidateFunc: intInSlice([]int{1, 7, 14, 28, 30}),
+				ValidateFunc: intInSlice([]int{1, 7, 14, 28}),
 			},
 			"unit": {
 				Type:         schema.TypeString,

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -60,6 +60,7 @@ resources compared to which endpoint is in use.
 | `newrelic_nrql_alert_condition`                     | NerdGraph               | `api_key`             |
 | `newrelic_nrql_drop_rule`                           | NerdGraph               | `api_key`             |
 | `newrelic_one_dashboard`                            | NerdGraph               | `api_key`             |
+| `newrelic_service_level`                            | NerdGraph               | `api_key`             |
 | `newrelic_synthetics_alert_condition`               | RESTv2                  | `api_key`             |
 | `newrelic_synthetics_monitor`                       | Synthetics REST API     | `api_key`             |
 | `newrelic_synthetics_monitor_script`                | Synthetics REST API     | `api_key`             |

--- a/website/docs/r/service_level.html.markdown
+++ b/website/docs/r/service_level.html.markdown
@@ -87,7 +87,7 @@ All nested `events` blocks support the following common arguments:
   * `target` - (Required) The target for your SLO, valid values between `0` and `100`. Up to 5 decimals accepted.
   * `time_window` - (Required) Time window is the period for the SLO.
     * `rolling` - (Required) Rolling window.
-      * `count` - (Required) Valid values are `1`, `7`, `14`, `28` and `30`.
+      * `count` - (Required) Valid values are `1`, `7`, `14` and `28`.
       * `unit` - (Required) The only supported value is `DAY`.
 
 ## Attributes Reference


### PR DESCRIPTION
- Update docs and validation since SLO periods now only include complete weeks. The API is no longer accepting a 30 days period.
- Update index to add the service level resource.