### PR TITLE
chore(docs): removed broken Terraform logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 - [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
 - Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
 
-<img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/logo-hashicorp.svg" width="600px">
-
 ## Requirements
 
 - [Terraform](https://www.terraform.io/downloads.html) 1.0+


### PR DESCRIPTION
# Description

Small fix to README to remove broken Terraform logo

