### PR TITLE
fix(alerts): Allow negative threshold values for non-baseline NRQL conditions

### DIFF
--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -40,10 +40,9 @@ func termSchema() *schema.Resource {
 				},
 			},
 			"threshold": {
-				Type:         schema.TypeFloat,
-				Required:     true,
-				Description:  "Must be 0 or greater. For baseline conditions must be in range [1, 1000].",
-				ValidateFunc: float64Gte(0.0),
+				Type:        schema.TypeFloat,
+				Required:    true,
+				Description: "For baseline conditions must be in range [1, 1000].",
 			},
 			// Does not exist in NerdGraph. Equivalent to `threshold_occurrences`,
 			// but with different wording.

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -117,7 +117,7 @@ The `term` block supports the following arguments:
 
 - `operator` - (Optional) Valid values are `above`, `below`, or `equals` (case insensitive). Defaults to `equals`. Note that when using a `type` of `outlier` or `baseline`, the only valid option here is `above`.
 - `priority` - (Optional) `critical` or `warning`. Defaults to `critical`.
-- `threshold` - (Required) The value which will trigger a violation. Must be `0` or greater.
+- `threshold` - (Required) The value which will trigger a violation.
 <br>For _baseline_ NRQL alert conditions, the value must be in the range [1, 1000]. The value is the number of standard deviations from the baseline that the metric must exceed in order to create a violation.
 - `threshold_duration` - (Optional) The duration, in seconds, that the threshold must violate in order to create a violation. Value must be a multiple of the `aggregation_window` (which has a default of 60 seconds).
 <br>For _baseline_ and _outlier_ NRQL alert conditions, the value must be within 120-3600 seconds (inclusive).


### PR DESCRIPTION
# Description

Remove validation that prevents creating a negative NRQL condition threshold. This brings the provider in-line with the UI and API.

Fixes #1643

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

## Checklist:

- [X] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [X] I have performed a self-review of my own code
- [X] New and existing unit tests pass locally with my changes.

## How to test this change?

- Use the `newrelic_nrql_alert_condition` resource to create a non-baseline NRQL condition with a negative threshold e.g. 
 
```
critical {
    operator              = "above"
    threshold             = -9.987
    threshold_duration    = 300
    threshold_occurrences = "ALL"
  }
```
