### PR TITLE
fix: remove 14 days deprecated option from service levels

### DIFF
--- a/newrelic/resource_newrelic_service_level.go
+++ b/newrelic/resource_newrelic_service_level.go
@@ -182,7 +182,7 @@ func rollingTimeWindowSchema() *schema.Resource {
 				Type:         schema.TypeInt,
 				Required:     true,
 				Description:  "",
-				ValidateFunc: intInSlice([]int{1, 7, 14, 28}),
+				ValidateFunc: intInSlice([]int{1, 7, 28}),
 			},
 			"unit": {
 				Type:         schema.TypeString,

--- a/website/docs/r/service_level.html.markdown
+++ b/website/docs/r/service_level.html.markdown
@@ -85,7 +85,7 @@ All nested `events` blocks support the following common arguments:
   * `target` - (Required) The target of the objective, valid values between `0` and `100`. Up to 5 decimals accepted.
   * `time_window` - (Required) Time window is the period of the objective.
     * `rolling` - (Required) Rolling window.
-      * `count` - (Required) Valid values are `1`, `7`, `14` and `28`.
+      * `count` - (Required) Valid values are `1`, `7` and `28`.
       * `unit` - (Required) The only supported value is `DAY`.
 
 ## Attributes Reference


### PR DESCRIPTION
# Description

Since some time 14 days SLIs are not allowed anymore, this was out of date in the provider, so 14 days was accepted by terraform but then receiving an error when going to the APi.

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.

- [X] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

-