### PR TITLE
Stop fuzzy search on resource_newrelic_application_settings failing applies

### DIFF
--- a/newrelic/resource_newrelic_application_settings.go
+++ b/newrelic/resource_newrelic_application_settings.go
@@ -55,14 +55,17 @@ func resourceNewRelicApplicationSettingsCreate(ctx context.Context, d *schema.Re
 		return diag.FromErr(err)
 	}
 
-	if len(result) != 1 {
-		return diag.Errorf("more/less than one result from query for %s", userApp.Name)
+	var app *apm.Application
+
+	for _, a := range result {
+		if a.Name == userApp.Name {
+			app = a
+			break
+		}
 	}
 
-	app := *result[0]
-
-	if app.Name != userApp.Name {
-		return diag.Errorf("the result name %s does not match requested name %s", app.Name, userApp.Name)
+	if app == nil {
+		return diag.Errorf("the name '%s' does not match any New Relic applications", userApp.Name)
 	}
 
 	d.SetId(strconv.Itoa(app.ID))


### PR DESCRIPTION
# Description

Use the same logic as data_source_newrelic_application for finding the correct APM app in resource_newrelic_application_settings. This resolves the issue of the resource failing to find an application that uses a name that's a substring of another app. E.g. "api" would previously not be found if another app was called "privateapi" because multiple results were returned by the APM client.

Fixes #2013

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Create an application in newrelic called "app"
- Create a second application in newrelic called "appduplicate"
- Apply the terraform change that will set the apdex threshold on the first application "app":
```hcl
resource "newrelic_application_settings" "monitored_entity" {
  name                = "app"
  app_apdex_threshold = 0.5
}
```