### PR TITLE
fix(newrelic_entity_tags): extended timeout to see if it fixes not found errors

### DIFF
--- a/newrelic/resource_newrelic_entity_tags.go
+++ b/newrelic/resource_newrelic_entity_tags.go
@@ -65,7 +65,7 @@ func resourceNewRelicEntityTags() *schema.Resource {
 			},
 		},
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(10 * time.Second),
+			Create: schema.DefaultTimeout(20 * time.Second),
 		},
 	}
 }
@@ -314,7 +314,9 @@ func tagValuesExist(t *entities.TaggingTagInput, values []string) bool {
 
 func getTag(tags []*entities.TaggingTagInput, key string) *entities.TaggingTagInput {
 	for _, t := range tags {
+		log.Printf("[INFO] Checking tag %s compared to tag %s", t.Key, key)
 		if t.Key == key {
+			log.Printf("[INFO] All good! %s = %s", t.Key, key)
 			return t
 		}
 	}


### PR DESCRIPTION
# Description

Having hard time reproducing #1556 It looks like the API takes some time to apply the tags, which makes Terraform think the tags haven't been applied. Adding this to check if an increased timeout removes the issue for the impacted users. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

