### PR TITLE
fix(one_dashboard): Make limit for bullet widget required

### DIFF
--- a/newrelic/resource_newrelic_one_dashboard.go
+++ b/newrelic/resource_newrelic_one_dashboard.go
@@ -275,7 +275,7 @@ func dashboardWidgetBulletSchemaElem() *schema.Resource {
 
 	s["limit"] = &schema.Schema{
 		Type:        schema.TypeFloat,
-		Optional:    true,
+		Required:    true,
 		Description: "The maximum value for the visualization",
 	}
 

--- a/website/docs/r/one_dashboard.html.markdown
+++ b/website/docs/r/one_dashboard.html.markdown
@@ -136,7 +136,7 @@ Each widget type supports an additional set of arguments:
     * `warning` - (Optional) Threshold above which the displayed value will be styled with a yellow color.
   * `widget_bullet`
     * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql-query-blocks) below for details.
-    * `limit` - (Optional) Visualization limit for the widget.
+    * `limit` - (Required) Visualization limit for the widget.
   * `widget_funnel`
     * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql-query-blocks) below for details.
   * `widget_json`


### PR DESCRIPTION
# Description

There is a mismatch between Terraform's schema and the API. The Dashboards API requires limit while it's optional in Terraform leading to confusion. 

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

- Create a `one_dashboard` resource with a `widget_bullet` type but without a `limit` value.
- Terraform apply

We should see an error that this value is required.
