### PR TITLE
fix(docs): Add safe migration pathway for monitors

### DIFF
--- a/website/docs/guides/migration_guide_v3.html.markdown
+++ b/website/docs/guides/migration_guide_v3.html.markdown
@@ -56,7 +56,7 @@ resource "newrelic_synthetics_script_monitor" "monitor" {
 2. Remove `AWS_` from the location name, e.g. `AWS_US_EAST_1` becomes `US_EAST_1`
 3. Rename `frequency` to `period` and change to one of the valid values - EVERY_MINUTE, EVERY_5_MINUTES, EVERY_10_MINUTES, EVERY_15_MINUTES, EVERY_30_MINUTES, EVERY_HOUR, EVERY_6_HOURS, EVERY_12_HOURS, or EVERY_DAY
 4. Run `terraform state rm newrelic_synthetics_monitor_script.<your_monitor_name>` and then log in to New Relic to find your monitor guid.
-5. Using the guid e.g. `MTk2MQxYjk3YWIzLWZlM05JVE9SfDQxYj...` run `terraform import newrelic_synthetics_script_monitor.<your_monitor_name>` to continue managing your existing monitor in Terraform. There won't be any down time, only a brief moment where your monitor is not managed by Terraform.
+5. Using the guid e.g. `MTk2MQxYjk3YWIzLWZlM05JVE9SfDQxYj...` run `terraform import newrelic_synthetics_script_monitor.<your_monitor_name> guid` to continue managing your existing monitor in Terraform. There won't be any down time, only a brief moment where your monitor is not managed by Terraform.
 
 ### Migrating script Synthetics monitor resources with VSE
 

--- a/website/docs/guides/migration_guide_v3.html.markdown
+++ b/website/docs/guides/migration_guide_v3.html.markdown
@@ -55,6 +55,8 @@ resource "newrelic_synthetics_script_monitor" "monitor" {
 1. Move the value in `text` from `newrelic_synthetics_monitor_script` to `script` in `newrelic_synthetics_script_monitor`
 2. Remove `AWS_` from the location name, e.g. `AWS_US_EAST_1` becomes `US_EAST_1`
 3. Rename `frequency` to `period` and change to one of the valid values - EVERY_MINUTE, EVERY_5_MINUTES, EVERY_10_MINUTES, EVERY_15_MINUTES, EVERY_30_MINUTES, EVERY_HOUR, EVERY_6_HOURS, EVERY_12_HOURS, or EVERY_DAY
+4. Run `terraform state rm newrelic_synthetics_monitor_script.<your_monitor_name>` and then log in to New Relic to find your monitor guid.
+5. Using the guid e.g. `MTk2MQxYjk3YWIzLWZlM05JVE9SfDQxYj...` run `terraform import newrelic_synthetics_script_monitor.<your_monitor_name>` to continue managing your existing monitor in Terraform. There won't be any down time, only a brief moment where your monitor is not managed by Terraform.
 
 ### Migrating script Synthetics monitor resources with VSE
 


### PR DESCRIPTION

# Description

The upgrade pathway is currently broken. Users can upgrade safely using terraform commands to temporarily exclude monitors from Terraform.

Fixes #1987

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] I have made corresponding changes to the documentation

## How to test this change?

Refer to GitHub issue
