### PR TITLE
chore(docs): improved documentation for synthetics_multilocation_alert (fixes #1929)

### DIFF
--- a/website/docs/r/synthetics_multilocation_alert_condition.markdown
+++ b/website/docs/r/synthetics_multilocation_alert_condition.markdown
@@ -24,7 +24,7 @@ resource "newrelic_synthetics_multilocation_alert_condition" "example" {
   violation_time_limit_seconds = "3600"
 
 	entities = [
-		"<GUID_GOES_HERE>"
+		"<Monitor ID>"
 	]
 
 	critical {
@@ -44,7 +44,7 @@ The following arguments are supported:
   * `runbook_url` - (Optional) Runbook URL to display in notifications.
   * `enabled` - (Optional) Set whether to enable the alert condition.  Defaults to true.
   * `violation_time_limit_seconds` - (Required) The maximum number of seconds a violation can remain open before being closed by the system. Must be one of: 0, 3600, 7200, 14400, 28800, 43200, 86400.
-  * `entities` - (Required) The GUIDs of the Synthetics monitors to alert on.
+  * `entities` - (Required) The Monitor ID's of the Synthetics monitors to alert on. You can find them in the UI under tags, or using this NRQL query `SELECT monitorId FROM SyntheticCheck WHERE monitorName = 'myMonitorName'`
   * `critical` - (Required) A condition term with the priority set to critical.
   * `warning` - (Optional) A condition term with the priority set to warning.
 


### PR DESCRIPTION
# Description

Documentation improvement to remove confusion on entities

Fixes #1929 

## Type of change

Documentation change to clarify which GUID to use in `synthetics_multilocation_alert`.

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

Tested with manually creating Synthetics check in UI, and the following code:

```
resource "newrelic_alert_policy" "ssl_certs" {
  name                = "SSL Certificates PROD"
  incident_preference = "PER_CONDITION_AND_TARGET"
}

resource "newrelic_synthetics_multilocation_alert_condition" "ssl_cond" {
  policy_id = newrelic_alert_policy.ssl_certs.id

  name                         = "SSL CDN (W/TF)"
  enabled                      = true
  violation_time_limit_seconds = "43200" #3 days

  # used a single ssl monitor guid here for testing reasons
  entities = ["monitor ID"]

  warning { threshold = 1 }
  critical { threshold = 2 }

  depends_on = [
    newrelic_alert_policy.ssl_certs
  ]
}

```
