### PR TITLE
feat(Alerts): deprecate nrql condition value_function, sum, single_value

### DIFF
--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -244,12 +244,14 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 			// between new:old and old:new is handled via maps in structures file.
 			// Conflicts with `baseline_direction` when using NerdGraph.
 			"value_function": {
+				Deprecated:   "'value_function' is deprecated.  Remove this field and condition will evaluate as 'single_value' by default.  To replicate 'sum' behavior, use 'slide_by'.",
 				Type:         schema.TypeString,
 				Optional:     true,
-				Description:  "Valid values are: 'single_value' or 'sum'",
+				Description:  "Values are: 'single_value' (deprecated) or 'sum' (deprecated)",
 				ValidateFunc: validation.StringInSlice([]string{"single_value", "sum"}, true),
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return strings.EqualFold(old, new) // Case fold this attribute when diffing
+					// If a value is not provided and the condition uses the default value (single_value), don't show a diff
+					return (strings.EqualFold(old, "SINGLE_VALUE") && new == "") || strings.EqualFold(old, new)
 				},
 			},
 			"account_id": {

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -529,6 +529,92 @@ func TestAccNewRelicNrqlAlertCondition_RevertToDeprecatedSinceValue(t *testing.T
 	})
 }
 
+func TestAccNewRelicNrqlAlertCondition_StaticConditionOptionalValueFunction(t *testing.T) {
+	resourceName := "newrelic_nrql_alert_condition.foo"
+	rName := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
+		Steps: []resource.TestStep{
+			// Test: Create (NerdGraph) static condition without value function
+			{
+				Config: testAccNewRelicNrqlAlertConditionStaticNoValueFunctionNerdGraphConfig(
+					rName,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),
+				),
+			},
+			// Test: Update (NerdGraph) static condition to explicitly set value function
+			{
+				Config: testAccNewRelicNrqlAlertConditionStaticWithValueFunctionNerdGraphConfig(
+					rName,
+					"single_value",
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNewRelicNrqlAlertCondition_StaticConditionConvertSumToSlideBy(t *testing.T) {
+	resourceName := "newrelic_nrql_alert_condition.foo"
+	rName := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
+		Steps: []resource.TestStep{
+			// Test: Create (NerdGraph) static condition with sum value function
+			{
+				Config: testAccNewRelicNrqlAlertConditionStaticWithValueFunctionNerdGraphConfig(
+					rName,
+					"sum",
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),
+				),
+			},
+			// Test: Update (NerdGraph) static condition to remove value function and use slide by instead
+			{
+				Config: testAccNewRelicNrqlAlertConditionStaticWithSlideByNerdGraphConfig(
+					rName,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNewRelicNrqlAlertCondition_StaticConditionSlideByNoValueFunction(t *testing.T) {
+	resourceName := "newrelic_nrql_alert_condition.foo"
+	rName := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
+		Steps: []resource.TestStep{
+			// Test: Create (NerdGraph) static condition with slide by and no value function
+			{
+				Config: testAccNewRelicNrqlAlertConditionStaticWithSlideByNerdGraphConfig(
+					rName,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckNewRelicNrqlAlertConditionDestroy(s *terraform.State) error {
 	providerConfig := testAccProvider.Meta().(*ProviderConfig)
 	client := providerConfig.NewClient
@@ -1035,4 +1121,118 @@ resource "newrelic_nrql_alert_condition" "foo" {
 	%[4]s
 }
 `, name, evaluationOffset, duration, conditionalAttrs, aggregationWindow)
+}
+
+func testAccNewRelicNrqlAlertConditionStaticNoValueFunctionNerdGraphConfig(
+	name string,
+) string {
+	return fmt.Sprintf(`
+resource "newrelic_alert_policy" "foo" {
+	name = "tf-test-%[1]s"
+}
+
+resource "newrelic_nrql_alert_condition" "foo" {
+	policy_id   = newrelic_alert_policy.foo.id
+
+	name                           = "tf-test-%[1]s"
+	type                           = "static"
+	runbook_url                    = "https://foo.example.com"
+	enabled                        = false
+	description                    = "test description"
+	violation_time_limit_seconds   = 3600
+	close_violations_on_expiration = true
+	open_violation_on_expiration   = true
+	expiration_duration            = 120
+ 	aggregation_delay              = 120
+	aggregation_method             = "event_flow"
+
+	nrql {
+		query             = "SELECT uniqueCount(hostname) FROM ComputeSample"
+	}
+
+	critical {
+    operator              = "above"
+    threshold             = 0
+		threshold_duration    = 120
+		threshold_occurrences = "ALL"
+	}
+}
+`, name)
+}
+
+func testAccNewRelicNrqlAlertConditionStaticWithValueFunctionNerdGraphConfig(
+	name string,
+	valueFunction string,
+) string {
+	return fmt.Sprintf(`
+resource "newrelic_alert_policy" "foo" {
+	name = "tf-test-%[1]s"
+}
+
+resource "newrelic_nrql_alert_condition" "foo" {
+	policy_id   = newrelic_alert_policy.foo.id
+
+	name                           = "tf-test-%[1]s"
+	type                           = "static"
+	runbook_url                    = "https://foo.example.com"
+	enabled                        = false
+	description                    = "test description"
+	violation_time_limit_seconds   = 3600
+	close_violations_on_expiration = true
+	open_violation_on_expiration   = true
+	expiration_duration            = 120
+ 	aggregation_delay              = 120
+	aggregation_method             = "event_flow"
+	value_function 				   = "%[2]s"
+
+	nrql {
+		query             = "SELECT uniqueCount(hostname) FROM ComputeSample"
+	}
+
+	critical {
+    operator              = "above"
+    threshold             = 0
+		threshold_duration    = 120
+		threshold_occurrences = "AT_LEAST_ONCE"
+	}
+}
+`, name, valueFunction)
+}
+
+func testAccNewRelicNrqlAlertConditionStaticWithSlideByNerdGraphConfig(
+	name string,
+) string {
+	return fmt.Sprintf(`
+resource "newrelic_alert_policy" "foo" {
+	name = "tf-test-%[1]s"
+}
+
+resource "newrelic_nrql_alert_condition" "foo" {
+	policy_id   = newrelic_alert_policy.foo.id
+
+	name                           = "tf-test-%[1]s"
+	type                           = "static"
+	runbook_url                    = "https://foo.example.com"
+	enabled                        = false
+	description                    = "test description"
+	violation_time_limit_seconds   = 3600
+	close_violations_on_expiration = true
+	open_violation_on_expiration   = true
+	expiration_duration            = 120
+ 	aggregation_delay              = 120
+	aggregation_method             = "event_flow"
+	slide_by					   = 30
+
+	nrql {
+		query             = "SELECT uniqueCount(hostname) FROM ComputeSample"
+	}
+
+	critical {
+    operator              = "above"
+    threshold             = 0
+		threshold_duration    = 120
+		threshold_occurrences = "ALL"
+	}
+}
+`, name)
 }

--- a/newrelic/structures_newrelic_nrql_alert_condition.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition.go
@@ -76,8 +76,6 @@ func expandNrqlAlertConditionCreateInput(d *schema.ResourceData) (*alerts.NrqlCo
 		if attr, ok := d.GetOk("value_function"); ok {
 			valFn := alerts.NrqlConditionValueFunction(strings.ToUpper(attr.(string)))
 			input.ValueFunction = &valFn
-		} else {
-			return nil, fmt.Errorf("attribute `%s` is required for nrql alert conditions of type `%+v`", "value_function", conditionType)
 		}
 	}
 
@@ -169,7 +167,7 @@ func expandNrqlAlertConditionUpdateInput(d *schema.ResourceData) (*alerts.NrqlCo
 			valFn := alerts.NrqlConditionValueFunction(strings.ToUpper(attr.(string)))
 			input.ValueFunction = &valFn
 		} else {
-			return nil, fmt.Errorf("attribute `%s` is required for nrql alert conditions of type `%+v`", "value_function", conditionType)
+			input.ValueFunction = &alerts.NrqlConditionValueFunctions.SingleValue
 		}
 	}
 

--- a/newrelic/structures_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition_test.go
@@ -79,14 +79,6 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 				BaselineDirection: &alerts.NrqlBaselineDirections.LowerOnly,
 			},
 		},
-		"static condition, requires value_function attr": {
-			Data: map[string]interface{}{
-				"nrql": []interface{}{nrql},
-				"type": "static",
-			},
-			ExpectErr:    true,
-			ExpectReason: "attribute `value_function` is required for nrql alert conditions of type `static`",
-		},
 		"static condition, has value_function attr": {
 			Data: map[string]interface{}{
 				"nrql":           []interface{}{nrql},

--- a/website/docs/d/entity.html.markdown
+++ b/website/docs/d/entity.html.markdown
@@ -38,7 +38,6 @@ resource "newrelic_nrql_alert_condition" "foo" {
   description                  = "Alert when transactions are taking too long"
   runbook_url                  = "https://www.example.com"
   enabled                      = true
-  value_function               = "single_value"
   violation_time_limit_seconds = 3600
 
   nrql {

--- a/website/docs/guides/getting_started.html.markdown
+++ b/website/docs/guides/getting_started.html.markdown
@@ -111,7 +111,6 @@ resource "newrelic_nrql_alert_condition" "foo" {
   description                  = "Alert when transactions are taking too long"
   runbook_url                  = "https://www.example.com"
   enabled                      = true
-  value_function               = "single_value"
   violation_time_limit_seconds = 3600
 
   nrql {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -111,7 +111,6 @@ resource "newrelic_nrql_alert_condition" "foo" {
   description                  = "Alert when transactions are taking too long"
   runbook_url                  = "https://www.example.com"
   enabled                      = true
-  value_function               = "single_value"
   violation_time_limit_seconds = 3600
 
   nrql {

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -31,7 +31,6 @@ resource "newrelic_nrql_alert_condition" "foo" {
   runbook_url                    = "https://www.example.com"
   enabled                        = true
   violation_time_limit_seconds   = 3600
-  value_function                 = "single_value"
   fill_option                    = "static"
   fill_value                     = 1.0
   aggregation_window             = 60
@@ -79,7 +78,7 @@ The following arguments are supported:
 - `term` - (Optional) **DEPRECATED** Use `critical`, and `warning` instead.  A list of terms for this condition. See [Terms](#terms) below for details.
 - `critical` - (Required) A list containing the `critical` threshold values. See [Terms](#terms) below for details.
 - `warning` - (Optional) A list containing the `warning` threshold values. See [Terms](#terms) below for details.
-- `value_function` - (Required if `type` is `static`, omit when `type` is `baseline` or `outlier` ) Possible values are `single_value`, `sum` (case insensitive).
+- `value_function` - (Optional if `type` is `static`, omit when `type` is `baseline` or `outlier` ) **DEPRECATED** Use `signal.slide_by` instead.
 - `expected_groups` - (Optional) Number of expected groups when using `outlier` detection.
 - `open_violation_on_group_overlap` - (Optional) Whether or not to trigger a violation when groups overlap. Set to `true` if you want to trigger a violation when groups overlap. This argument is only applicable in `outlier` conditions.
 - `ignore_overlap` - (Optional) **DEPRECATED:** Use `open_violation_on_group_overlap` instead, but use the inverse value of your boolean - e.g. if `ignore_overlap = false`, use `open_violation_on_group_overlap = true`. This argument sets whether to trigger a violation when groups overlap. If set to `true` overlapping groups will not trigger a violation. This argument is only applicable in `outlier` conditions.


### PR DESCRIPTION
# Description

https://newrelic.atlassian.net/browse/AINTER-8206

Corresponding Go Client ticket https://github.com/newrelic/newrelic-client-go/pull/850

**This PR requires a MINOR release and should ensure the changelog has an entry noting NRQL condition  deprecation of fields `value_function`, `sum`, and `single_value`.**

This PR should:
- Make nrql condition `value_function` optional for create and update
- Add deprecation warning messages for `sum`, `single_value`, and `value_function`
- Update documentation
- Ensure the changelog has an entry noting the deprecation
- Be released as a MINOR release

Deprecation warning example:
<img width="1091" alt="image" src="https://user-images.githubusercontent.com/26093145/155437914-08000d4c-b360-444d-bef4-ec35a7af74ee.png">


## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

I added integration tests.  Also, please manually test.  See below.

To manually test:
- Create a static condition without a value function (the condition-api will default to `single_value` when it receives no value function)
- Update that condition to add a `single_value` value function.  Note that there are no changes because `single_value` was already set in the condition api.  There should be no errors.
- Update that condition to add a `sum` value function.  You should be able to successfully to this. 

Then try:
- Create a static condition with a `sum` value function
- Update that condition to remove the value function and add slide by:
<img width="360" alt="image" src="https://user-images.githubusercontent.com/26093145/155441181-09daf2af-f931-40a3-af0d-a1de81746908.png">

Also please:
- Ensure you see the deprecation message for value function
- Confirm documentation reflects deprecation and optional value function

## Implementation notes:
- Left `omitEmpty` in Go Client update struct
- Did not add `computed` on Provider update struct
- Added a special line that in the absence of a value function, we send “single value” by default in the expand method on update.  This is necessary because we could not remove `omitEmpty` from the client update struct.
- Added a diff suppress function so that if there is no value_function configured and the API returns “single_value” we don’t generate a diff
- Removed warning that compelled a user to include a value_function when creating static conditions
