### PR TITLE
fix(workflows): make it possible to remove all workflow enrichments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.17.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.0.2
+	github.com/newrelic/newrelic-client-go/v2 v2.2.2
 	github.com/stretchr/testify v1.8.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -283,6 +283,8 @@ github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fz
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
 github.com/newrelic/newrelic-client-go/v2 v2.0.2 h1:ViXca4J8Awg+F1q++GQV/loTJB1qle/r+PwC6gdgNfo=
 github.com/newrelic/newrelic-client-go/v2 v2.0.2/go.mod h1:xDZ6IDWI6fpl7MhTI4Hk75alJLAIfXzOt/rINEolxhQ=
+github.com/newrelic/newrelic-client-go/v2 v2.2.2 h1:IvMQvs+t7YuJwneJdCbicLDS9451bE0aS6/lMs75/RI=
+github.com/newrelic/newrelic-client-go/v2 v2.2.2/go.mod h1:xDZ6IDWI6fpl7MhTI4Hk75alJLAIfXzOt/rINEolxhQ=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=

--- a/newrelic/resource_newrelic_workflow_test.go
+++ b/newrelic/resource_newrelic_workflow_test.go
@@ -132,6 +132,45 @@ func TestNewRelicWorkflow_MinimalConfig(t *testing.T) {
 	})
 }
 
+func TestNewRelicWorkflow_RemoveEnrichments(t *testing.T) {
+	resourceName := "newrelic_workflow.foo"
+	channelResourceName := "foo"
+	workflowName := acctest.RandString(5)
+	enrichmentsSection := `
+enrichments {
+	nrql {
+		name = "Log Count"
+		configuration {
+			query = "SELECT count(*) FROM Log"
+		}
+	}
+}
+`
+	channelResources := testAccNewRelicChannelConfigurationEmail(channelResourceName)
+	workflowWithEnrichment := testAccNewRelicWorkflowConfigurationCustom(workflowName, channelResourceName, enrichmentsSection)
+	workflowWithoutEnrichment := testAccNewRelicWorkflowConfigurationCustom(workflowName, channelResourceName, "")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccNewRelicWorkflowDestroy,
+		Steps: []resource.TestStep{
+
+			// Test: Create workflow
+			{
+				Config: channelResources + workflowWithEnrichment,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicWorkflowExists(resourceName),
+				),
+			},
+			// Test: Remove enrichments, verify that the plan is empty afterwards
+			{
+				Config: channelResources + workflowWithoutEnrichment,
+			},
+		},
+	})
+}
+
 func testAccNewRelicWorkflowConfigurationMinimal(accountID int, name string) string {
 	return fmt.Sprintf(`
 resource "newrelic_notification_destination" "foo" {
@@ -282,7 +321,13 @@ resource "newrelic_notification_channel" "%[1]s" {
 }
 
 func testAccNewRelicWorkflowConfiguration(channelResourceName string) string {
-	workflowName := acctest.RandString(5)
+	return testAccNewRelicWorkflowConfigurationCustom(
+		acctest.RandString(5),
+		channelResourceName,
+		"")
+}
+
+func testAccNewRelicWorkflowConfigurationCustom(workflowName string, channelResourceName string, customSections string) string {
 	return fmt.Sprintf(`
 resource "newrelic_workflow" "foo" {
   account_id            = newrelic_notification_channel.%[1]s.account_id
@@ -303,10 +348,12 @@ resource "newrelic_workflow" "foo" {
     }
   }
 
+  %[3]s
+
   destination {
     channel_id = newrelic_notification_channel.%[1]s.id
   }
-}`, channelResourceName, workflowName)
+}`, channelResourceName, workflowName, customSections)
 }
 
 func testAccNewRelicWorkflowConfigurationEmail(accountID int, name string) string {


### PR DESCRIPTION
# Description

Once you have added at least one enrichment to a workflow, it is currently impossible to remove all of them without deleting the entire workflow. 
I also did a tiny refactoring in a couple of methods.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

The main fix was in the newrelic client, this PR just updates the client version and adds tests to reproduce the issue and verify the fix.
You can use the examples added in integration tests to reproduce the problem manually as well.
