### PR TITLE
fix(docs): removed two accountID warnings that were incorrect

### DIFF
--- a/website/docs/r/alert_channel.html.markdown
+++ b/website/docs/r/alert_channel.html.markdown
@@ -35,10 +35,6 @@ The following arguments are supported:
   * `type` - (Required) The type of channel.  One of: `email`, `slack`, `opsgenie`, `pagerduty`, `victorops`, or `webhook`.
   * `config` - (Optional) A nested block that describes an alert channel configuration.  Only one config block is permitted per alert channel definition.  See [Nested config blocks](#nested-config-blocks) below for details.
 
-```
-Warning: This resource will use the account ID linked to your API key. At the moment it is not possible to dynamically set the account ID.
-```
-
 ### Nested `config` blocks
 
 Each alert channel type supports a specific set of arguments for the `config` block:

--- a/website/docs/r/alert_policy_channel.html.markdown
+++ b/website/docs/r/alert_policy_channel.html.markdown
@@ -62,10 +62,6 @@ The following arguments are supported:
 - `policy_id` - (Required) The ID of the policy.
 - `channel_ids` - (Required) Array of channel IDs to apply to the specified policy. We recommended sorting channel IDs in ascending order to avoid drift your Terraform state.
 
-```
-Warning: This resource will use the account ID linked to your API key. At the moment it is not possible to dynamically set the account ID.
-```
-
 ## Import
 
 Alert policy channels can be imported using the following notation: `<policyID>:<channelID>:<channelID>`, e.g.


### PR DESCRIPTION
# Description

Fixed two incorrect warnings for accountID. In these two cases the accountID can be set in the resource. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

