### PR TITLE
docs: fix broken link to terraform docs

### DIFF
--- a/website/docs/guides/getting_started.html.markdown
+++ b/website/docs/guides/getting_started.html.markdown
@@ -230,4 +230,4 @@ You can also run `terraform destroy` to tear down your resources if that's ever 
 
 [user_api_key]: https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key
 [user_api_key_via_nerdgraph]: https://docs.newrelic.com/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys
-[terraform_data_sources]: https://www.terraform.io/docs/configuration/data-sources.html
+[terraform_data_sources]: https://www.terraform.io/language/data-sources


### PR DESCRIPTION
# Description

This change fixes a broken link in the docs

## Type of change

- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation