### PR TITLE
fix(simple_monitor): #1984 populating uri and custom headers

### DIFF
--- a/newrelic/structures_newrelic_synthetics_simple_monitor.go
+++ b/newrelic/structures_newrelic_synthetics_simple_monitor.go
@@ -63,6 +63,14 @@ func buildSyntheticsSimpleMonitorUpdateStruct(d *schema.ResourceData) synthetics
 	simpleMonitorUpdateInput.Status = inputBase.Status
 	simpleMonitorUpdateInput.Tags = inputBase.Tags
 
+	if v, ok := d.GetOk("custom_header"); ok {
+		simpleMonitorUpdateInput.AdvancedOptions.CustomHeaders = expandSyntheticsCustomHeaders(v.(*schema.Set).List())
+	}
+
+	if v, ok := d.GetOk("uri"); ok {
+		simpleMonitorUpdateInput.Uri = v.(string)
+	}
+
 	if v, ok := d.GetOk("locations_public"); ok {
 		simpleMonitorUpdateInput.Locations.Public = expandStringSlice(v.(*schema.Set).List())
 	}


### PR DESCRIPTION
# Description

Updated the "buildSyntheticsSimpleMonitorUpdateStruct" function so the uri and custom_header fields are set on the "SyntheticsUpdateSimpleMonitorInput" struct that is returned.  This results in those fields being sent to the GraphQL endpoint and updated with any changes.  I believe the uri not being populated was the root cause of the linked issue.

Fixes #1984 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [X] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Use the configuration from the [gist](https://gist.github.com/usfdmiller/a8f362bd96d5d0e32d00e81fbe27785f).
- Run "terraform apply"
- Verify the monitors were created on the New Relic website.
- Change the custom_header and uri attributes.
- Run "terraform apply" again.
- Verify on the New Relic website the values have been updated.
