### PR TITLE
build(deps): bump newrelic-client-go to v0.86.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.16.1
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go v0.86.0
+	github.com/newrelic/newrelic-client-go v0.86.1
 	github.com/stretchr/testify v1.7.2
 )
 


### PR DESCRIPTION
# Description

Upgrade newrelic-client-go to stop usage of deprecated field 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.

- [X] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
