### PR TITLE
Fix broken V2 migration links

### DIFF
--- a/website/docs/d/entity.html.markdown
+++ b/website/docs/d/entity.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Use this data source to get information about a specific entity in New Relic One that already exists. More information on Terraform's data sources can be found [here](https://www.terraform.io/docs/configuration/data-sources.html).
 
--> **IMPORTANT!** Version 2.0.0 of the New Relic Terraform Provider introduces some [additional requirements](/docs/providers/newrelic/index.html) for configuring the provider.
+-> **IMPORTANT!** Version 2.0.0 of the New Relic Terraform Provider introduces some [additional requirements](/providers/newrelic/newrelic/latest/docs/guides/migration_guide_v2) for configuring the provider.
 <br><br>
 Before upgrading to version 2.0.0 or later, it is recommended to upgrade to the most recent 1.x version of the provider and ensure that your environment successfully runs `terraform plan` without unexpected changes.
 

--- a/website/docs/r/alert_muting_rule.html.markdown
+++ b/website/docs/r/alert_muting_rule.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Use this resource to create a muting rule for New Relic Alerts violations.
 
--> **IMPORTANT!** Version 2.0.0 of the New Relic Terraform Provider introduces some [additional requirements](/docs/providers/newrelic/index.html) for configuring the provider.
+-> **IMPORTANT!** Version 2.0.0 of the New Relic Terraform Provider introduces some [additional requirements](/providers/newrelic/newrelic/latest/docs/guides/migration_guide_v2) for configuring the provider.
 <br><br>
 Before upgrading to version 2.0.0 or later, it is recommended to upgrade to the most recent 1.x version of the provider and ensure that your environment successfully runs `terraform plan` without unexpected changes.
 

--- a/website/docs/r/entity_tags.html.markdown
+++ b/website/docs/r/entity_tags.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Use this resource to create, update, and delete tags for a New Relic One entity.
 
--> **IMPORTANT!** Version 2.0.0 of the New Relic Terraform Provider introduces some [additional requirements](/docs/providers/newrelic/index.html) for configuring the provider.
+-> **IMPORTANT!** Version 2.0.0 of the New Relic Terraform Provider introduces some [additional requirements](/providers/newrelic/newrelic/latest/docs/guides/migration_guide_v2) for configuring the provider.
 <br><br>
 Before upgrading to version 2.0.0 or later, it is recommended to upgrade to the most recent 1.x version of the provider and ensure that your environment successfully runs `terraform plan` without unexpected changes.
 

--- a/website/docs/r/events_to_metrics_rule.html.markdown
+++ b/website/docs/r/events_to_metrics_rule.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Use this resource to create, update, and delete New Relic Events to Metrics rules.
 
--> **IMPORTANT!** Version 2.0.0 of the New Relic Terraform Provider introduces some [additional requirements](/docs/providers/newrelic/index.html) for configuring the provider.
+-> **IMPORTANT!** Version 2.0.0 of the New Relic Terraform Provider introduces some [additional requirements](/providers/newrelic/newrelic/latest/docs/guides/migration_guide_v2) for configuring the provider.
 <br><br>
 Before upgrading to version 2.0.0 or later, it is recommended to upgrade to the most recent 1.x version of the provider and ensure that your environment successfully runs `terraform plan` without unexpected changes.
 

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Use this resource to create and manage NRQL alert conditions in New Relic.
 
--> **IMPORTANT!** Version 2.0.0 of the New Relic Terraform Provider introduces some [additional requirements](/docs/providers/newrelic/index.html) for configuring the provider.
+-> **IMPORTANT!** Version 2.0.0 of the New Relic Terraform Provider introduces some [additional requirements](/providers/newrelic/newrelic/latest/docs/guides/migration_guide_v2) for configuring the provider.
 <br><br>
 Before upgrading to version 2.0.0 or later, it is recommended to upgrade to the most recent 1.x version of the provider and ensure that your environment successfully runs `terraform plan` without unexpected changes.
 

--- a/website/docs/r/nrql_drop_rule.html.markdown
+++ b/website/docs/r/nrql_drop_rule.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Use this resource to create, and delete New Relic NRQL Drop Rules.
 
--> **IMPORTANT!** Version 2.0.0 of the New Relic Terraform Provider introduces some [additional requirements](/docs/providers/newrelic/index.html) for configuring the provider.
+-> **IMPORTANT!** Version 2.0.0 of the New Relic Terraform Provider introduces some [additional requirements](/providers/newrelic/newrelic/latest/docs/guides/migration_guide_v2) for configuring the provider.
 <br><br>
 Before upgrading to version 2.0.0 or later, it is recommended to upgrade to the most recent 1.x version of the provider and ensure that your environment successfully runs `terraform plan` without unexpected changes.
 


### PR DESCRIPTION
# Description

The links in the docs are broken: https://registry.terraform.io/docs/providers/newrelic/index. The PR links to migration V2 guid correctly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.


- [x] I have made corresponding changes to the documentation

## How to test this change?

Via testing new link: https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/migration_guide_v2
