### PR TITLE
docs: Update 'violations' to 'incidents' in Alerts docs

### DIFF
--- a/newrelic/resource_newrelic_alert_condition.go
+++ b/newrelic/resource_newrelic_alert_condition.go
@@ -137,7 +137,7 @@ func resourceNewRelicAlertCondition() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ValidateFunc: intInSlice([]int{1, 2, 4, 8, 12, 24}),
-				Description:  "Automatically close instance-based violations, including JVM health metric violations, after the number of hours specified. Must be: 1, 2, 4, 8, 12 or 24.",
+				Description:  "Automatically close instance-based incidents, including JVM health metric incidents, after the number of hours specified. Must be: 1, 2, 4, 8, 12 or 24.",
 			},
 			"gc_metric": {
 				Type:        schema.TypeString,

--- a/newrelic/resource_newrelic_alert_muting_rule.go
+++ b/newrelic/resource_newrelic_alert_muting_rule.go
@@ -120,7 +120,7 @@ func resourceNewRelicAlertMutingRule() *schema.Resource {
 			"condition": {
 				Type:        schema.TypeList,
 				Required:    true,
-				Description: "The condition that defines which violations to target.",
+				Description: "The condition that defines which incidents to target.",
 				MaxItems:    1,
 				MinItems:    1,
 				Elem: &schema.Resource{
@@ -135,7 +135,7 @@ func resourceNewRelicAlertMutingRule() *schema.Resource {
 										Type:         schema.TypeString,
 										Required:     true,
 										ValidateFunc: validateMutingRuleConditionAttribute,
-										Description:  "The attribute on a violation.",
+										Description:  "The attribute on an incident.",
 									},
 									"operator": {
 										Type:         schema.TypeString,
@@ -182,7 +182,7 @@ func resourceNewRelicAlertMutingRule() *schema.Resource {
 				MaxItems:    1,
 				Optional:    true,
 				Elem:        scheduleSchema(),
-				Description: "The time window when the MutingRule should actively mute violations.",
+				Description: "The time window when the MutingRule should actively mute incidents.",
 			},
 		},
 	}

--- a/newrelic/resource_newrelic_infra_alert_condition.go
+++ b/newrelic/resource_newrelic_infra_alert_condition.go
@@ -144,7 +144,7 @@ func resourceNewRelicInfraAlertCondition() *schema.Resource {
 				MaxItems:    1,
 				Optional:    true,
 				Elem:        thresholdSchema(),
-				Description: "Identifies the threshold parameters for opening a critical alert violation.",
+				Description: "Identifies the threshold parameters for opening a critical alert incident.",
 				//TODO: ValidateFunc from thresholdConditionTypes map
 			},
 			"warning": {
@@ -154,7 +154,7 @@ func resourceNewRelicInfraAlertCondition() *schema.Resource {
 				MinItems:    1,
 				ForceNew:    true,
 				Elem:        thresholdSchema(),
-				Description: "Identifies the threshold parameters for opening a warning alert violation.",
+				Description: "Identifies the threshold parameters for opening a warning alert incident.",
 				//TODO: ValidateFunc from thresholdConditionTypes map
 			},
 			"integration_provider": {
@@ -167,7 +167,7 @@ func resourceNewRelicInfraAlertCondition() *schema.Resource {
 				Optional:     true,
 				Default:      24,
 				ValidateFunc: validateViolationCloseTimer(),
-				Description:  "Determines how much time, in hours, will pass before a violation is automatically closed. Valid values are 1, 2, 4, 8, 12, 24, 48, or 72",
+				Description:  "Determines how much time, in hours, will pass before an incident is automatically closed. Valid values are 1, 2, 4, 8, 12, 24, 48, or 72",
 			},
 			"description": {
 				Type:        schema.TypeString,

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -72,7 +72,7 @@ func termSchema() *schema.Resource {
 			"threshold_duration": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Description: "The duration, in seconds, that the threshold must violate in order to create a violation. Value must be a multiple of the 'aggregation_window' (which has a default of 60 seconds). Value must be within 120-3600 seconds for baseline conditions, within 120-7200 seconds for static conditions with the sum value function, and within 60-7200 seconds for static conditions with the single_value value function.",
+				Description: "The duration, in seconds, that the threshold must violate in order to create an incident. Value must be a multiple of the 'aggregation_window' (which has a default of 60 seconds). Value must be within 120-3600 seconds for baseline conditions, and within 60-7200 seconds for static conditions with the single_value value function.",
 			},
 		},
 	}
@@ -203,7 +203,7 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 			"violation_time_limit_seconds": {
 				Type:          schema.TypeInt,
 				Optional:      true,
-				Description:   "Sets a time limit, in seconds, that will automatically force-close a long-lasting violation after the time limit you select.  Must be in the range of 300 to 2592000 (inclusive)",
+				Description:   "Sets a time limit, in seconds, that will automatically force-close a long-lasting incident after the time limit you select.  Must be in the range of 300 to 2592000 (inclusive)",
 				ConflictsWith: []string{"violation_time_limit"},
 				ValidateFunc:  validation.IntBetween(300, 2592000),
 			},
@@ -237,7 +237,7 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 				Deprecated:    "use `violation_time_limit_seconds` attribute instead",
 				Optional:      true,
 				Computed:      true,
-				Description:   "Sets a time limit, in hours, that will automatically force-close a long-lasting violation after the time limit you select. Possible values are 'ONE_HOUR', 'TWO_HOURS', 'FOUR_HOURS', 'EIGHT_HOURS', 'TWELVE_HOURS', 'TWENTY_FOUR_HOURS', 'THIRTY_DAYS' (case insensitive).",
+				Description:   "Sets a time limit, in hours, that will automatically force-close a long-lasting incident after the time limit you select. Possible values are 'ONE_HOUR', 'TWO_HOURS', 'FOUR_HOURS', 'EIGHT_HOURS', 'TWELVE_HOURS', 'TWENTY_FOUR_HOURS', 'THIRTY_DAYS' (case insensitive).",
 				ConflictsWith: []string{"violation_time_limit_seconds"},
 				ValidateFunc:  validation.StringInSlice([]string{"ONE_HOUR", "TWO_HOURS", "FOUR_HOURS", "EIGHT_HOURS", "TWELVE_HOURS", "TWENTY_FOUR_HOURS", "THIRTY_DAYS"}, true),
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
@@ -247,12 +247,12 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 			"open_violation_on_expiration": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "Whether to create a new violation to capture that the signal expired.",
+				Description: "Whether to create a new incident to capture that the signal expired.",
 			},
 			"close_violations_on_expiration": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "Whether to close all open violations when the signal expires.",
+				Description: "Whether to close all open incidents when the signal expires.",
 			},
 			"aggregation_window": {
 				Type:        schema.TypeInt,
@@ -295,7 +295,7 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice([]string{"CADENCE", "EVENT_FLOW", "EVENT_TIMER"}, true),
-				Description:  "The method that determines when we consider an aggregation window to be complete so that we can evaluate the signal for violations. Default is EVENT_FLOW.",
+				Description:  "The method that determines when we consider an aggregation window to be complete so that we can evaluate the signal for incidents. Default is EVENT_FLOW.",
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					_, sinceValueExists := d.GetOk("nrql.0.since_value")
 					if sinceValueExists {

--- a/newrelic/resource_newrelic_synthetics_multilocation_alert_condition.go
+++ b/newrelic/resource_newrelic_synthetics_multilocation_alert_condition.go
@@ -18,7 +18,7 @@ func syntheticsMultiLocationConditionTermSchema() *schema.Resource {
 			"threshold": {
 				Type:        schema.TypeInt,
 				Required:    true,
-				Description: "The minimum number of monitor locations that must be concurrently failing before a violation is opened.",
+				Description: "The minimum number of monitor locations that must be concurrently failing before an incident is opened.",
 			},
 		},
 	}
@@ -83,7 +83,7 @@ func resourceNewRelicSyntheticsMultiLocationAlertCondition() *schema.Resource {
 				Type:         schema.TypeInt,
 				Required:     true,
 				ValidateFunc: validation.IntInSlice([]int{0, 3600, 7200, 14400, 28800, 43200, 86400}),
-				Description:  "The maximum number of seconds a violation can remain open before being closed by the system.  Must be one of: 0, 3600, 7200, 14400, 28800, 43200, 86400",
+				Description:  "The maximum number of seconds an incident can remain open before being closed by the system.  Must be one of: 0, 3600, 7200, 14400, 28800, 43200, 86400",
 			},
 		},
 	}

--- a/website/docs/r/alert_condition.html.markdown
+++ b/website/docs/r/alert_condition.html.markdown
@@ -99,7 +99,7 @@ The following arguments are supported:
   * `condition_scope` - (Required for some types) `application` or `instance`.  Choose `application` for most scenarios.  If you are using the JVM plugin in New Relic, the `instance` setting allows your condition to trigger [for specific app instances](https://docs.newrelic.com/docs/alerts/new-relic-alerts/defining-conditions/scope-alert-thresholds-specific-instances).
   * `enabled` - (Optional) Whether the condition is enabled or not. Defaults to true.
   * `gc_metric` - (Optional) A valid Garbage Collection metric e.g. `GC/G1 Young Generation`.
-  * `violation_close_timer` - (Optional) Automatically close instance-based violations, including JVM health metric violations, after the number of hours specified. Must be: `1`, `2`, `4`, `8`, `12` or `24`.
+  * `violation_close_timer` - (Optional) Automatically close instance-based incidents, including JVM health metric incidents, after the number of hours specified. Must be: `1`, `2`, `4`, `8`, `12` or `24`.
   * `runbook_url` - (Optional) Runbook URL to display in notifications.
   * `term` - (Required) A list of terms for this condition. See [Terms](#terms) below for details.
   * `user_defined_metric` - (Optional) A custom metric to be evaluated.

--- a/website/docs/r/alert_muting_rule.html.markdown
+++ b/website/docs/r/alert_muting_rule.html.markdown
@@ -3,12 +3,12 @@ layout: 'newrelic'
 page_title: 'New Relic: newrelic_alert_muting_rule'
 sidebar_current: 'docs-newrelic-resource-alert-muting-rule'
 description: |-
-  Create a muting rule for New Relic Alerts violations.
+  Create a muting rule for New Relic Alerts incidents.
 ---
 
 # Resource: newrelic_alert_muting_rule
 
-Use this resource to create a muting rule for New Relic Alerts violations.
+Use this resource to create a muting rule for New Relic Alerts incidents.
 
 -> **IMPORTANT!** Version 2.0.0 of the New Relic Terraform Provider introduces some [additional requirements](/providers/newrelic/newrelic/latest/docs/guides/migration_guide_v2) for configuring the provider.
 <br><br>
@@ -49,7 +49,7 @@ resource "newrelic_alert_muting_rule" "foo" {
 
 The following arguments are supported:
   * `account_id` - (Optional) The account id of the MutingRule.
-  * `condition`  - (Required) The condition that defines which violations to target. See [Nested condition blocks](#nested-condition-blocks) below for details.
+  * `condition`  - (Required) The condition that defines which incidents to target. See [Nested condition blocks](#nested-condition-blocks) below for details.
   * `enabled` - (Required) Whether the MutingRule is enabled.
   * `name` - The name of the MutingRule.
   * `description` - The description of the MutingRule.
@@ -64,7 +64,7 @@ All nested `condition` blocks support the following arguments:
 
 
 ### Nested `conditions` blocks
-* `attribute` - (Required) The attribute on a violation. Valid values are   `accountId`, `conditionId`, `conditionName`, `conditionRunbookUrl`, `conditionType`, `entity.guid`, `nrqlEventType`, `nrqlQuery`, `policyId`, `policyName`, `product`, `tags.<NAME>`, `targetId`, `targetName`
+* `attribute` - (Required) The attribute on an incident. Valid values are   `accountId`, `conditionId`, `conditionName`, `conditionRunbookUrl`, `conditionType`, `entity.guid`, `nrqlEventType`, `nrqlQuery`, `policyId`, `policyName`, `product`, `tags.<NAME>`, `targetId`, `targetName`
 * `operator` - (Required) The operator used to compare the attribute's value with the supplied value(s). Valid values are `ANY`, `CONTAINS`, `ENDS_WITH`, `EQUALS`, `IN`, `IS_BLANK`, `IS_NOT_BLANK`, `NOT_CONTAINS`, `NOT_ENDS_WITH`, `NOT_EQUALS`, `NOT_IN`, `NOT_STARTS_WITH`, `STARTS_WITH`
 * `values` - (Required) The value(s) to compare against the attribute's value.
 

--- a/website/docs/r/infra_alert_condition.html.markdown
+++ b/website/docs/r/infra_alert_condition.html.markdown
@@ -102,15 +102,15 @@ The following arguments are supported:
   * `event` - (Required) The metric event; for example, `SystemSample` or `StorageSample`.  Supported by the `infra_metric` condition type.
   * `select` - (Required) The attribute name to identify the metric being targeted; for example, `cpuPercent`, `diskFreePercent`, or `memoryResidentSizeBytes`.  The underlying API will automatically populate this value for Infrastructure integrations (for example `diskFreePercent`), so make sure to explicitly include this value to avoid diff issues.  Supported by the `infra_metric` condition type.
   * `comparison` - (Required) The operator used to evaluate the threshold value.  Valid values are `above`, `below`, and `equal`.  Supported by the `infra_metric` and `infra_process_running` condition types.
-  * `critical` - (Required) Identifies the threshold parameters for opening a critical alert violation. See [Thresholds](#thresholds) below for details.
-  * `warning` - (Optional) Identifies the threshold parameters for opening a warning alert violation. See [Thresholds](#thresholds) below for details.
+  * `critical` - (Required) Identifies the threshold parameters for opening a critical alert incident. See [Thresholds](#thresholds) below for details.
+  * `warning` - (Optional) Identifies the threshold parameters for opening a warning alert incident. See [Thresholds](#thresholds) below for details.
   * `enabled` - (Optional) Whether the condition is turned on or off.  Valid values are `true` and `false`.  Defaults to `true`.
   * `where` - (Optional) If applicable, this identifies any Infrastructure host filters used; for example: `hostname LIKE '%cassandra%'`.
   * `process_where` - (Optional) Any filters applied to processes; for example: `commandName = 'java'`.  Required by the `infra_process_running` condition type.
   * `integration_provider` - (Optional) For alerts on integrations, use this instead of `event`.  Supported by the `infra_metric` condition type.
   * `description` - (Optional) The description of the Infrastructure alert condition.
   * `runbook_url` - (Optional) Runbook URL to display in notifications.
-  * `violation_close_timer` - (Optional) Determines how much time will pass (in hours) before a violation is automatically closed. Valid values are `1 2 4 8 12 24 48 72`. Defaults to 24. If `0` is provided, default of `24` is used and will have configuration drift during the apply phase until a valid value is provided. 
+  * `violation_close_timer` - (Optional) Determines how much time will pass (in hours) before an incident is automatically closed. Valid values are `1 2 4 8 12 24 48 72`. Defaults to 24. If `0` is provided, default of `24` is used and will have configuration drift during the apply phase until a valid value is provided. 
 
 ```
 Warning: This resource will use the account ID linked to your API key. At the moment it is not possible to dynamically set the account ID.

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -79,19 +79,19 @@ The following arguments are supported:
 - `critical` - (Required) A list containing the `critical` threshold values. See [Terms](#terms) below for details.
 - `warning` - (Optional) A list containing the `warning` threshold values. See [Terms](#terms) below for details.
 - `value_function` - (Optional if `type` is `static`, omit when `type` is `baseline`) **DEPRECATED** Use `signal.slide_by` instead.
-- `violation_time_limit` - (Optional) **DEPRECATED:** Use `violation_time_limit_seconds` instead. Sets a time limit, in hours, that will automatically force-close a long-lasting violation after the time limit you select. Possible values are `ONE_HOUR`, `TWO_HOURS`, `FOUR_HOURS`, `EIGHT_HOURS`, `TWELVE_HOURS`, `TWENTY_FOUR_HOURS`, `THIRTY_DAYS` (case insensitive).<br>
+- `violation_time_limit` - (Optional) **DEPRECATED:** Use `violation_time_limit_seconds` instead. Sets a time limit, in hours, that will automatically force-close a long-lasting incident after the time limit you select. Possible values are `ONE_HOUR`, `TWO_HOURS`, `FOUR_HOURS`, `EIGHT_HOURS`, `TWELVE_HOURS`, `TWENTY_FOUR_HOURS`, `THIRTY_DAYS` (case insensitive).<br>
 <small>\***Note**: One of `violation_time_limit` _or_ `violation_time_limit_seconds` must be set, but not both.</small>
 
-- `violation_time_limit_seconds` - (Optional) Sets a time limit, in seconds, that will automatically force-close a long-lasting violation after the time limit you select. The value must be between 300 seconds (5 minutes) to 2592000 seconds (30 days) (inclusive). <br>
+- `violation_time_limit_seconds` - (Optional) Sets a time limit, in seconds, that will automatically force-close a long-lasting incident after the time limit you select. The value must be between 300 seconds (5 minutes) to 2592000 seconds (30 days) (inclusive). <br>
 <small>\***Note**: One of `violation_time_limit` _or_ `violation_time_limit_seconds` must be set, but not both.</small>
 
 - `fill_option` - (Optional) Which strategy to use when filling gaps in the signal. Possible values are `none`, `last_value` or `static`. If `static`, the `fill_value` field will be used for filling gaps in the signal.
 - `fill_value` - (Optional, required when `fill_option` is `static`) This value will be used for filling gaps in the signal.
 - `aggregation_window` - (Optional) The duration of the time window used to evaluate the NRQL query, in seconds. The value must be at least 30 seconds, and no more than 900 seconds (15 minutes). Default is 60 seconds.
 - `expiration_duration` - (Optional) The amount of time (in seconds) to wait before considering the signal expired. The value must be at least 30 seconds, and no more than 172800 seconds (48 hours).
-- `open_violation_on_expiration` - (Optional) Whether to create a new violation to capture that the signal expired.
-- `close_violations_on_expiration` - (Optional) Whether to close all open violations when the signal expires.
-- `aggregation_method` - (Optional) Determines when we consider an aggregation window to be complete so that we can evaluate the signal for violations. Possible values are `cadence`, `event_flow` or `event_timer`. Default is `event_flow`. `aggregation_method` cannot be set with `nrql.evaluation_offset`.
+- `open_violation_on_expiration` - (Optional) Whether to create a new incident to capture that the signal expired.
+- `close_violations_on_expiration` - (Optional) Whether to close all open incidents when the signal expires.
+- `aggregation_method` - (Optional) Determines when we consider an aggregation window to be complete so that we can evaluate the signal for incidents. Possible values are `cadence`, `event_flow` or `event_timer`. Default is `event_flow`. `aggregation_method` cannot be set with `nrql.evaluation_offset`.
 - `aggregation_delay` - (Optional) How long we wait for data that belongs in each aggregation window. Depending on your data, a longer delay may increase accuracy but delay notifications. Use `aggregation_delay` with the `event_flow` and `cadence` methods. The maximum delay is 1200 seconds (20 minutes) when using `event_flow` and 3600 seconds (60 minutes) when using `cadence`. In both cases, the minimum delay is 0 seconds and the default is 120 seconds. `aggregation_delay` cannot be set with `nrql.evaluation_offset`.
 - `aggregation_timer` - (Optional) How long we wait after each data point arrives to make sure we've processed the whole batch. Use `aggregation_timer` with the `event_timer` method. The timer value can range from 0 seconds to 1200 seconds (20 minutes); the default is 60 seconds. `aggregation_timer` cannot be set with `nrql.evaluation_offset`.
 - `slide_by` - (Optional) Gathers data in overlapping time windows to smooth the chart line, making it easier to spot trends. The `slide_by` value is specified in seconds and must be smaller than and a factor of the `aggregation_window`. `slide_by` cannot be used with `static` NRQL conditions using the `sum` `value_function`.
@@ -101,7 +101,7 @@ The following arguments are supported:
 The `nrql` block supports the following arguments:
 
 - `query` - (Required) The NRQL query to execute for the condition.
-- `evaluation_offset` - (Optional) **DEPRECATED:** Use `aggregation_method` instead. Represented in minutes and must be within 1-20 minutes (inclusive). NRQL queries are evaluated based on their `aggregation_window` size. The start time depends on this value. It's recommended to set this to 3 windows. An offset of less than 3 windows will trigger violations sooner, but you may see more false positives and negatives due to data latency. With `evaluation_offset` set to 3 windows and an `aggregation_window` of 60 seconds, the NRQL time window applied to your query will be: `SINCE 3 minutes ago UNTIL 2 minutes ago`. `evaluation_offset` cannot be set with `aggregation_method`, `aggregation_delay`, or `aggregation_timer`.<br>
+- `evaluation_offset` - (Optional) **DEPRECATED:** Use `aggregation_method` instead. Represented in minutes and must be within 1-20 minutes (inclusive). NRQL queries are evaluated based on their `aggregation_window` size. The start time depends on this value. It's recommended to set this to 3 windows. An offset of less than 3 windows will trigger incidents sooner, but you may see more false positives and negatives due to data latency. With `evaluation_offset` set to 3 windows and an `aggregation_window` of 60 seconds, the NRQL time window applied to your query will be: `SINCE 3 minutes ago UNTIL 2 minutes ago`. `evaluation_offset` cannot be set with `aggregation_method`, `aggregation_delay`, or `aggregation_timer`.<br>
 - `since_value` - (Optional)  **DEPRECATED:** Use `aggregation_method` instead. The value to be used in the `SINCE <X> minutes ago` clause for the NRQL query. Must be between 1-20 (inclusive). <br>
 
 ## Terms
@@ -114,15 +114,15 @@ The `term` block supports the following arguments:
 
 - `operator` - (Optional) Valid values are `above`, `above_or_equals`, `below`, `below_or_equals`, `equals`, or `not_equals` (case insensitive). Defaults to `equals`. Note that when using a `type` of `baseline`, the only valid option here is `above`.
 - `priority` - (Optional) `critical` or `warning`. Defaults to `critical`.
-- `threshold` - (Required) The value which will trigger a violation.
-<br>For _baseline_ NRQL alert conditions, the value must be in the range [1, 1000]. The value is the number of standard deviations from the baseline that the metric must exceed in order to create a violation.
-- `threshold_duration` - (Optional) The duration, in seconds, that the threshold must violate in order to create a violation. Value must be a multiple of the `aggregation_window` (which has a default of 60 seconds).
+- `threshold` - (Required) The value which will trigger an incident.
+<br>For _baseline_ NRQL alert conditions, the value must be in the range [1, 1000]. The value is the number of standard deviations from the baseline that the metric must exceed in order to create an incident.
+- `threshold_duration` - (Optional) The duration, in seconds, that the threshold must violate in order to create an incident. Value must be a multiple of the `aggregation_window` (which has a default of 60 seconds).
 <br>For _baseline_ NRQL alert conditions, the value must be within 120-3600 seconds (inclusive).
 <br>For _static_ NRQL alert conditions with the `sum` value function, the value must be within 120-7200 seconds (inclusive).
 <br>For _static_ NRQL alert conditions with the `single_value` value function, the value must be within 60-7200 seconds (inclusive).
 
 - `threshold_occurrences` - (Optional) The criteria for how many data points must be in violation for the specified threshold duration. Valid values are: `all` or `at_least_once` (case insensitive).
-- `duration` - (Optional) **DEPRECATED:** Use `threshold_duration` instead. The duration of time, in _minutes_, that the threshold must violate for in order to create a violation. Must be within 1-120 (inclusive).
+- `duration` - (Optional) **DEPRECATED:** Use `threshold_duration` instead. The duration of time, in _minutes_, that the threshold must violate for in order to create an incident. Must be within 1-120 (inclusive).
 - `time_function` - (Optional) **DEPRECATED:** Use `threshold_occurrences` instead. The criteria for how many data points must be in violation for the specified threshold duration. Valid values are: `all` or `any`.
 
 ## Attributes Reference


### PR DESCRIPTION
# Description

Updating instances of "violation" to be "incident" in the Alerts resources documentation. This reflects a change in nomenclature that is represented elsewhere (e.g., New Relic's public documentation, UI copy in the web app). Note that this **does not** update instances of "violation" in any API field names.

## Type of change

- [x] Documentation amendments

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works **N/A**
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally. **N/A**

## How to test this change?

Changes are only to documentation.
