### PR TITLE
feat: Expose NRQL Condition EntityGUID on conditions

### DIFF
--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -360,6 +360,11 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 					return oldInt == 120 && (newInt == 0) && d.Get("aggregation_method") == "EVENT_TIMER"
 				},
 			},
+			"entity_guid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The unique entity identifier of the dashboard in New Relic.",
+			},
 			// Baseline ONLY
 			"baseline_direction": {
 				Type:          schema.TypeString,

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -363,7 +363,7 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 			"entity_guid": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The unique entity identifier of the dashboard in New Relic.",
+				Description: "The unique entity identifier of the NRQL Condition in New Relic.",
 			},
 			// Baseline ONLY
 			"baseline_direction": {

--- a/newrelic/structures_newrelic_nrql_alert_condition.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition.go
@@ -562,6 +562,7 @@ func flattenNrqlAlertCondition(accountID int, condition *alerts.NrqlAlertConditi
 	_ = d.Set("name", condition.Name)
 	_ = d.Set("runbook_url", condition.RunbookURL)
 	_ = d.Set("enabled", condition.Enabled)
+	_ = d.Set("entity_guid", condition.EntityGUID)
 
 	if conditionType == "baseline" {
 		_ = d.Set("baseline_direction", string(*condition.BaselineDirection))

--- a/newrelic/structures_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/newrelic/newrelic-client-go/pkg/common"
+
 	"github.com/newrelic/newrelic-client-go/pkg/alerts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -476,11 +478,13 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 	}
 	nrqlConditionBaseline.Type = alerts.NrqlConditionTypes.Baseline
 	nrqlConditionBaseline.BaselineDirection = &alerts.NrqlBaselineDirections.LowerOnly
+	nrqlConditionBaseline.EntityGUID = common.EntityGUID("NDAwMzA0fEFPTkRJVElPTnwxNDMzNjc3")
 
 	// Static
 	nrqlConditionStatic := nrqlCondition
 	nrqlConditionStatic.Type = alerts.NrqlConditionTypes.Static
 	nrqlConditionStatic.ValueFunction = &alerts.NrqlConditionValueFunctions.Sum
+	nrqlConditionStatic.EntityGUID = common.EntityGUID("TkRJVElPTnwxNDMzNjc3NDAwMzA0fEFP")
 
 	// Outlier
 	expectedGroups := 2
@@ -496,6 +500,7 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 		AggregationTimer:  &[]int{60}[0],
 	}
 	nrqlConditionOutlier.Expiration = nil
+	nrqlConditionOutlier.EntityGUID = common.EntityGUID("PzA0fEFTnwxNDMzNjc3NDAwMTkRJV0fEFP")
 
 	conditions := []*alerts.NrqlAlertCondition{
 		&nrqlConditionBaseline,
@@ -551,8 +556,6 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 		assert.Equal(t, 660, warningTerms[0].(map[string]interface{})["threshold_duration"])
 		assert.Equal(t, "below", warningTerms[0].(map[string]interface{})["operator"])
 
-		// require.Equal(t, 1, d.Get("critical.threshold").(map[string]interface{}))
-
 		switch condition.Type {
 		case alerts.NrqlConditionTypes.Baseline:
 			require.Equal(t, string(alerts.NrqlBaselineDirections.LowerOnly), d.Get("baseline_direction").(string))
@@ -567,6 +570,7 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 			require.Equal(t, "cadence", d.Get("aggregation_method").(string))
 			require.Equal(t, "60", d.Get("aggregation_delay").(string))
 			require.Equal(t, "60", d.Get("aggregation_timer").(string))
+			require.Equal(t, nrqlConditionBaseline.EntityGUID, common.EntityGUID(d.Get("entity_guid").(string)))
 
 		case alerts.NrqlConditionTypes.Static:
 			require.Equal(t, string(alerts.NrqlConditionValueFunctions.Sum), d.Get("value_function").(string))
@@ -581,6 +585,7 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 			require.Equal(t, "cadence", d.Get("aggregation_method").(string))
 			require.Equal(t, "60", d.Get("aggregation_delay").(string))
 			require.Equal(t, "60", d.Get("aggregation_timer").(string))
+			require.Equal(t, nrqlConditionStatic.EntityGUID, common.EntityGUID(d.Get("entity_guid").(string)))
 
 		case alerts.NrqlConditionTypes.Outlier:
 			require.Equal(t, 2, d.Get("expected_groups").(int))
@@ -596,6 +601,7 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 			require.Equal(t, "cadence", d.Get("aggregation_method").(string))
 			require.Equal(t, "60", d.Get("aggregation_delay").(string))
 			require.Equal(t, "60", d.Get("aggregation_timer").(string))
+			require.Equal(t, nrqlConditionOutlier.EntityGUID, common.EntityGUID(d.Get("entity_guid").(string)))
 		}
 	}
 }

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -235,7 +235,7 @@ resource "newrelic_nrql_alert_condition" "foo" {
 
 ## Import
 
-Alert conditions can be imported using a composite ID of `<policy_id>:<condition_id>:<conditionType>`, e.g.
+NRQL alert conditions can be imported using a composite ID of `<policy_id>:<condition_id>:<conditionType>`, e.g.
 
 ```
 // For `baseline` conditions
@@ -251,7 +251,69 @@ $ terraform import newrelic_nrql_alert_condition.foo 538291:6789035:outlier
 ~> **NOTE:** The value of `conditionType` in the import composite ID must be a valid condition type - `static`, `baseline`, or `outlier.` Also note that deprecated arguments will *not* be set when importing.
 
 Users can find the actual values for `policy_id` and `condition_id` from the New Relic One UI under respective policy and condition.
- 
+
+
+## Tags
+
+Manage NRQL alert condition tags with `newrelic_entity_tags`. For up-to-date documentation about the tagging resource, please check [newrelic_entity_tags](entity_tags.html#example-usage)
+
+```hcl
+resource "newrelic_alert_policy" "foo" {
+  name = "foo"
+}
+
+resource "newrelic_nrql_alert_condition" "foo" {
+  account_id                     = <Your Account ID>
+  policy_id                      = newrelic_alert_policy.foo.id
+  type                           = "static"
+  name                           = "foo"
+  description                    = "Alert when transactions are taking too long"
+  runbook_url                    = "https://www.example.com"
+  enabled                        = true
+  violation_time_limit_seconds   = 3600
+  fill_option                    = "static"
+  fill_value                     = 1.0
+  aggregation_window             = 60
+  aggregation_method             = "event_flow"
+  aggregation_delay              = 120
+  expiration_duration            = 120
+  open_violation_on_expiration   = true
+  close_violations_on_expiration = true
+  slide_by                       = 30
+
+  nrql {
+    query = "SELECT average(duration) FROM Transaction where appName = 'Your App'"
+  }
+
+  critical {
+    operator              = "above"
+    threshold             = 5.5
+    threshold_duration    = 300
+    threshold_occurrences = "ALL"
+  }
+
+  warning {
+    operator              = "above"
+    threshold             = 3.5
+    threshold_duration    = 600
+    threshold_occurrences = "ALL"
+  }
+}
+
+resource "newrelic_entity_tags" "my_condition_entity_tags" {
+  guid = newrelic_nrql_alert_condition.foo.entity_guid
+
+  tag {
+    key = "my-key"
+    values = ["my-value", "my-other-value"]
+  }
+
+  tag {
+    key = "my-key-2"
+    values = ["my-value-2"]
+  }
+}
+```
 
 
 ## Upgrade from 1.x to 2.x

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -133,6 +133,8 @@ The `term` block supports the following arguments:
 In addition to all arguments above, the following attributes are exported:
 
 - `id` - The ID of the NRQL alert condition. This is a composite ID with the format `<policy_id>:<condition_id>` - e.g. `538291:6789035`.
+- `entity_guid` - The unique entity identifier of the NRQL Condition in New Relic.
+
 
 ## Additional Examples
 


### PR DESCRIPTION
# Description

Exposes the EntityGUID on NRQL Conditions to enable tagging of conditions via terraform.

Fixes https://newrelic.atlassian.net/browse/AINTER-8514

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

* Create a NRQL Alert Condition and add tags to it using the `newrelic_entity_tag` resource
```
variable "nr_api_key" {
  type = string
  description = "your new relic API key"
}

variable "account_id" {
  type = number
  description = "your new relic account"
}

variable "region" {
  type = string
  description = "the region you're using."
}

provider newrelic {
  api_key = var.nr_api_key
  account_id = var.account_id
  region = var.region
}

resource "newrelic_alert_policy" "alex_terraform" {
  name = "Alex Terraform Test Policy"
  account_id = 400304
}


// Create a new condition and link it directly to an entity tag thing.
resource "newrelic_nrql_alert_condition" "alex_terraform" {
  policy_id                      = newrelic_alert_policy.alex_terraform.id
  type                           = "static"
  name                           = "my condition"
  description                    = "Alert when transactions are taking too long"
  runbook_url                    = "https://www.example.com"
  enabled                        = false
  violation_time_limit_seconds   = 3600
  fill_option                    = "static"
  fill_value                     = 1.0
  aggregation_method             = "event_flow"
  aggregation_window             = 60
  aggregation_delay              = 30
  expiration_duration            = 120
  open_violation_on_expiration   = true
  close_violations_on_expiration = true
  slide_by                       = 30

  nrql {
    query = "SELECT count(*) FROM Transaction"
  }

  critical {
    operator              = "above"
    threshold             = 5.5
    threshold_duration    = 300
    threshold_occurrences = "ALL"
  }

  warning {
    operator              = "above"
    threshold             = 3.5
    threshold_duration    = 600
    threshold_occurrences = "ALL"
  }
}


resource "newrelic_entity_tags" "alex_terraform" {
  guid = newrelic_nrql_alert_condition.alex_terraform.entity_guid

  tag {
    key = "my-key"
    values = ["my-value", "my-other-value"]
  }

  tag {
    key = "my-key-2"
    values = ["my-value-2"]
  }

    tag {
    key = "my-key-3"
    values = ["my-value-3!"]
  }
}
```
