### PR TITLE
add account id to config

### DIFF
--- a/newrelic/config.go
+++ b/newrelic/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	InsightsQueryURL     string
 	NerdGraphAPIURL      string
 	SyntheticsAPIURL     string
+	AccountId			 string
 	userAgent            string
 }
 
@@ -92,6 +93,10 @@ func (c *Config) Client() (*nr.NewRelic, error) {
 
 	if c.NerdGraphAPIURL != "" {
 		options = append(options, nr.ConfigNerdGraphBaseURL(c.NerdGraphAPIURL))
+	}
+
+	if c.AccountId != "" {
+		options = append(options, nr.ConfigAccountId(c.AccountId))
 	}
 
 	client, err := nr.New(options...)

--- a/newrelic/provider.go
+++ b/newrelic/provider.go
@@ -190,6 +190,7 @@ func providerConfigure(data *schema.ResourceData, terraformVersion string) (inte
 		userAgent:            userAgent,
 		InsecureSkipVerify:   data.Get("insecure_skip_verify").(bool),
 		CACertFile:           data.Get("cacert_file").(string),
+		AccountId: 			  strconv.Itoa(accountID),
 	}
 	log.Println("[INFO] Initializing newrelic-client-go")
 


### PR DESCRIPTION
Experimenting adding x-account-id header addressed in the newrelic-client-go issue. https://github.com/newrelic/newrelic-client-go/issues/697

Depends on https://github.com/newrelic/newrelic-client-go/pull/853

Hopefully pave a way to address this [terraform-provider-newrelic](https://github.com/newrelic/terraform-provider-newrelic/issues/1645) issue


Testing with the following resources. Note the API Key is from a parent account, and the account id is a child of that parent account.

```
variable "nr_api_key" {
  type = string
  description = "your new relic API key"
}

variable "account_id" {
  type = number
  description = "your new relic account"
}

variable "region" {
  type = string
  description = "the region you're using."
}

provider newrelic {
  api_key = var.nr_api_key
  account_id = var.account_id
  region = var.region
}
resource "newrelic_alert_policy" "alex_terraform_test_policy" {
  name = "Cross account policy"
}

resource "newrelic_nrql_alert_condition" "alex_terraform_test_condition" {
  name = "Cross account condition"
  policy_id = newrelic_alert_policy.alex_terraform_test_policy.id
  nrql {
    query = "SELECT count(*) FROM Transaction"
  }
  critical {
    operator = "above"
    threshold = 0
    threshold_duration = 60
    threshold_occurrences = "all"
  }
  aggregation_window=60
  slide_by=30
  close_violations_on_expiration = true
  value_function = "single_value"
  violation_time_limit_seconds = 86400
  aggregation_method = "event_flow"
  aggregation_delay = 120
  type = "static"
  expiration_duration = 180
}

resource "newrelic_alert_channel" "alex_terraform_test_alert_channel" {
  name = "Cross acocunt alert email channel"
  type = "email"

  config {
    recipients              = "foo@bar.com"
    include_json_attachment = "1"
  }
}
# Applies the created channels above to the alert policy
# referenced at the top of the config.
resource "newrelic_alert_policy_channel" "alex_terraform_test_alert_policy_channel" {
  policy_id  = newrelic_alert_policy.alex_terraform_test_policy.id
  channel_ids = [
    newrelic_alert_channel.alex_terraform_test_alert_channel.id,
  ]
}

```
