### PR TITLE
Add optional account_id parameter to private location data source

### DIFF
--- a/newrelic/data_source_newrelic_synthetics_private_location.go
+++ b/newrelic/data_source_newrelic_synthetics_private_location.go
@@ -60,7 +60,7 @@ func dataSourceNewRelicSyntheticsPrivateLocationRead(ctx context.Context, d *sch
 
 		// It's possible to have multiple private locations with the same name.
 		// Return the first matching private location.
-		if accountID == accountID && loc.Name == name {
+		if loc.AccountID == accountID && loc.Name == name {
 			location = loc
 			break
 		}

--- a/newrelic/data_source_newrelic_synthetics_private_location.go
+++ b/newrelic/data_source_newrelic_synthetics_private_location.go
@@ -15,6 +15,11 @@ func dataSourceNewRelicSyntheticsPrivateLocation() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceNewRelicSyntheticsPrivateLocationRead,
 		Schema: map[string]*schema.Schema{
+			"account_id": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The ID of the account in New Relic.",
+			},
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -25,7 +30,9 @@ func dataSourceNewRelicSyntheticsPrivateLocation() *schema.Resource {
 }
 
 func dataSourceNewRelicSyntheticsPrivateLocationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*ProviderConfig).NewClient
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+	accountID := selectAccountID(providerConfig, d)
 
 	log.Printf("[INFO] Reading Synthetics monitor locations")
 
@@ -35,7 +42,8 @@ func dataSourceNewRelicSyntheticsPrivateLocationRead(ctx context.Context, d *sch
 	}
 
 	query := fmt.Sprintf("domain = 'SYNTH' AND type = 'PRIVATE_LOCATION' AND name = '%s'", name)
-	entitySearch, err := client.Entities.GetEntitySearchByQuery(
+	entitySearch, err := client.Entities.GetEntitySearchByQueryWithContext(
+		ctx,
 		entities.EntitySearchOptions{},
 		query,
 		[]entities.EntitySearchSortCriteria{},
@@ -52,7 +60,7 @@ func dataSourceNewRelicSyntheticsPrivateLocationRead(ctx context.Context, d *sch
 
 		// It's possible to have multiple private locations with the same name.
 		// Return the first matching private location.
-		if loc.Name == name {
+		if accountID == accountID && loc.Name == name {
 			location = loc
 			break
 		}

--- a/newrelic/data_source_newrelic_synthetics_private_location_test.go
+++ b/newrelic/data_source_newrelic_synthetics_private_location_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/newrelic/newrelic-client-go/v2/pkg/synthetics"
 )
 
-func TestAccNewRelicSyntheticsPrivateLocationDataSource(t *testing.T) {
+func TestAccNewRelicSyntheticsPrivateLocationDataSource_Basic(t *testing.T) {
 	t.Parallel()
 
 	privateLocationName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))

--- a/website/docs/d/synthetics_private_location.html.markdown
+++ b/website/docs/d/synthetics_private_location.html.markdown
@@ -14,7 +14,8 @@ Use this data source to get information about a specific Synthetics monitor priv
 
 ```hcl
 data "newrelic_synthetics_private_location" "example" {
-  name = "My private location"
+  account_id = 123456
+  name       = "My private location"
 }
 
 resource "newrelic_synthetics_monitor" "foo" {
@@ -25,11 +26,14 @@ resource "newrelic_synthetics_monitor" "foo" {
 
 ```hcl
 data "newrelic_synthetics_private_location" "example" {
-  name = "My private location"
+  account_id = 123456
+  name       = "My private location"
 }
-resource "newrelic_synthetics_monitor" "foo" {
+resource "newrelic_synthetics_step_monitor" "foo" {
   // Reference the private location data source in the monitor resource
-  location_private { guid = data.newrelic_synthetics_private_location.example.id }
+  location_private { 
+    guid = data.newrelic_synthetics_private_location.example.id 
+  }
 }
 ```
 
@@ -37,5 +41,5 @@ resource "newrelic_synthetics_monitor" "foo" {
 
 The following arguments are supported:
 
-
+* `account_id` - (Optional) The New Relic account ID of the associated private location. If left empty will default to account ID specified in provider level configuration.
 * `name` - (Required) The name of the Synthetics monitor private location.


### PR DESCRIPTION
# Description

This makes the private location search more specific by including account ID as a search parameter

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.
