### PR TITLE
fix(notifications): made account_id optional #1994

### DIFF
--- a/newrelic/resource_newrelic_notifications_channel.go
+++ b/newrelic/resource_newrelic_notifications_channel.go
@@ -27,7 +27,8 @@ func resourceNewRelicNotificationChannel() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"account_id": {
 				Type:        schema.TypeInt,
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
 				ForceNew:    true,
 				Description: "The account id of the channel.",
 			},


### PR DESCRIPTION
# Description

Fixes #1994 

Configured the account_id field of newrelic_resource_notifications_channel to be an optional, computed field.  This should result in the account_id now being optional, which matches the documentation.  I've tried to follow the established patterns I've seen in similar fixes.  

(This is also my first PR on GitHub, please forgive any PR related faux pas!)

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.

- [X] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [X] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Create a Terraform configuration that defines a newrelic_resource_notifications_channel resource.
- Verify the account_id attribute is _not_ set in the resource block.
- Verify the account_id is defined in either the provider block or an environmental variable
- Run "terraform plan" on the configuration, it should complete without errors regarding account_id
