### PR TITLE
fix: Allow 0 values for aggregation_delay

### DIFF
--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -338,7 +338,7 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 				},
 			},
 			"aggregation_delay": {
-				Type:         schema.TypeInt,
+				Type:         schema.TypeString,
 				Optional:     true,
 				Description:  "How long we wait for data that belongs in each aggregation window. Depending on your data, a longer delay may increase accuracy but delay notifications. Use aggregationDelay with the EVENT_FLOW and CADENCE aggregation methods.",
 				RequiredWith: []string{"aggregation_method"},
@@ -354,7 +354,7 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 				},
 			},
 			"aggregation_timer": {
-				Type:         schema.TypeInt,
+				Type:         schema.TypeString,
 				Optional:     true,
 				Description:  "How long we wait after each data point arrives to make sure we've processed the whole batch. Use aggregationTimer with the EVENT_TIMER aggregation method.",
 				RequiredWith: []string{"aggregation_method"},

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -413,6 +413,44 @@ func TestAccNewRelicNrqlAlertCondition_NerdGraphStreamingMethods(t *testing.T) {
 	})
 }
 
+func TestAccNewRelicNrqlAlertCondition_AggregationDelayZero(t *testing.T) {
+	resourceName := "newrelic_nrql_alert_condition.foo"
+	rName := acctest.RandString(5)
+	timer := "null"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
+		Steps: []resource.TestStep{
+			// Test: Create (NerdGraph) condition with streaming method cadence
+			{
+				Config: testAccNewRelicNrqlAlertConditionStreamingMethodsNerdGraphConfig(
+					rName,
+					"cadence",
+					"0",
+					timer,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),
+				),
+			},
+			// Test: Update (NerdGraph) condition with streaming method event_timer
+			{
+				Config: testAccNewRelicNrqlAlertConditionStreamingMethodsNerdGraphConfig(
+					rName,
+					"event_flow",
+					"0",
+					timer,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),
+				),
+			},
+		},
+	})
+}
+
 func TestAccNewRelicNrqlAlertCondition_NerdGraphNrqlEvaluationOffset(t *testing.T) {
 	resourceName := "newrelic_nrql_alert_condition.foo"
 	rName := acctest.RandString(5)

--- a/newrelic/structures_newrelic_nrql_alert_condition.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition.go
@@ -478,15 +478,19 @@ func expandCreateSignal(d *schema.ResourceData) (*alerts.AlertsNrqlConditionCrea
 	}
 
 	if aggregationDelay, ok := d.GetOk("aggregation_delay"); ok {
-		v := aggregationDelay.(int)
-
-		signal.AggregationDelay = &v
+		value := aggregationDelay.(string)
+		if value != "" {
+			v, _ := strconv.Atoi(value)
+			signal.AggregationDelay = &v
+		}
 	}
 
 	if aggregationTimer, ok := d.GetOk("aggregation_timer"); ok {
-		v := aggregationTimer.(int)
-
-		signal.AggregationTimer = &v
+		value := aggregationTimer.(string)
+		if value != "" {
+			v, _ := strconv.Atoi(value)
+			signal.AggregationTimer = &v
+		}
 	}
 
 	return &signal, nil
@@ -524,15 +528,19 @@ func expandUpdateSignal(d *schema.ResourceData) (*alerts.AlertsNrqlConditionUpda
 	}
 
 	if aggregationDelay, ok := d.GetOk("aggregation_delay"); ok {
-		v := aggregationDelay.(int)
-
-		signal.AggregationDelay = &v
+		value := aggregationDelay.(string)
+		if value != "" {
+			v, _ := strconv.Atoi(value)
+			signal.AggregationDelay = &v
+		}
 	}
 
 	if aggregationTimer, ok := d.GetOk("aggregation_timer"); ok {
-		v := aggregationTimer.(int)
-
-		signal.AggregationTimer = &v
+		value := aggregationTimer.(string)
+		if value != "" {
+			v, _ := strconv.Atoi(value)
+			signal.AggregationTimer = &v
+		}
 	}
 
 	return &signal, nil
@@ -685,13 +693,15 @@ func flattenSignal(d *schema.ResourceData, signal *alerts.AlertsNrqlConditionSig
 	}
 
 	if signal.AggregationDelay != nil {
-		if err := d.Set("aggregation_delay", signal.AggregationDelay); err != nil {
+		delay := strconv.Itoa(*signal.AggregationDelay)
+		if err := d.Set("aggregation_delay", delay); err != nil {
 			return fmt.Errorf("[DEBUG] Error setting nrql alert condition `aggregation_delay`: %v", err)
 		}
 	}
 
 	if signal.AggregationTimer != nil {
-		if err := d.Set("aggregation_timer", signal.AggregationTimer); err != nil {
+		timer := strconv.Itoa(*signal.AggregationTimer)
+		if err := d.Set("aggregation_timer", timer); err != nil {
 			return fmt.Errorf("[DEBUG] Error setting nrql alert condition `aggregation_timer`: %v", err)
 		}
 	}

--- a/newrelic/structures_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition_test.go
@@ -290,12 +290,25 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 		"aggregation delay not nil": {
 			Data: map[string]interface{}{
 				"nrql":              []interface{}{nrql},
-				"aggregation_delay": 60,
+				"aggregation_delay": "60",
 			},
 			Expanded: &alerts.NrqlConditionCreateInput{
 				NrqlConditionCreateBase: alerts.NrqlConditionCreateBase{
 					Signal: &alerts.AlertsNrqlConditionCreateSignal{
 						AggregationDelay: &[]int{60}[0],
+					},
+				},
+			},
+		},
+		"aggregation delay 0": {
+			Data: map[string]interface{}{
+				"nrql":              []interface{}{nrql},
+				"aggregation_delay": "0",
+			},
+			Expanded: &alerts.NrqlConditionCreateInput{
+				NrqlConditionCreateBase: alerts.NrqlConditionCreateBase{
+					Signal: &alerts.AlertsNrqlConditionCreateSignal{
+						AggregationDelay: &[]int{0}[0],
 					},
 				},
 			},
@@ -314,7 +327,7 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 		"aggregation timer not nil": {
 			Data: map[string]interface{}{
 				"nrql":              []interface{}{nrql},
-				"aggregation_timer": 60,
+				"aggregation_timer": "60",
 			},
 			Expanded: &alerts.NrqlConditionCreateInput{
 				NrqlConditionCreateBase: alerts.NrqlConditionCreateBase{
@@ -552,8 +565,8 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 			require.Equal(t, "static", d.Get("fill_option").(string))
 			require.Equal(t, 0.0, d.Get("fill_value").(float64))
 			require.Equal(t, "cadence", d.Get("aggregation_method").(string))
-			require.Equal(t, 60, d.Get("aggregation_delay").(int))
-			require.Equal(t, 60, d.Get("aggregation_timer").(int))
+			require.Equal(t, "60", d.Get("aggregation_delay").(string))
+			require.Equal(t, "60", d.Get("aggregation_timer").(string))
 
 		case alerts.NrqlConditionTypes.Static:
 			require.Equal(t, string(alerts.NrqlConditionValueFunctions.Sum), d.Get("value_function").(string))
@@ -566,8 +579,8 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 			require.Equal(t, "last_value", d.Get("fill_option").(string))
 			require.Zero(t, d.Get("fill_value").(float64))
 			require.Equal(t, "cadence", d.Get("aggregation_method").(string))
-			require.Equal(t, 60, d.Get("aggregation_delay").(int))
-			require.Equal(t, 60, d.Get("aggregation_timer").(int))
+			require.Equal(t, "60", d.Get("aggregation_delay").(string))
+			require.Equal(t, "60", d.Get("aggregation_timer").(string))
 
 		case alerts.NrqlConditionTypes.Outlier:
 			require.Equal(t, 2, d.Get("expected_groups").(int))
@@ -581,8 +594,8 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 			require.Equal(t, "none", d.Get("fill_option").(string))
 			require.Zero(t, d.Get("fill_value").(float64))
 			require.Equal(t, "cadence", d.Get("aggregation_method").(string))
-			require.Equal(t, 60, d.Get("aggregation_delay").(int))
-			require.Equal(t, 60, d.Get("aggregation_timer").(int))
+			require.Equal(t, "60", d.Get("aggregation_delay").(string))
+			require.Equal(t, "60", d.Get("aggregation_timer").(string))
 		}
 	}
 }


### PR DESCRIPTION
# Description

Fixes a bug where setting the `aggregation_delay` to 0 causes create/update to fail because of how Go handles 0 value ints. This was implemented by changing the field to a string type in TF and converting back and forth to int as needed.

Fixes #1655 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.

- [ ] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Create a NRQL Alert Condition using either cadence or event_flow aggregation method
- Set the aggregation_delay to 0
- terraform apply
