### PR TITLE
Handle setting linked_entity_guids

### DIFF
--- a/newrelic/structures_newrelic_one_dashboard.go
+++ b/newrelic/structures_newrelic_one_dashboard.go
@@ -860,8 +860,16 @@ func findDashboardWidgetFilterCurrentDashboard(d *schema.ResourceData) ([]interf
 					w := widget.(map[string]interface{})
 					if v, ok := w["filter_current_dashboard"]; ok && v.(bool) {
 
-						if l, ok := w["linked_entity_guids"]; ok && len(l.([]interface{})) > 0 {
-							return nil, fmt.Errorf("err: filter_current_dashboard can't be set if linked_entity_guids is configured")
+						if l, ok := w["linked_entity_guids"]; ok && len(l.([]interface{})) > 1 {
+							return nil, fmt.Errorf("filter_current_dashboard can't be set if linked_entity_guids is configured")
+						}
+
+						if l, ok := w["linked_entity_guids"]; ok && len(l.([]interface{})) == 1 {
+							for _, le := range l.([]interface{}) {
+								if le.(string) != p["guid"] {
+									return nil, fmt.Errorf("filter_current_dashboard can't be set if linked_entity_guids is configured")
+								}
+							}
 						}
 
 						unqWidget := make(map[string]interface{})


### PR DESCRIPTION
# Description

This change handles reading `linked_entity_guids` after they've been set through `filter_current_dashboard`

Fixes #1494 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

Use the following HCL config

```
resource "newrelic_one_dashboard" "default" {
  name        = "Ticket 1494"
  description = "Managed via Terraform"

  page {
    name        = "Simple Page"
    description = "Simple Page"

    # Pie charts
    widget_pie {
      title                    = "Filter Example"
      row                      = 1
      column                   = 1
      width                    = 5
      height                   = 5
      linked_entity_guids      = null
      filter_current_dashboard = true
      nrql_query {
        query = "FROM K8sClusterSample select uniqueCount(hostname) FACET clusterName limit max since 5 minutes ago"
      }
    }

    widget_pie {
      title                    = "Target Example"
      row                      = 1
      column                   = 6
      width                    = 7
      height                   = 5
      linked_entity_guids      = null
      filter_current_dashboard = false
      nrql_query {
        query = "FROM K8sClusterSample select uniqueCount(hostname) FACET instanceType limit max since 5 minutes ago"
      }
    }
  }
}
```

1. Terraform apply
2. Now change the NRQL query in a pie widget from since `5 minutes ago` to since `10 minutes ago`
3. No error should occur
