### PR TITLE
fix: up timeout to give entity chance to index

### DIFF
--- a/newrelic/resource_newrelic_synthetics_secure_credential.go
+++ b/newrelic/resource_newrelic_synthetics_secure_credential.go
@@ -60,7 +60,7 @@ func resourceNewRelicSyntheticsSecureCredential() *schema.Resource {
 			},
 		},
 		Timeouts: &schema.ResourceTimeout{
-			Read: schema.DefaultTimeout(20 * time.Second),
+			Read: schema.DefaultTimeout(30 * time.Second),
 		},
 	}
 }

--- a/newrelic/resource_newrelic_synthetics_secure_credential.go
+++ b/newrelic/resource_newrelic_synthetics_secure_credential.go
@@ -60,7 +60,7 @@ func resourceNewRelicSyntheticsSecureCredential() *schema.Resource {
 			},
 		},
 		Timeouts: &schema.ResourceTimeout{
-			Read: schema.DefaultTimeout(45 * time.Second),
+			Read: schema.DefaultTimeout(30 * time.Second),
 		},
 	}
 }
@@ -97,7 +97,7 @@ func resourceNewRelicSyntheticsSecureCredentialCreate(ctx context.Context, d *sc
 
 	d.SetId(res.Key)
 
-	return resourceNewRelicSyntheticsSecureCredentialRead(ctx, d, meta)
+	return nil
 }
 
 func resourceNewRelicSyntheticsSecureCredentialRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -130,6 +130,7 @@ func resourceNewRelicSyntheticsSecureCredentialRead(ctx context.Context, d *sche
 	})
 
 	if retryErr != nil {
+		d.SetId("")
 		return diag.FromErr(retryErr)
 	}
 
@@ -166,7 +167,7 @@ func resourceNewRelicSyntheticsSecureCredentialUpdate(ctx context.Context, d *sc
 		return diags
 	}
 
-	return resourceNewRelicSyntheticsSecureCredentialRead(ctx, d, meta)
+	return nil
 }
 
 func resourceNewRelicSyntheticsSecureCredentialDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/newrelic/resource_newrelic_synthetics_secure_credential.go
+++ b/newrelic/resource_newrelic_synthetics_secure_credential.go
@@ -60,7 +60,7 @@ func resourceNewRelicSyntheticsSecureCredential() *schema.Resource {
 			},
 		},
 		Timeouts: &schema.ResourceTimeout{
-			Read: schema.DefaultTimeout(30 * time.Second),
+			Read: schema.DefaultTimeout(45 * time.Second),
 		},
 	}
 }
@@ -118,6 +118,7 @@ func resourceNewRelicSyntheticsSecureCredentialRead(ctx context.Context, d *sche
 		if entityResults.Count != 1 {
 			return resource.RetryableError(fmt.Errorf("entity not found, or found more than one"))
 		}
+
 		for _, e := range entityResults.Results.Entities {
 			// Conditional on case sensitive match
 			if e.GetName() == d.Id() {

--- a/newrelic/resource_newrelic_synthetics_secure_credential.go
+++ b/newrelic/resource_newrelic_synthetics_secure_credential.go
@@ -60,7 +60,7 @@ func resourceNewRelicSyntheticsSecureCredential() *schema.Resource {
 			},
 		},
 		Timeouts: &schema.ResourceTimeout{
-			Read: schema.DefaultTimeout(30 * time.Second),
+			Read: schema.DefaultTimeout(20 * time.Second),
 		},
 	}
 }
@@ -96,6 +96,10 @@ func resourceNewRelicSyntheticsSecureCredentialCreate(ctx context.Context, d *sc
 	}
 
 	d.SetId(res.Key)
+	d.Set("key", res.Key)
+	d.Set("description", res.Description)
+	d.Set("last_updated", time.Time(res.LastUpdate).Format(time.RFC3339))
+	d.Set("account_id", accountID)
 
 	return nil
 }
@@ -120,7 +124,7 @@ func resourceNewRelicSyntheticsSecureCredentialRead(ctx context.Context, d *sche
 		}
 
 		for _, e := range entityResults.Results.Entities {
-			// Conditional on case sensitive match
+			// Conditional on case-sensitive match
 			if e.GetName() == d.Id() {
 				entity = &e
 				break
@@ -166,6 +170,11 @@ func resourceNewRelicSyntheticsSecureCredentialUpdate(ctx context.Context, d *sc
 	if len(diags) > 0 {
 		return diags
 	}
+
+	d.Set("key", res.Key)
+	d.Set("description", res.Description)
+	d.Set("last_updated", time.Time(res.LastUpdate).Format(time.RFC3339))
+	d.Set("account_id", accountID)
 
 	return nil
 }
@@ -216,6 +225,7 @@ func expandSyntheticsSecureCredential(d *schema.ResourceData) *synthetics.Secure
 func flattenSyntheticsSecureCredential(sc *entities.EntityOutlineInterface, d *schema.ResourceData) diag.Diagnostics {
 	switch e := (*sc).(type) {
 	case *entities.SecureCredentialEntityOutline:
+		_ = d.Set("account_id", e.AccountID)
 		_ = d.Set("key", e.GetName())
 		_ = d.Set("description", e.Description)
 		_ = d.Set("last_updated", time.Time(*e.UpdatedAt).Format(time.RFC3339))

--- a/newrelic/resource_newrelic_synthetics_secure_credential_test.go
+++ b/newrelic/resource_newrelic_synthetics_secure_credential_test.go
@@ -66,7 +66,7 @@ func testAccCheckNewRelicSyntheticsSecureCredentialExists(n string) resource.Tes
 		client := testAccProvider.Meta().(*ProviderConfig).NewClient
 
 		// Unfortunately we still have to wait due to async delay with entity indexing :(
-		time.Sleep(20 * time.Second)
+		time.Sleep(10 * time.Second)
 
 		nrqlQuery := fmt.Sprintf("domain = 'SYNTH' AND type = 'SECURE_CRED' AND name = '%s'", rs.Primary.ID)
 		found, err := client.Entities.GetEntitySearchByQuery(entities.EntitySearchOptions{}, nrqlQuery, []entities.EntitySearchSortCriteria{})
@@ -92,7 +92,7 @@ func testAccCheckNewRelicSyntheticsSecureCredentialDestroy(s *terraform.State) e
 		}
 
 		// Unfortunately we still have to wait due to async delay with entity indexing :(
-		time.Sleep(20 * time.Second)
+		time.Sleep(15 * time.Second)
 
 		nrqlQuery := fmt.Sprintf("domain = 'SYNTH' AND type = 'SECURE_CRED' AND name = '%s'", r.Primary.ID)
 		found, err := client.Entities.GetEntitySearchByQuery(entities.EntitySearchOptions{}, nrqlQuery, []entities.EntitySearchSortCriteria{})

--- a/newrelic/resource_newrelic_synthetics_secure_credential_test.go
+++ b/newrelic/resource_newrelic_synthetics_secure_credential_test.go
@@ -66,7 +66,7 @@ func testAccCheckNewRelicSyntheticsSecureCredentialExists(n string) resource.Tes
 		client := testAccProvider.Meta().(*ProviderConfig).NewClient
 
 		// Unfortunately we still have to wait due to async delay with entity indexing :(
-		time.Sleep(10 * time.Second)
+		time.Sleep(20 * time.Second)
 
 		nrqlQuery := fmt.Sprintf("domain = 'SYNTH' AND type = 'SECURE_CRED' AND name = '%s'", rs.Primary.ID)
 		found, err := client.Entities.GetEntitySearchByQuery(entities.EntitySearchOptions{}, nrqlQuery, []entities.EntitySearchSortCriteria{})
@@ -92,7 +92,7 @@ func testAccCheckNewRelicSyntheticsSecureCredentialDestroy(s *terraform.State) e
 		}
 
 		// Unfortunately we still have to wait due to async delay with entity indexing :(
-		time.Sleep(15 * time.Second)
+		time.Sleep(20 * time.Second)
 
 		nrqlQuery := fmt.Sprintf("domain = 'SYNTH' AND type = 'SECURE_CRED' AND name = '%s'", r.Primary.ID)
 		found, err := client.Entities.GetEntitySearchByQuery(entities.EntitySearchOptions{}, nrqlQuery, []entities.EntitySearchSortCriteria{})


### PR DESCRIPTION
# Description

This PR increases the timeout for the resource_secure_credential test to give the entity a chance to index.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

Secure credentials test should stop failing intermittently with `"Error: entity not found, or found more than one"` message
