### PR TITLE
docs: remove beta-specific info ahead of general release

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+# Description
+
+Please include a summary of the change and which issue is fixed (if relevant).
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+## Checklist:
+
+Please delete options that are not relevant.
+
+- [ ] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
+- [ ] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
+- [ ] I have performed a self-review of my own code
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.
+
+## How to test this change?
+
+Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc
+
+- Step 1
+- Step 2
+- etc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,7 @@ To test your locally compiled plugin you can add your hcl files in the `testing`
 directory. The `testing/dev.tfrc` file contains the local development configuration.
 Before running any Terraform commands don't forgot to change the authentication
 credentials in `testing/newrelic.tf` or use environment variables as mentioned above.
+Additionally run the following command, or add it to your shell profile: `export TF_CLI_CONFIG_FILE=dev.tfrc`
 
 You can now run `terraform plan` and
 `terraform apply` in the `testing` directory to test your local version of the provider.

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.15.2
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go v0.72.0
+	github.com/newrelic/newrelic-client-go v0.73.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/tools v0.0.0-20201028111035-eafbe7b904eb // indirect
 	google.golang.org/api v0.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -388,8 +388,8 @@ github.com/newrelic/go-agent/v3 v3.15.2 h1:NEpksu2AhuZncbwkDqUg2IvUJst3JQ/TemYfK
 github.com/newrelic/go-agent/v3 v3.15.2/go.mod h1:1A1dssWBwzB7UemzRU6ZVaGDsI+cEn5/bNxI0wiYlIc=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go v0.72.0 h1:7dv4V+Wq4cKqZ1vq2OkspF9j08Q65D9A19LB6FWn9XM=
-github.com/newrelic/newrelic-client-go v0.72.0/go.mod h1:VXjhsfui0rvhM9cVwnKwlidF8NbXlHZvh63ZKi6fImA=
+github.com/newrelic/newrelic-client-go v0.73.0 h1:mLBjJEAYCIRsvA8M0cLnLEzUvRzYFZu0Clana74Mwww=
+github.com/newrelic/newrelic-client-go v0.73.0/go.mod h1:VXjhsfui0rvhM9cVwnKwlidF8NbXlHZvh63ZKi6fImA=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -72,27 +72,6 @@ func termSchema() *schema.Resource {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "The duration, in seconds, that the threshold must violate in order to create a violation. Value must be a multiple of the 'aggregation_window' (which has a default of 60 seconds). Value must be within 120-3600 seconds for baseline and outlier conditions, within 120-7200 seconds for static conditions with the sum value function, and within 60-7200 seconds for static conditions with the single_value value function.",
-				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					v := val.(int)
-					minVal := 60
-					maxVal := 7200
-
-					// Value must be a factor of 60.
-					if v%60 != 0 {
-						errs = append(errs, fmt.Errorf("%q must be a factor of %d, got: %d", key, minVal, v))
-					}
-
-					// This validation is a top-level validation check.
-					// Static conditions with a single_value value function must be within range [60, 7200].
-					// Static conditions with a sum value function must be within range [120, 7200].
-					// Baseline conditions must be within range [120, 3600].
-					// Outlier conditions must be within range [120, 3600].
-					if v < minVal || v > maxVal {
-						errs = append(errs, fmt.Errorf("%q must be between %d and %d inclusive, got: %d", key, minVal, maxVal, v))
-					}
-
-					return
-				},
 			},
 		},
 	}
@@ -320,7 +299,7 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 			"expiration_duration": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Description: "The amount of time (in seconds) to wait before considering the signal expired.",
+				Description: "The amount of time (in seconds) to wait before considering the signal expired.  Must be in the range of 30 to 172800 (inclusive)",
 			},
 			"fill_option": {
 				Type:         schema.TypeString,

--- a/newrelic/resource_newrelic_synthetics_monitor.go
+++ b/newrelic/resource_newrelic_synthetics_monitor.go
@@ -72,7 +72,7 @@ func resourceNewRelicSyntheticsMonitor() *schema.Resource {
 				Type:        schema.TypeFloat,
 				Optional:    true,
 				Default:     7,
-				Description: "The base threshold for the SLA report.",
+				Description: "The base threshold (in seconds) to calculate the apdex score for use in the SLA report. (Default 7 seconds)",
 			},
 			// TODO: ValidationFunc (options only valid if SIMPLE or BROWSER)
 			"validation_string": {

--- a/website/docs/guides/getting_started.html.markdown
+++ b/website/docs/guides/getting_started.html.markdown
@@ -230,4 +230,4 @@ You can also run `terraform destroy` to tear down your resources if that's ever 
 
 [user_api_key]: https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key
 [user_api_key_via_nerdgraph]: https://docs.newrelic.com/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys
-[terraform_data_sources]: https://www.terraform.io/docs/configuration/data-sources.html
+[terraform_data_sources]: https://www.terraform.io/language/data-sources

--- a/website/docs/r/nrql_drop_rule.html.markdown
+++ b/website/docs/r/nrql_drop_rule.html.markdown
@@ -14,9 +14,6 @@ Use this resource to create, and delete New Relic NRQL Drop Rules.
 <br><br>
 Before upgrading to version 2.0.0 or later, it is recommended to upgrade to the most recent 1.x version of the provider and ensure that your environment successfully runs `terraform plan` without unexpected changes.
 
--> **Drop attributes on dimensional metric rollups is in preview**
-Please contact your account team or fill in this [form](https://forms.gle/FGPZpy2y1zdSN9dn9) if you'd like to enroll your account. The feature is subject to change, and more information can be found in [the docs](https://docs.newrelic.com/docs/data-apis/manage-data/drop-data-using-nerdgraph/#drop-attributes-on-dimensional-metric-rollups).
-
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/synthetics_monitor.html.markdown
+++ b/website/docs/r/synthetics_monitor.html.markdown
@@ -37,7 +37,7 @@ The following arguments are supported:
   * `frequency` - (Required) The interval (in minutes) at which this monitor should run.
   * `status` - (Required) The monitor status (i.e. `ENABLED`, `MUTED`, `DISABLED`).
   * `locations` - (Required) The locations in which this monitor should be run.
-  * `sla_threshold` - (Optional) The base threshold for the SLA report.
+  * `sla_threshold` - (Optional) The base threshold (in seconds) to calculate the [Apdex score](https://docs.newrelic.com/docs/apm/new-relic-apm/apdex/apdex-measure-user-satisfaction/) for use in the [SLA report](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/pages/synthetic-monitoring-aggregate-monitor-metrics/#viewing). Default is 7 seconds.
 
  The `SIMPLE` monitor type supports the following additional arguments:
 


### PR DESCRIPTION
# Description

We are preparing general release of drop rules for metric aggregate attributes, so this PR removes the beta-specific blurb.

## Type of change

- [X] This change requires a documentation update

## Checklist:

- [X] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] I have made corresponding changes to the documentation