### PR TITLE
fix(src): Delete exactlyOne validation in scheme 

### DIFF
--- a/newrelic/resource_newrelic_notifications_destination.go
+++ b/newrelic/resource_newrelic_notifications_destination.go
@@ -50,12 +50,11 @@ func resourceNewRelicNotificationDestination() *schema.Resource {
 				Elem:        notificationsPropertySchema(),
 			},
 			"auth_basic": {
-				Type:         schema.TypeList,
-				Optional:     true,
-				MinItems:     1,
-				MaxItems:     1,
-				ExactlyOneOf: []string{"auth_basic", "auth_token"},
-				Description:  "Basic username and password authentication credentials.",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MinItems:    1,
+				MaxItems:    1,
+				Description: "Basic username and password authentication credentials.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"user": {
@@ -71,12 +70,11 @@ func resourceNewRelicNotificationDestination() *schema.Resource {
 				},
 			},
 			"auth_token": {
-				Type:         schema.TypeList,
-				Optional:     true,
-				MinItems:     1,
-				MaxItems:     1,
-				ExactlyOneOf: []string{"auth_basic", "auth_token"},
-				Description:  "Token authentication credentials.",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MinItems:    1,
+				MaxItems:    1,
+				Description: "Token authentication credentials.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"prefix": {

--- a/newrelic/resource_newrelic_notifications_destination.go
+++ b/newrelic/resource_newrelic_notifications_destination.go
@@ -50,11 +50,12 @@ func resourceNewRelicNotificationDestination() *schema.Resource {
 				Elem:        notificationsPropertySchema(),
 			},
 			"auth_basic": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				MinItems:    1,
-				MaxItems:    1,
-				Description: "Basic username and password authentication credentials.",
+				Type:          schema.TypeList,
+				Optional:      true,
+				MinItems:      1,
+				MaxItems:      1,
+				ConflictsWith: []string{"auth_token"},
+				Description:   "Basic username and password authentication credentials.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"user": {
@@ -70,11 +71,12 @@ func resourceNewRelicNotificationDestination() *schema.Resource {
 				},
 			},
 			"auth_token": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				MinItems:    1,
-				MaxItems:    1,
-				Description: "Token authentication credentials.",
+				Type:          schema.TypeList,
+				Optional:      true,
+				MinItems:      1,
+				MaxItems:      1,
+				ConflictsWith: []string{"auth_basic"},
+				Description:   "Token authentication credentials.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"prefix": {


### PR DESCRIPTION
fix(src): Delete exactlyOne validation in scheme of Notification Destination

# Description

An error occurs when not supplying a block for either auth_basic or auth_token in the newrelic_notification_destination resource, even when auth is not required.

Fixes # (issue)

#1963 newrelic_notification_destination requires an authentication type even if no auth is required

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Step 1
- Step 2
- etc
