### PR TITLE
fix(rql_alert_condition): Add nil check when flattening slide_by

### DIFF
--- a/newrelic/structures_newrelic_nrql_alert_condition.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition.go
@@ -664,9 +664,10 @@ func flattenSignal(d *schema.ResourceData, signal *alerts.AlertsNrqlConditionSig
 	if err := d.Set("aggregation_window", signal.AggregationWindow); err != nil {
 		return fmt.Errorf("[DEBUG] Error setting nrql alert condition `aggregation_window`: %v", err)
 	}
-
-	if err := d.Set("slide_by", signal.SlideBy); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting nrql alert condition `slide_by`: %v", err)
+	if signal.SlideBy != nil {
+		if err := d.Set("slide_by", signal.SlideBy); err != nil {
+			return fmt.Errorf("[DEBUG] Error setting nrql alert condition `slide_by`: %v", err)
+		}
 	}
 
 	if err := d.Set("fill_value", signal.FillValue); err != nil {


### PR DESCRIPTION
This fixes an issue in 2.36.0 where unset slideBy values were being represented as 0 in state. This caused some confusing diffs as slide_by=0 was added to state. 

