### PR TITLE
fix(newrelic_cloud): only set Id after error check

### DIFF
--- a/newrelic/resource_newrelic_cloud_aws_link_account.go
+++ b/newrelic/resource_newrelic_cloud_aws_link_account.go
@@ -79,7 +79,9 @@ func resourceNewRelicCloudAwsAccountLinkCreate(ctx context.Context, d *schema.Re
 			}
 		}
 
-		d.SetId(strconv.Itoa(cloudLinkAccountPayload.LinkedAccounts[0].ID))
+		if len(cloudLinkAccountPayload.LinkedAccounts) > 0 {
+			d.SetId(strconv.Itoa(cloudLinkAccountPayload.LinkedAccounts[0].ID))
+		}
 
 		return nil
 	})

--- a/newrelic/resource_newrelic_cloud_azure_link_account.go
+++ b/newrelic/resource_newrelic_cloud_azure_link_account.go
@@ -79,11 +79,12 @@ func resourceNewRelicCloudAzureLinkAccountCreate(ctx context.Context, d *schema.
 		}
 	}
 
-	d.SetId(strconv.Itoa(cloudLinkAccountPayload.LinkedAccounts[0].ID))
-
 	if len(diags) > 0 {
 		return diags
 	}
+
+	d.SetId(strconv.Itoa(cloudLinkAccountPayload.LinkedAccounts[0].ID))
+
 	return nil
 }
 

--- a/newrelic/resource_newrelic_cloud_gcp_link_account.go
+++ b/newrelic/resource_newrelic_cloud_gcp_link_account.go
@@ -61,12 +61,12 @@ func resourceNewRelicCloudGcpLinkAccountCreate(ctx context.Context, d *schema.Re
 		}
 	}
 
-	//Storing the linked account id using setId func after creating the resource.
-	d.SetId(strconv.Itoa(cloudLinkAccountPayload.LinkedAccounts[0].ID))
-
 	if len(diags) > 0 {
 		return diags
 	}
+
+	// Storing the linked account id using setId func after creating the resource.
+	d.SetId(strconv.Itoa(cloudLinkAccountPayload.LinkedAccounts[0].ID))
 
 	return nil
 }


### PR DESCRIPTION
# Description

Possible fix for #1709

We should only set the ID if we haven't received an error back from the API. My only concern here is that the API could return an error, but still create the resource, leaving Terraform in a bad state. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.
