### PR TITLE
Fix incorrect permission value in dashboard docs

### DIFF
--- a/website/docs/r/one_dashboard.html.markdown
+++ b/website/docs/r/one_dashboard.html.markdown
@@ -13,7 +13,7 @@ description: |-
 ```hcl
 resource "newrelic_one_dashboard" "exampledash" {
   name = "New Relic Terraform Example"
-  permissions = "public_read"
+  permissions = "public_read_only"
 
   page {
     name = "New Relic Terraform Example"


### PR DESCRIPTION
# Description

The provided example for [newrelic_one_dashboard](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/one_dashboard) has an incorrect value for permissions.  Currently set to 'public_read' and should be 'public_read_only'.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x ] This change requires a documentation update

