### PR TITLE
docs: remove beta info ahead of general release

### DIFF
--- a/website/docs/r/nrql_drop_rule.html.markdown
+++ b/website/docs/r/nrql_drop_rule.html.markdown
@@ -14,9 +14,6 @@ Use this resource to create, and delete New Relic NRQL Drop Rules.
 <br><br>
 Before upgrading to version 2.0.0 or later, it is recommended to upgrade to the most recent 1.x version of the provider and ensure that your environment successfully runs `terraform plan` without unexpected changes.
 
--> **Drop attributes on dimensional metric rollups is in preview**
-Please contact your account team or fill in this [form](https://forms.gle/FGPZpy2y1zdSN9dn9) if you'd like to enroll your account. The feature is subject to change, and more information can be found in [the docs](https://docs.newrelic.com/docs/data-apis/manage-data/drop-data-using-nerdgraph/#drop-attributes-on-dimensional-metric-rollups).
-
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
# Description

We are preparing general release of drop rules for metric aggregate attributes, so this PR removes the beta-specific blurb.

- [X] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [X] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] I have made corresponding changes to the documentation