### PR TITLE
fix: Tags resource implicit dependency

### DIFF
--- a/newrelic/resource_newrelic_entity_tags.go
+++ b/newrelic/resource_newrelic_entity_tags.go
@@ -38,6 +38,7 @@ func resourceNewRelicEntityTags() *schema.Resource {
 			"guid": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "The guid of the entity to tag.",
 			},
 			"tag": {


### PR DESCRIPTION
## Description
Very often tags resource is used referencing the dependency (i.e. entity) implicitly. If that entity is re-created, the tags resource doesn't refresh and continues referencing to the old entity GUID.

I believe that the fix should also address the following issue: https://github.com/newrelic/terraform-provider-newrelic/issues/1556

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.