### PR TITLE
fix: remove unnecesary read of service level entity after creation

### DIFF
--- a/newrelic/resource_newrelic_service_level.go
+++ b/newrelic/resource_newrelic_service_level.go
@@ -4,16 +4,14 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"log"
-	"strconv"
-	"strings"
-	"time"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/newrelic/newrelic-client-go/pkg/common"
 	"github.com/newrelic/newrelic-client-go/pkg/errors"
+	"log"
+	"strconv"
+	"strings"
 )
 
 func resourceNewRelicServiceLevel() *schema.Resource {
@@ -219,13 +217,13 @@ func resourceNewRelicServiceLevelCreate(ctx context.Context, d *schema.ResourceD
 		EntityGUID: entityGUID,
 	}
 
+	sliGUID := getSliGUID(&identifier)
+
 	d.SetId(identifier.String())
 	_ = d.Set("sli_id", created.ID)
-	_ = d.Set("sli_guid", getSliGUID(&identifier))
+	_ = d.Set("sli_guid", sliGUID)
 
-	time.Sleep(2 * time.Second)
-
-	return resourceNewRelicServiceLevelRead(ctx, d, meta)
+	return diag.FromErr(flattenServiceLevelIndicator(*created, &identifier, d, sliGUID))
 }
 
 func resourceNewRelicServiceLevelRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
# Description

After the creation of the SLI instead of reading the resource (that is causing issues cause in some cases is still not indexed in Entity Platform, causing the creation to fail) we are using the answer of the create mutation to write the state, since is the same resource returned

Fixes # (issue)
https://github.com/newrelic/terraform-provider-newrelic/issues/1792

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.

- [X ] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [X] I have performed a self-review of my own code
- [X] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Create N SLI
- All the SLIS should succeed 
