### PR TITLE
Removed deprecated api_key check and made api_key required

### DIFF
--- a/newrelic/config.go
+++ b/newrelic/config.go
@@ -139,10 +139,6 @@ type ProviderConfig struct {
 	PersonalAPIKey       string
 }
 
-func (c *ProviderConfig) hasNerdGraphCredentials() bool {
-	return c.AccountID > 0 && c.PersonalAPIKey != ""
-}
-
 // If the argument is a path, Read loads it and returns the contents,
 // otherwise the argument is assumed to be the desired contents and is simply
 // returned.

--- a/newrelic/data_source_newrelic_alert_policy.go
+++ b/newrelic/data_source_newrelic_alert_policy.go
@@ -47,13 +47,7 @@ func dataSourceNewRelicAlertPolicy() *schema.Resource {
 
 func dataSourceNewRelicAlertPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*ProviderConfig)
-
-	if !cfg.hasNerdGraphCredentials() {
-		return diag.Errorf("err: NerdGraph support not present, but required for Read")
-	}
-
 	client := cfg.NewClient
-
 	log.Printf("[INFO] Reading New Relic Alert Policies")
 
 	name := d.Get("name").(string)

--- a/newrelic/provider.go
+++ b/newrelic/provider.go
@@ -226,10 +226,6 @@ func providerConfigure(data *schema.ResourceData, terraformVersion string) (inte
 		AccountID:            accountID,
 	}
 
-	if !providerConfig.hasNerdGraphCredentials() {
-		return nil, fmt.Errorf("err: NerdGraph support not present, but required. Set the 'api_key' attribute to a New Relic User API key")
-	}
-
 	return &providerConfig, nil
 }
 

--- a/newrelic/provider.go
+++ b/newrelic/provider.go
@@ -42,7 +42,7 @@ func Provider() *schema.Provider {
 			},
 			"api_key": {
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("NEW_RELIC_API_KEY", nil),
 				Sensitive:   true,
 			},

--- a/newrelic/provider_unit_test.go
+++ b/newrelic/provider_unit_test.go
@@ -12,16 +12,3 @@ func TestProvider(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 }
-
-func TestProviderConfig(t *testing.T) {
-	c := ProviderConfig{
-		PersonalAPIKey: "abc123",
-		AccountID:      123,
-	}
-
-	hasNerdGraphCreds := c.hasNerdGraphCredentials()
-
-	if !hasNerdGraphCreds {
-		t.Error("hasNerdGraphCreds should be true")
-	}
-}

--- a/newrelic/resource_newrelic_alert_policy.go
+++ b/newrelic/resource_newrelic_alert_policy.go
@@ -2,7 +2,6 @@ package newrelic
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -60,11 +59,6 @@ func resourceNewRelicAlertPolicy() *schema.Resource {
 
 func resourceNewRelicAlertPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
-
-	if !providerConfig.hasNerdGraphCredentials() {
-		return diag.Errorf("err: NerdGraph support not present, but required for Create")
-	}
-
 	client := providerConfig.NewClient
 	accountID := selectAccountID(providerConfig, d)
 	// We're creating this updatedContext for the findExistingChannelIDs function which is still REST based
@@ -120,11 +114,6 @@ func resourceNewRelicAlertPolicyCreate(ctx context.Context, d *schema.ResourceDa
 
 func resourceNewRelicAlertPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
-
-	if !providerConfig.hasNerdGraphCredentials() {
-		return diag.Errorf("err: NerdGraph support not present, but required for Read")
-	}
-
 	client := providerConfig.NewClient
 
 	ids, err := parseHashedIDs(d.Id())
@@ -166,11 +155,6 @@ func resourceNewRelicAlertPolicyRead(ctx context.Context, d *schema.ResourceData
 
 func resourceNewRelicAlertPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
-
-	if !providerConfig.hasNerdGraphCredentials() {
-		return diag.Errorf("err: NerdGraph support not present, but required for Update")
-	}
-
 	client := providerConfig.NewClient
 
 	accountID := selectAccountID(providerConfig, d)
@@ -199,12 +183,6 @@ func resourceNewRelicAlertPolicyUpdate(ctx context.Context, d *schema.ResourceDa
 
 func resourceNewRelicAlertPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
-
-	if !providerConfig.hasNerdGraphCredentials() {
-		err := errors.New("err: NerdGraph support not present, but required for Delete")
-		return diag.FromErr(err)
-	}
-
 	client := providerConfig.NewClient
 
 	accountID := selectAccountID(providerConfig, d)

--- a/newrelic/resource_newrelic_entity_tags.go
+++ b/newrelic/resource_newrelic_entity_tags.go
@@ -72,11 +72,6 @@ func resourceNewRelicEntityTags() *schema.Resource {
 
 func resourceNewRelicEntityTagsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
-
-	if !providerConfig.hasNerdGraphCredentials() {
-		return diag.Errorf("err: NerdGraph support not present, but required for Create")
-	}
-
 	client := providerConfig.NewClient
 
 	guid := common.EntityGUID(d.Get("guid").(string))
@@ -125,11 +120,6 @@ func resourceNewRelicEntityTagsCreate(ctx context.Context, d *schema.ResourceDat
 
 func resourceNewRelicEntityTagsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
-
-	if !providerConfig.hasNerdGraphCredentials() {
-		return diag.Errorf("err: NerdGraph support not present, but required for Read")
-	}
-
 	client := providerConfig.NewClient
 
 	log.Printf("[INFO] Reading New Relic entity tags for entity guid %s", d.Id())
@@ -152,11 +142,6 @@ func resourceNewRelicEntityTagsRead(ctx context.Context, d *schema.ResourceData,
 
 func resourceNewRelicEntityTagsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
-
-	if !providerConfig.hasNerdGraphCredentials() {
-		return diag.Errorf("err: NerdGraph support not present, but required for Update")
-	}
-
 	client := providerConfig.NewClient
 
 	log.Printf("[INFO] Updating New Relic entity tags for entity guid %s", d.Id())
@@ -222,11 +207,6 @@ func convertTagTypes(tags []*entities.EntityTag) []*entities.TaggingTagInput {
 
 func resourceNewRelicEntityTagsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
-
-	if !providerConfig.hasNerdGraphCredentials() {
-		return diag.Errorf("err: NerdGraph support not present, but required for Delete")
-	}
-
 	client := providerConfig.NewClient
 
 	log.Printf("[INFO] Deleting New Relic entity tags from entity guid %s", d.Id())

--- a/newrelic/resource_newrelic_events_to_metrics_rule.go
+++ b/newrelic/resource_newrelic_events_to_metrics_rule.go
@@ -64,11 +64,6 @@ func resourceNewRelicEventsToMetricsRule() *schema.Resource {
 
 func resourceNewRelicEventsToMetricsRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
-
-	if !providerConfig.hasNerdGraphCredentials() {
-		return diag.Errorf("err: NerdGraph support not present, but required for Create")
-	}
-
 	client := providerConfig.NewClient
 
 	createInput := []eventstometrics.EventsToMetricsCreateRuleInput{
@@ -111,11 +106,6 @@ func resourceNewRelicEventsToMetricsRuleCreate(ctx context.Context, d *schema.Re
 
 func resourceNewRelicEventsToMetricsRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
-
-	if !providerConfig.hasNerdGraphCredentials() {
-		return diag.Errorf("err: NerdGraph support not present, but required for Read")
-	}
-
 	client := providerConfig.NewClient
 
 	log.Printf("[INFO] Reading New Relic entity tags for entity guid %s", d.Id())
@@ -168,11 +158,6 @@ func resourceNewRelicEventsToMetricsRuleRead(ctx context.Context, d *schema.Reso
 
 func resourceNewRelicEventsToMetricsRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
-
-	if !providerConfig.hasNerdGraphCredentials() {
-		return diag.Errorf("err: NerdGraph support not present, but required for Update")
-	}
-
 	client := providerConfig.NewClient
 
 	log.Printf("[INFO] Updating New Relic events to metric rules")
@@ -200,11 +185,6 @@ func resourceNewRelicEventsToMetricsRuleUpdate(ctx context.Context, d *schema.Re
 
 func resourceNewRelicEventsToMetricsRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
-
-	if !providerConfig.hasNerdGraphCredentials() {
-		return diag.Errorf("err: NerdGraph support not present, but required for Delete")
-	}
-
 	client := providerConfig.NewClient
 
 	log.Printf("[INFO] Deleting New Relic entity tags from entity guid %s", d.Id())

--- a/newrelic/resource_newrelic_nrql_drop_rule.go
+++ b/newrelic/resource_newrelic_nrql_drop_rule.go
@@ -61,11 +61,6 @@ func resourceNewRelicNRQLDropRule() *schema.Resource {
 
 func resourceNewRelicNRQLDropRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
-
-	if !providerConfig.hasNerdGraphCredentials() {
-		return diag.Errorf("err: NerdGraph support not present, but required for Create")
-	}
-
 	client := providerConfig.NewClient
 
 	accountID := selectAccountID(providerConfig, d)
@@ -98,11 +93,6 @@ func resourceNewRelicNRQLDropRuleCreate(ctx context.Context, d *schema.ResourceD
 
 func resourceNewRelicNRQLDropRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
-
-	if !providerConfig.hasNerdGraphCredentials() {
-		return diag.Errorf("err: NerdGraph support not present, but required for Read")
-	}
-
 	client := providerConfig.NewClient
 
 	log.Printf("[INFO] Reading New Relic NRQL Drop Rule for %s", d.Id())
@@ -148,11 +138,6 @@ func resourceNewRelicNRQLDropRuleRead(ctx context.Context, d *schema.ResourceDat
 
 func resourceNewRelicNRQLDropRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
-
-	if !providerConfig.hasNerdGraphCredentials() {
-		return diag.Errorf("err: NerdGraph support not present, but required for Delete")
-	}
-
 	client := providerConfig.NewClient
 
 	log.Printf("[INFO] Deleting New Relic entity tags from entity guid %s", d.Id())

--- a/newrelic/resource_newrelic_one_dashboard.go
+++ b/newrelic/resource_newrelic_one_dashboard.go
@@ -413,11 +413,6 @@ func dashboardWidgetFilterCurrentDashboardSchema() *schema.Schema {
 
 func resourceNewRelicOneDashboardCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
-
-	if !providerConfig.hasNerdGraphCredentials() {
-		return diag.Errorf("err: NerdGraph support not present, but required for Create")
-	}
-
 	client := providerConfig.NewClient
 	accountID := selectAccountID(providerConfig, d)
 
@@ -487,11 +482,6 @@ func resourceNewRelicOneDashboardCreate(ctx context.Context, d *schema.ResourceD
 // resourceNewRelicOneDashboardRead NerdGraph => Terraform reader
 func resourceNewRelicOneDashboardRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
-
-	if !providerConfig.hasNerdGraphCredentials() {
-		return diag.Errorf("err: NerdGraph support not present, but required for Read")
-	}
-
 	client := providerConfig.NewClient
 
 	log.Printf("[INFO] Reading New Relic One dashboard %s", d.Id())
@@ -511,11 +501,6 @@ func resourceNewRelicOneDashboardRead(ctx context.Context, d *schema.ResourceDat
 
 func resourceNewRelicOneDashboardUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
-
-	if !providerConfig.hasNerdGraphCredentials() {
-		return diag.Errorf("err: NerdGraph support not present, but required for Update")
-	}
-
 	client := providerConfig.NewClient
 	accountID := selectAccountID(providerConfig, d)
 

--- a/newrelic/resource_newrelic_one_dashboard_json.go
+++ b/newrelic/resource_newrelic_one_dashboard_json.go
@@ -55,11 +55,6 @@ func resourceNewRelicOneDashboardJSON() *schema.Resource {
 
 func resourceNewRelicOneDashboardJSONCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
-
-	if !providerConfig.hasNerdGraphCredentials() {
-		return diag.Errorf("err: NerdGraph support not present, but required for Create")
-	}
-
 	client := providerConfig.NewClient
 	accountID := selectAccountID(providerConfig, d)
 

--- a/newrelic/resource_newrelic_one_dashboard_raw.go
+++ b/newrelic/resource_newrelic_one_dashboard_raw.go
@@ -172,11 +172,6 @@ func dashboardRawWidgetSchemaBase() map[string]*schema.Schema {
 
 func resourceNewRelicOneDashboardRawCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
-
-	if !providerConfig.hasNerdGraphCredentials() {
-		return diag.Errorf("err: NerdGraph support not present, but required for Create")
-	}
-
 	client := providerConfig.NewClient
 	accountID := selectAccountID(providerConfig, d)
 
@@ -212,11 +207,6 @@ func resourceNewRelicOneDashboardRawCreate(ctx context.Context, d *schema.Resour
 // resourceNewRelicOneDashboardRawRead NerdGraph => Terraform reader
 func resourceNewRelicOneDashboardRawRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
-
-	if !providerConfig.hasNerdGraphCredentials() {
-		return diag.Errorf("err: NerdGraph support not present, but required for Read")
-	}
-
 	client := providerConfig.NewClient
 
 	log.Printf("[INFO] Reading New Relic One dashboard %s", d.Id())
@@ -236,11 +226,6 @@ func resourceNewRelicOneDashboardRawRead(ctx context.Context, d *schema.Resource
 
 func resourceNewRelicOneDashboardRawUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
-
-	if !providerConfig.hasNerdGraphCredentials() {
-		return diag.Errorf("err: NerdGraph support not present, but required for Update")
-	}
-
 	client := providerConfig.NewClient
 	accountID := selectAccountID(providerConfig, d)
 


### PR DESCRIPTION
# Description

Removed some outdated code to check if an API_KEY was set (User API Key). Most of our resources now use GraphQL and the field was already set to `required` in the docs. 

This change removes a check from the resources and makes the field `required` in provider configuration.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

