### PR TITLE
feat: bump of new-relic-client-go and add service level capability to use select field for event queries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.17.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go v0.91.1
+	github.com/newrelic/newrelic-client-go v1.0.0
 	github.com/stretchr/testify v1.8.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -281,8 +281,8 @@ github.com/newrelic/go-agent/v3 v3.17.0 h1:FLhxjckKKoJWB2rR14oNm+mYZLpktfEy+JKRS
 github.com/newrelic/go-agent/v3 v3.17.0/go.mod h1:BFJOlbZWRlPTXKYIC1TTTtQKTnYntEJaU0VU507hDc0=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go v0.91.1 h1:P+6f80/3ytdBINUHqRog0aTggQgVAmvZsgKVbJYsEII=
-github.com/newrelic/newrelic-client-go v0.91.1/go.mod h1:RYMXt7hgYw7nzuXIGd2BH0F1AivgWw7WrBhNBQZEB4k=
+github.com/newrelic/newrelic-client-go v1.0.0 h1:0ugZUujCiJg3WGDxnmOT1QRP2gDiZKIMN0Z04SvxVBc=
+github.com/newrelic/newrelic-client-go v1.0.0/go.mod h1:RYMXt7hgYw7nzuXIGd2BH0F1AivgWw7WrBhNBQZEB4k=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=

--- a/newrelic/resource_newrelic_service_level.go
+++ b/newrelic/resource_newrelic_service_level.go
@@ -126,6 +126,33 @@ func eventsQuerySchema() *schema.Resource {
 				Description:  "",
 				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
+			"select": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "",
+				MinItems:    0,
+				MaxItems:    1,
+				Elem:        eventsQuerySelectSchema(),
+			},
+		},
+	}
+}
+
+func eventsQuerySelectSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"attribute": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "",
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+			},
+			"function": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "",
+				ValidateFunc: validation.StringInSlice([]string{"COUNT", "SUM"}, false),
+			},
 		},
 	}
 }
@@ -266,7 +293,7 @@ func resourceNewRelicServiceLevelUpdate(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
-	_, err = client.ServiceLevel.ServiceLevelUpdateWithContext(ctx, identifier.ID, updateInput)
+	_, err = client.ServiceLevel.ServiceLevelUpdateWithContext(ctx, common.EntityGUID(getSliGUID(identifier)), updateInput)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -284,7 +311,7 @@ func resourceNewRelicServiceLevelDelete(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
-	if _, err := client.ServiceLevel.ServiceLevelDeleteWithContext(ctx, identifier.ID); err != nil {
+	if _, err := client.ServiceLevel.ServiceLevelDeleteWithContext(ctx, common.EntityGUID(getSliGUID(identifier))); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/newrelic/resource_newrelic_service_level_test.go
+++ b/newrelic/resource_newrelic_service_level_test.go
@@ -61,6 +61,10 @@ resource "newrelic_service_level" "sli" {
 		}
 		good_events {
 			from = "Transaction"
+			select {
+				attribute = "duration"
+				function = "COUNT"
+			}
 		}
 	}
 
@@ -94,6 +98,10 @@ resource "newrelic_service_level" "sli" {
 		account_id = %[1]d
 		valid_events {
 			from = "Transaction"
+			select {
+				attribute = "duration"
+				function = "SUM"
+			}
 		}
 		good_events {
 			from = "Transaction"

--- a/newrelic/structures_newrelic_service_level.go
+++ b/newrelic/structures_newrelic_service_level.go
@@ -55,7 +55,7 @@ func flattenServiceLevelEventsQuerySelect(selectValue servicelevel.ServiceLevelE
 	selectOutput := make([]interface{}, 1)
 
 	selectQueryMap["attribute"] = selectValue.Attribute
-	selectQueryMap["where"] = selectValue.Function
+	selectQueryMap["function"] = selectValue.Function
 
 	selectOutput[0] = selectQueryMap
 	return selectOutput

--- a/newrelic/structures_newrelic_service_level.go
+++ b/newrelic/structures_newrelic_service_level.go
@@ -44,9 +44,21 @@ func flattenServiceLevelEventsQuery(eventsQuery *servicelevel.ServiceLevelEvents
 
 	eventsQueryMap["from"] = eventsQuery.From
 	eventsQueryMap["where"] = eventsQuery.Where
+	eventsQueryMap["select"] = flattenServiceLevelEventsQuerySelect(eventsQuery.Select)
 
 	eventsQueryOutput[0] = eventsQueryMap
 	return eventsQueryOutput
+}
+
+func flattenServiceLevelEventsQuerySelect(selectValue servicelevel.ServiceLevelEventsQuerySelect) []interface{} {
+	selectQueryMap := make(map[string]interface{})
+	selectOutput := make([]interface{}, 1)
+
+	selectQueryMap["attribute"] = selectValue.Attribute
+	selectQueryMap["where"] = selectValue.Function
+
+	selectOutput[0] = selectQueryMap
+	return selectOutput
 }
 
 func flattenServiceLevelObjectives(objectives []servicelevel.ServiceLevelObjective) []interface{} {
@@ -140,7 +152,23 @@ func expandServiceLevelEventsQueryCreateInput(cfg map[string]interface{}) *servi
 		eventsQuery.Where = servicelevel.NRQL(where.(string))
 	}
 
+	if value, ok := cfg["select"].([]interface{}); ok && len(value) > 0 {
+		eventsQuery.Select = expandServiceLevelEventsQuerySelectCreateInput(value[0].(map[string]interface{}))
+	}
+
 	return &eventsQuery
+}
+
+func expandServiceLevelEventsQuerySelectCreateInput(cfg map[string]interface{}) *servicelevel.ServiceLevelEventsQuerySelectCreateInput {
+	selectValue := servicelevel.ServiceLevelEventsQuerySelectCreateInput{}
+
+	if attribute, ok := cfg["attribute"]; ok {
+		selectValue.Attribute = attribute.(string)
+	}
+
+	selectValue.Function = servicelevel.ServiceLevelEventsQuerySelectFunction(cfg["function"].(string))
+
+	return &selectValue
 }
 
 func expandServiceLevelObjectivesCreateInput(cfg []interface{}) []servicelevel.ServiceLevelObjectiveCreateInput {
@@ -245,7 +273,23 @@ func expandServiceLevelEventsQueryUpdateInput(cfg map[string]interface{}) *servi
 		eventsQuery.Where = servicelevel.NRQL(where.(string))
 	}
 
+	if value, ok := cfg["select"].([]interface{}); ok && len(value) > 0 {
+		eventsQuery.Select = expandServiceLevelEventsQuerySelectUpdateInput(value[0].(map[string]interface{}))
+	}
+
 	return &eventsQuery
+}
+
+func expandServiceLevelEventsQuerySelectUpdateInput(cfg map[string]interface{}) *servicelevel.ServiceLevelEventsQuerySelectUpdateInput {
+	selectValue := servicelevel.ServiceLevelEventsQuerySelectUpdateInput{}
+
+	if attribute, ok := cfg["attribute"]; ok {
+		selectValue.Attribute = attribute.(string)
+	}
+
+	selectValue.Function = servicelevel.ServiceLevelEventsQuerySelectFunction(cfg["function"].(string))
+
+	return &selectValue
 }
 
 func expandServiceLevelObjectivesUpdateInput(cfg []interface{}) []servicelevel.ServiceLevelObjectiveUpdateInput {

--- a/website/docs/r/service_level.html.markdown
+++ b/website/docs/r/service_level.html.markdown
@@ -71,14 +71,23 @@ All nested `events` blocks support the following common arguments:
   * `valid_events` - (Required) The definition of valid requests.
     * `from` - (Required) The event type where NRDB data will be fetched from.
     * `where` - (Optional) A filter that specifies all the NRDB events that are considered in this SLI (e.g, those that refer to a particular entity).
+    * `select` - (Optional) The NRQL SELECT clause to aggregate events.
+      * `attribute` - (Optional) The event attribute to use in the SELECT clause.
+      * `function` - (Required) The function to use in the SELECT clause. Valid values are `COUNT`and `SUM`.
   * `good_events` - (Optional) The definition of good responses. If you define an SLI from valid and good events, you must leave the bad events argument empty.
     * `from` - (Required) The event type where NRDB data will be fetched from.
     * `where` - (Optional) A filter that narrows down the NRDB events just to those that are considered good responses (e.g, those that refer to
     a particular entity and were successful).
+    * `select` - (Optional) The NRQL SELECT clause to aggregate events.
+        * `attribute` - (Optional) The event attribute to use in the SELECT clause.
+        * `function` - (Required) The function to use in the SELECT clause. Valid values are `COUNT`and `SUM`.
   * `bad_events` - (Optional) The definition of the bad responses. If you define an SLI from valid and bad events, you must leave the good events argument empty.
     * `from` - (Required) The event type where NRDB data will be fetched from.
     * `where` - (Optional) A filter that narrows down the NRDB events just to those that are considered bad responses (e.g, those that refer to
     a particular entity and returned an error).
+    * `select` - (Optional) The NRQL SELECT clause to aggregate events.
+        * `attribute` - (Optional) The event attribute to use in the SELECT clause.
+        * `function` - (Required) The function to use in the SELECT clause. Valid values are `COUNT`and `SUM`.
 
 ### Objective
 


### PR DESCRIPTION
# Description

Added the capability to define the select field in the event queries of the service levels, to allow the usage of the SUM function.

## Type of change

Please delete options that are not relevant.

- [ X] New feature (non-breaking change which adds functionality)
- 
## Checklist:

- [X] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [X ] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X ] I have added tests that prove my fix is effective or that my feature works
- [X ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

```
resource "newrelic_service_level" "foo" {
    guid = $someEntityGuid
    name = "TF PROVIDER TEST"
    description = "TF PROVIDER TEST."

    events {
        account_id = $accountId
        valid_events {
            from = "Transaction"
            where = "(transactionType='Web')"
             select {
                function = "SUM"
                attribute = "duration"
            }
        }
        good_events {
            from = "Transaction"
            where = "(transactionType= 'Web') AND duration < 0.1"
            select {
                function = "COUNT"
            }
        }
    }

    objective {
        target = 99.00
        time_window {
            rolling {
                count = 7
                unit = "DAY"
            }
        }
    }
}
```
