### PR TITLE
fix: dashboard import statement missing guid

### DIFF
--- a/website/docs/r/one_dashboard.html.markdown
+++ b/website/docs/r/one_dashboard.html.markdown
@@ -275,8 +275,8 @@ resource "newrelic_one_dashboard" "multi_page_dashboard" {
 
 New Relic dashboards can be imported using their GUID, e.g.
 
-```
-$ terraform import newrelic_one_dashboard.my_dashboard <Dashboard GUID>
+```bash
+$ terraform import newrelic_one_dashboard.my_dashboard <dashboard GUID>
 ```
 
 In addition you can use the [New Relic CLI](https://github.com/newrelic/newrelic-cli#readme) to convert existing dashboards to HCL. [Copy your dashboards as JSON using the UI](https://docs.newrelic.com/docs/query-your-data/explore-query-data/dashboards/dashboards-charts-import-export-data/), save it as a file (for example `terraform.json`), and use the following command to convert it to HCL: `cat terraform.json | newrelic utils terraform dashboard --label my_dashboard_resource`.


### PR DESCRIPTION
# Description

When importing a New Relic One dashboard I was really confused by the example as I couldn't see the GUID. After guessing hey it's probably imported by GUID I was okay, but the docs should be fixed.

It's not clear to me why it was broken so my idea was to find one that is visible:

https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/cloud_aws_govcloud_link_account#import

And copy that code style (add bash descriptor + use lower case text) to:

https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/one_dashboard#import

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have made corresponding changes to the documentation

## How to test this change?

Not quite sure but hopefully someone from the docs team will know how we can test this or notify me of any changes required :)
