### PR TITLE
Verification that issues filter's name can't be empty

### DIFF
--- a/newrelic/resource_newrelic_workflow.go
+++ b/newrelic/resource_newrelic_workflow.go
@@ -70,6 +70,7 @@ func resourceNewRelicWorkflow() *schema.Resource {
 						"name": {
 							Type:        schema.TypeString,
 							Required:    true,
+							ValidateFunc: validation.StringIsNotWhiteSpace,
 							Description: "(Required) Filter's name.",
 						},
 						"type": {

--- a/newrelic/resource_newrelic_workflow_test.go
+++ b/newrelic/resource_newrelic_workflow_test.go
@@ -133,46 +133,6 @@ func TestNewRelicWorkflow_MinimalConfig(t *testing.T) {
 	})
 }
 
-func TestNewRelicWorkflow_RemoveEnrichments(t *testing.T) {
-	resourceName := "newrelic_workflow.foo"
-	channelResourceName := "foo"
-	workflowName := acctest.RandString(5)
-	issuesFilterName := acctest.RandString(5)
-	enrichmentsSection := `
-enrichments {
-	nrql {
-		name = "Log Count"
-		configuration {
-			query = "SELECT count(*) FROM Log"
-		}
-	}
-}
-`
-	channelResources := testAccNewRelicChannelConfigurationEmail(channelResourceName)
-	workflowWithEnrichment := testAccNewRelicWorkflowConfigurationCustom(workflowName, issuesFilterName, channelResourceName, enrichmentsSection)
-	workflowWithoutEnrichment := testAccNewRelicWorkflowConfigurationCustom(workflowName, issuesFilterName, channelResourceName, "")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckEnvVars(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccNewRelicWorkflowDestroy,
-		Steps: []resource.TestStep{
-
-			// Test: Create workflow
-			{
-				Config: channelResources + workflowWithEnrichment,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNewRelicWorkflowExists(resourceName),
-				),
-			},
-			// Test: Remove enrichments, verify that the plan is empty afterwards
-			{
-				Config: channelResources + workflowWithoutEnrichment,
-			},
-		},
-	})
-}
-
 func TestNewRelicWorkflow_EmptyIssuesFilterName(t *testing.T) {
 	channelResourceName := "foo"
 	workflowName := acctest.RandString(5)


### PR DESCRIPTION
# Description

This PR adds a verification that the issues filter's name is non-empty.

## Type of change
- Added verification that issues filter's name can't be empty
Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Create/Update a workflow with an empty issues filter name
