### PR TITLE
chore(newrelic_nrql_alert_condition): move read to create function to avoid root resource not found

### DIFF
--- a/newrelic/resource_newrelic_alert_policy_channel.go
+++ b/newrelic/resource_newrelic_alert_policy_channel.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -53,6 +54,9 @@ func resourceNewRelicAlertPolicyChannel() *schema.Resource {
 				Upgrade: migrateStateNewRelicAlertPolicyChannelV0toV1,
 				Version: 0,
 			},
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Second),
 		},
 	}
 }

--- a/newrelic/resource_newrelic_alert_policy_channel.go
+++ b/newrelic/resource_newrelic_alert_policy_channel.go
@@ -2,9 +2,11 @@ package newrelic
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/newrelic/newrelic-client-go/v2/newrelic"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/alerts"
@@ -116,9 +118,26 @@ func resourceNewRelicAlertPolicyChannelCreate(ctx context.Context, d *schema.Res
 		return diag.FromErr(err)
 	}
 
+	retryErr := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		exists, err := policyChannelsExist(updatedContext, client, policyChannels.ID, policyChannels.ChannelIDs)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		if !exists {
+			return resource.RetryableError(fmt.Errorf("alert policy channel was not created"))
+		}
+
+		return nil
+	})
+
+	if retryErr != nil {
+		return diag.FromErr(retryErr)
+	}
+
 	d.SetId(serializedID)
 
-	return resourceNewRelicAlertPolicyChannelRead(updatedContext, d, meta)
+	return nil
 }
 
 func resourceNewRelicAlertPolicyChannelRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -452,7 +452,7 @@ func resourceNewRelicNrqlAlertConditionRead(ctx context.Context, d *schema.Resou
 	_, err = client.Alerts.QueryPolicyWithContext(ctx, accountID, strconv.Itoa(policyID))
 	if err != nil {
 		if _, ok := err.(*errors.NotFound); ok {
-			d.SetId("") // triggers this line
+			d.SetId("")
 			return nil
 		}
 		return diag.FromErr(err)

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -417,10 +417,9 @@ func resourceNewRelicNrqlAlertConditionCreate(ctx context.Context, d *schema.Res
 		_, err := client.Alerts.GetNrqlConditionQueryWithContext(ctx, accountID, strconv.Itoa(conditionID))
 		if err != nil {
 			if _, ok := err.(*errors.NotFound); ok {
-				resource.RetryableError(fmt.Errorf("nrql condition was not created"))
-				return nil
+				return resource.RetryableError(fmt.Errorf("nrql condition was not created"))
 			}
-			return resource.RetryableError(err)
+			return resource.NonRetryableError(err)
 		}
 
 		return nil

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -354,6 +355,9 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 					return strings.EqualFold(old, new) // Case fold this attribute when diffing
 				},
 			},
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Second),
 		},
 	}
 }


### PR DESCRIPTION
# Description

Change to read function to avoid setId("") happening. I think we need to verify the resource has been created by reading it back before setting the Id.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

