### PR TITLE
fix(workflows): correctly handle notification channels deleted outside TF

### DIFF
--- a/newrelic/resource_newrelic_notifications_channel.go
+++ b/newrelic/resource_newrelic_notifications_channel.go
@@ -127,7 +127,8 @@ func resourceNewRelicNotificationChannelRead(ctx context.Context, d *schema.Reso
 	}
 
 	if len(channelResponse.Entities) == 0 {
-		return diag.FromErr(fmt.Errorf("[ERROR] notification channelResponse.Entities response is empty"))
+		d.SetId("")
+		return nil
 	}
 
 	errors := buildAiNotificationsResponseErrors(channelResponse.Errors)

--- a/newrelic/resource_newrelic_notifications_channel_test.go
+++ b/newrelic/resource_newrelic_notifications_channel_test.go
@@ -197,6 +197,43 @@ func TestNewRelicNotificationChannel_EmailPropertyError(t *testing.T) {
 	})
 }
 
+func TestNewRelicNotificationChannel_ImportChannel_WrongId(t *testing.T) {
+	resourceName := "newrelic_notification_channel.foo"
+	rand := acctest.RandString(6)
+	rName := fmt.Sprintf("tf-notifications-test-%s", rand)
+	channelPropsAttr := `property {
+		key = "email"
+		value = "no-reply+terraformtest@newrelic.com"
+	}`
+	destinationPropsAttr := `property {
+		key = "subject"
+		value = "some subject"
+	}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccNewRelicNotificationChannelDestroy,
+		Steps: []resource.TestStep{
+			// Import
+			{
+				Config: testNewRelicNotificationChannelConfig(
+					testAccountID,
+					rName,
+					string(notifications.AiNotificationsChannelTypeTypes.EMAIL),
+					channelPropsAttr,
+					destinationPropsAttr,
+				),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "d20a6505-dbe3-4484-82ef-7723cb17a7d2",
+				ExpectError:       regexp.MustCompile("Error: Cannot import non-existent remote object"),
+			},
+		},
+	})
+}
+
 func testNewRelicNotificationChannelConfig(accountID int, name string, notificationType string, channelProps string, destinationProps string) string {
 	return fmt.Sprintf(`
 resource "newrelic_notification_destination" "foo" {


### PR DESCRIPTION
# Description

Currently, if TF expects a channel with a given ID to exist but it does not, instead of reporting that the remote object does not exist we return an error.

In practice, the current behaviour results in two problems:
1. If a channel was already created/imported into your TF state but then deleted externally, the state would get corrupted and `plan`, `refresh`, and `apply` would just start failing
2. If you try to import a channel using a wrong ID, you would get a weird error instead of the standard "Cannot import non-existent remote object"

The second problem is fairly minor. 
The first one is not only a major issue, it also happens very often because of how workflows interact with channels. Namely, if you delete a workflow, it automatically deletes the associated channel. 
If you only deleted a workflow but left channel configuration intact in your TF files, your state will get corrupted. 

This PR addresses the incorrect handling of deleted/missing channels, fixing both problems mentioned above

Fixes https://github.com/newrelic/terraform-provider-newrelic/issues/2046 (partially)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

This PR includes integration tests for two scenarios:
1. Import a non-existent channel
2. Delete a channel object without a channel resource configuration (by deleting the workflow that uses the channel)

Both of these cases were broken before the fix and work after the fix