### PR TITLE
Fix url instead of domain, on the domain field for newrelic_synthetic…

### DIFF
--- a/website/docs/r/synthetics_monitor_cert_check.html.markdown
+++ b/website/docs/r/synthetics_monitor_cert_check.html.markdown
@@ -15,7 +15,7 @@ Use this resource to create, update, and delete a synthetics certificate check m
 ```hcl
 resource "newrelic_synthetics_cert_check_monitor" "cert-check-monitor" {
   name                   = "cert-check-monitor"
-  domain                 = "http://www.example.com"
+  domain                 = "www.example.com"
   locations_public       = ["AP_SOUTH_1"]
   certificate_expiration = "10"
   period                 = "EVERY_6_HOURS"


### PR DESCRIPTION
The document recommends the use of a URL instead of a domain.

This PR aims to fix the docs, the user should place a domain, not a URL.

Using the New Relic UI, having a URL is not even allowed.

-This change is updating the documentation.

No tests are required, just updating the doc.