### PR TITLE
fix(workflows): fix bogus diff for workflows with empty enrichments

### DIFF
--- a/newrelic/resource_newrelic_notifications_destination.go
+++ b/newrelic/resource_newrelic_notifications_destination.go
@@ -53,7 +53,6 @@ func resourceNewRelicNotificationDestination() *schema.Resource {
 			"auth_basic": {
 				Type:          schema.TypeList,
 				Optional:      true,
-				MinItems:      1,
 				MaxItems:      1,
 				ConflictsWith: []string{"auth_token"},
 				Description:   "Basic username and password authentication credentials.",
@@ -74,7 +73,6 @@ func resourceNewRelicNotificationDestination() *schema.Resource {
 			"auth_token": {
 				Type:          schema.TypeList,
 				Optional:      true,
-				MinItems:      1,
 				MaxItems:      1,
 				ConflictsWith: []string{"auth_basic"},
 				Description:   "Token authentication credentials.",

--- a/newrelic/resource_newrelic_workflow.go
+++ b/newrelic/resource_newrelic_workflow.go
@@ -146,7 +146,6 @@ func resourceNewRelicWorkflow() *schema.Resource {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				MaxItems:    1,
-				MinItems:    1,
 				Description: "Enrichments can give additional context on alert notifications by adding NRQL query results to them.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/newrelic/structures_newrelic_workflow.go
+++ b/newrelic/structures_newrelic_workflow.go
@@ -338,8 +338,10 @@ func flattenWorkflow(workflow *workflows.AiWorkflowsWorkflow, d *schema.Resource
 		return fmt.Errorf("[DEBUG] Error setting workflows enrichments: %#v", enrichmentsErr)
 	}
 
-	if err := d.Set("enrichments", enrichments); err != nil {
-		return err
+	if len(enrichments) > 0 {
+		if err := d.Set("enrichments", enrichments); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -428,8 +430,8 @@ func flattenWorkflowPredicate(p *workflows.AiWorkflowsPredicate) (map[string]int
 	return predicateResult, nil
 }
 
-func flattenWorkflowEnrichments(e *[]workflows.AiWorkflowsEnrichment) (interface{}, error) {
-	if e == nil {
+func flattenWorkflowEnrichments(e *[]workflows.AiWorkflowsEnrichment) ([]interface{}, error) {
+	if e == nil || len(*e) == 0 {
 		return nil, nil
 	}
 

--- a/newrelic/structures_newrelic_workflow_test.go
+++ b/newrelic/structures_newrelic_workflow_test.go
@@ -216,6 +216,39 @@ func TestFlattenWorkflow(t *testing.T) {
 				IssuesFilter:              issuesFilter,
 			},
 		},
+		"no_enrichments": {
+			Data: map[string]interface{}{
+				"name":                  "workflow-test",
+				"enrichments_enabled":   true,
+				"destinations_enabled":  true,
+				"enabled":               true,
+				"muting_rules_handling": "NOTIFY_ALL_ISSUES",
+				"issues_filter": map[string]interface{}{
+					"name": "issues-filter-test",
+					"type": "FILTER",
+					"predicate": []map[string]interface{}{{
+						"attribute": "source",
+						"operator":  "EQUAL",
+						"values":    []string{"newrelic"},
+					}},
+				},
+				"destination": []map[string]interface{}{{
+					"channel_id": "300848f9-c713-463c-9036-40b45c4c970f",
+					"name":       "destination-test",
+					"type":       "WEBHOOK",
+				}},
+			},
+			Flattened: &workflows.AiWorkflowsWorkflow{
+				Name:                      "workflow-test",
+				EnrichmentsEnabled:        true,
+				DestinationsEnabled:       true,
+				WorkflowEnabled:           true,
+				MutingRulesHandling:       workflows.AiWorkflowsMutingRulesHandlingTypes.NOTIFY_ALL_ISSUES,
+				Enrichments:               []workflows.AiWorkflowsEnrichment{},
+				DestinationConfigurations: destinationConfigurations,
+				IssuesFilter:              issuesFilter,
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
# Description

Currently, if workflow does not have any enrichments we show a bogus diff in TF plan even if nothing has actually been changed:

```
resource "newrelic_workflow" "workflow-example" {
    id                    = <UUID>
    name                  = <name>
    # (6 unchanged attributes hidden)

    - enrichments {
    }

    # (2 unchanged blocks hidden)
}
```

The root cause of this problem is the difference in how we treat a workflow with no enrichments when we create a new workflow vs. when we retrieve the current state of the workflow:
- For new workflows, workflow resource's `enrichments` field is not set if the workflow has no enrichments
- When retrieving the state, `enrichments` field is set to an empty set if the workflow has no enrichments

This PR changes the retrieval logic to mimic the new state logic. This should retroactively fix bogus `plan` diffs for all customers without any action from the users' side.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Create a configuration for a workflow with no enrichments
- Apply it
- Run `terraform plan` 
- Old behaviour:
  - TF reports that "Objects have changed outside of Terraform"
  - Plan says that we are going to delete `enrichments`
- New behaviour: the plan is empty, no warnings about objects being changed outside terraform
