### PR TITLE
feat(data_source_entity): remove limit on tags

### DIFF
--- a/newrelic/data_source_newrelic_entity.go
+++ b/newrelic/data_source_newrelic_entity.go
@@ -49,7 +49,6 @@ func dataSourceNewRelicEntity() *schema.Resource {
 			},
 			"tag": {
 				Type:        schema.TypeList,
-				MaxItems:    1,
 				Optional:    true,
 				Description: "A tag applied to the entity.",
 				Elem: &schema.Resource{

--- a/newrelic/data_source_newrelic_entity_integration_test.go
+++ b/newrelic/data_source_newrelic_entity_integration_test.go
@@ -94,6 +94,10 @@ data "newrelic_entity" "entity" {
 		key = "accountId"
 		value = "%d"
 	}
+	tag {
+		key = "account"
+		value = "New Relic Terraform Provider Acceptance Testing"
+	}
 }
 `, name, accountId)
 }

--- a/website/docs/d/entity.html.markdown
+++ b/website/docs/d/entity.html.markdown
@@ -82,7 +82,14 @@ The following arguments are supported:
 * `ignore_case` - (Optional) Ignore case of the `name` when searching for the entity. Defaults to false.
 * `type` - (Optional) The entity's type. Valid values are APPLICATION, DASHBOARD, HOST, MONITOR, and WORKLOAD.
 * `domain` - (Optional) The entity's domain. Valid values are APM, BROWSER, INFRA, MOBILE, SYNTH, and VIZ. If not specified, all domains are searched.
-* `tags` - (Optional) A tag applied to the entity.
+* `tag` - (Optional) A tag applied to the entity. See [Nested tag blocks](#nested-`tag`-blocks) below for details.
+
+### Nested `tag` blocks
+
+All nested `tag` blocks support the following common arguments:
+
+  * `key` - (Required) The tag key.
+  * `value` - (Required) The tag value.
 
 ## Attributes Reference
 


### PR DESCRIPTION
# Description

This PR removes the limit on tags that can be given as search parameters for the entity data source

Fixes #2095 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

Add more than 1 tag when using the entity data source and TF should not throw any errors and find the entity you're looking for.
