### PR TITLE
fix: Import payload_string when importing webhook channel

### DIFF
--- a/newrelic/structures_newrelic_alert_channel.go
+++ b/newrelic/structures_newrelic_alert_channel.go
@@ -272,6 +272,14 @@ func flattenAlertChannelConfiguration(c *alerts.ChannelConfiguration, d *schema.
 		}
 
 		configResult["payload_string"] = string(h)
+	} else if len(c.Payload) != 0 {
+		h, err := json.Marshal(c.Payload)
+
+		if err != nil {
+			return nil, err
+		}
+
+		configResult["payload_string"] = string(h)
 	}
 
 	return []interface{}{configResult}, nil


### PR DESCRIPTION
# Description

Updating newrelic_alert_channel read to correctly import the payload_string field when importing an Alerts Notification Channel. `payload` and `payload_string` were both previously ignored when importing because neither field was already set on the resource data.

This is always imported as the `payload_string` field because all payloads are valid in the `payload_string`, but more complex payloads are not valid in the `payload` field.

Fixes #1142 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.

- [ ] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [ ] I have performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Create a webhook notification channel and enter a custom payload
- Import this channel into Terraform
- Check terraform state to verify that the payload_string is stored in the state.
