### PR TITLE
fix(service_levels): Remove option for 14 days trailing time window

### DIFF
--- a/newrelic/resource_newrelic_service_level.go
+++ b/newrelic/resource_newrelic_service_level.go
@@ -173,7 +173,7 @@ func rollingTimeWindowSchema() *schema.Resource {
 				Type:         schema.TypeInt,
 				Required:     true,
 				Description:  "",
-				ValidateFunc: intInSlice([]int{1, 7, 14, 28}),
+				ValidateFunc: intInSlice([]int{1, 7, 28}),
 			},
 			"unit": {
 				Type:         schema.TypeString,

--- a/website/docs/r/service_level.html.markdown
+++ b/website/docs/r/service_level.html.markdown
@@ -87,7 +87,7 @@ All nested `events` blocks support the following common arguments:
   * `target` - (Required) The target for your SLO, valid values between `0` and `100`. Up to 5 decimals accepted.
   * `time_window` - (Required) Time window is the period for the SLO.
     * `rolling` - (Required) Rolling window.
-      * `count` - (Required) Valid values are `1`, `7`, `14` and `28`.
+      * `count` - (Required) Valid values are `1`, `7` and `28`.
       * `unit` - (Required) The only supported value is `DAY`.
 
 ## Attributes Reference


### PR DESCRIPTION
This option is to be deprecated in favour of 1, 7 and 28 days.