### PR TITLE
fix(nrql_alert_condition): Move condition validation to API

### DIFF
--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -72,27 +72,6 @@ func termSchema() *schema.Resource {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "The duration, in seconds, that the threshold must violate in order to create a violation. Value must be a multiple of the 'aggregation_window' (which has a default of 60 seconds). Value must be within 120-3600 seconds for baseline and outlier conditions, within 120-7200 seconds for static conditions with the sum value function, and within 60-7200 seconds for static conditions with the single_value value function.",
-				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					v := val.(int)
-					minVal := 60
-					maxVal := 7200
-
-					// Value must be a factor of 60.
-					if v%60 != 0 {
-						errs = append(errs, fmt.Errorf("%q must be a factor of %d, got: %d", key, minVal, v))
-					}
-
-					// This validation is a top-level validation check.
-					// Static conditions with a single_value value function must be within range [60, 7200].
-					// Static conditions with a sum value function must be within range [120, 7200].
-					// Baseline conditions must be within range [120, 3600].
-					// Outlier conditions must be within range [120, 3600].
-					if v < minVal || v > maxVal {
-						errs = append(errs, fmt.Errorf("%q must be between %d and %d inclusive, got: %d", key, minVal, maxVal, v))
-					}
-
-					return
-				},
 			},
 		},
 	}


### PR DESCRIPTION
### Issue Link :link:
https://github.com/newrelic/terraform-provider-newrelic/issues/1613

### Goals :soccer:
* Remove incorrect validation logic for `threshold_duration` from `newrelic_nrql_alert_condition`. This makes Condition API validate for the correct `aggregation_window` and `threshold_duration` values.

### Testing Details :mag:

**Valid Condition**

1. Create a valid condition whose critical or warning `threshold_duration` is not evenly divisible by 60. 
2. Expect that the condition can be created well. 

Example resource
```
resource "newrelic_alert_policy" "foo" {
  name = "foo"
}

resource "newrelic_nrql_alert_condition" "foo" {
  policy_id                    = newrelic_alert_policy.foo.id
  name                         = "myname"
  violation_time_limit_seconds = 3600
  aggregation_window           = 59
  aggregation_delay            = 120
  value_function               = "single_value"
  aggregation_method           = "event_flow"
  fill_option                  = "none"

  nrql {
    query = "SELECT count(*) FROM Transaction"
}

  critical {
    operator              = "above"
    threshold             = 1
    threshold_duration    = 118
    threshold_occurrences = "ALL"
  }
}
```

**Invalid Condition**

1. Create an invalid condition whose aggregation window is not a factor of the critical `threshold_duration`
2. Expect that an error is returned from the API

Example resource
```

resource "newrelic_alert_policy" "foo" {
  name = "foo"
}

resource "newrelic_nrql_alert_condition" "foo" {
  policy_id                    = newrelic_alert_policy.foo.id
  name                         = "myname"
  violation_time_limit_seconds = 3600
  aggregation_window           = 55
  aggregation_delay            = 120
  value_function               = "single_value"
  aggregation_method           = "event_flow"
  fill_option                  = "none"

  nrql {
    query = "SELECT count(*) FROM Transaction"
}

  critical {
    operator              = "above"
    threshold             = 1
    threshold_duration    = 118
    threshold_occurrences = "ALL"
  }
}

```