### PR TITLE
fix(synthetics): set additional attribute values on import

### DIFF
--- a/newrelic/resource_helpers_synthetics.go
+++ b/newrelic/resource_helpers_synthetics.go
@@ -376,3 +376,14 @@ func getMonitorID(monitorGUID string) string {
 	monitorID := splitGUID[3]
 	return monitorID
 }
+
+// This map is used to facilitate safely setting the schema attributes which
+// are returned as part of the monitor's entity tags. We have a limited set
+// of attributes we can set due to technical limitations in the API.
+// Note this is a caveat in how synthetics monitor data is provided
+// from the entity API. This is not a common resource pattern.
+var syntheticsMonitorTagKeyToSchemaAttrMap = map[string]string{
+	"runtimeType":        "runtime_type",
+	"runtimeTypeVersion": "runtime_type_version",
+	"scriptLanguage":     "script_language",
+}

--- a/newrelic/resource_helpers_synthetics.go
+++ b/newrelic/resource_helpers_synthetics.go
@@ -377,9 +377,9 @@ func getMonitorID(monitorGUID string) string {
 	return monitorID
 }
 
-// This map is used to facilitate safely setting the schema attributes which
-// are returned as part of the monitor's entity tags. We have a limited set
-// of attributes we can set due to technical limitations in the API.
+// This map facilitates safely setting the schema attributes which
+// are returned as part of the monitor's entity tags. We have a limited
+// set of attributes we can set from tags due to technical limitations in the API.
 // Note this is a caveat in how synthetics monitor data is provided
 // from the entity API. This is not a common resource pattern.
 var syntheticsMonitorTagKeyToSchemaAttrMap = map[string]string{

--- a/newrelic/resource_newrelic_synthetics_script_monitor.go
+++ b/newrelic/resource_newrelic_synthetics_script_monitor.go
@@ -232,8 +232,10 @@ func resourceNewRelicSyntheticsScriptMonitorUpdate(ctx context.Context, d *schem
 		}
 
 		err = setSyntheticsMonitorAttributes(d, map[string]string{
-			"name": resp.Monitor.Name,
-			"guid": string(resp.Monitor.GUID),
+			"name":   resp.Monitor.Name,
+			"guid":   string(resp.Monitor.GUID),
+			"period": string(resp.Monitor.Period),
+			"status": string(resp.Monitor.Status),
 		})
 		if err != nil {
 			return diag.FromErr(err)
@@ -252,8 +254,10 @@ func resourceNewRelicSyntheticsScriptMonitorUpdate(ctx context.Context, d *schem
 		}
 
 		err = setSyntheticsMonitorAttributes(d, map[string]string{
-			"name": resp.Monitor.Name,
-			"guid": string(resp.Monitor.GUID),
+			"name":   resp.Monitor.Name,
+			"guid":   string(resp.Monitor.GUID),
+			"period": string(resp.Monitor.Period),
+			"status": string(resp.Monitor.Status),
 		})
 		if err != nil {
 			return diag.FromErr(err)

--- a/newrelic/resource_newrelic_synthetics_script_monitor.go
+++ b/newrelic/resource_newrelic_synthetics_script_monitor.go
@@ -188,10 +188,20 @@ func resourceNewRelicSyntheticsScriptMonitorRead(ctx context.Context, d *schema.
 	switch e := (*resp).(type) {
 	case *entities.SyntheticMonitorEntity:
 		err = setSyntheticsMonitorAttributes(d, map[string]string{
-			"name": e.Name,
-			"type": string(e.MonitorType),
-			"guid": string(e.GUID),
+			"name":   e.Name,
+			"type":   string(e.MonitorType),
+			"guid":   string(e.GUID),
+			"period": string(syntheticsMonitorPeriodValueMap[int(e.GetPeriod())]),
+			"status": string(e.MonitorSummary.Status),
 		})
+
+		for _, t := range e.Tags {
+			if k, ok := syntheticsMonitorTagKeyToSchemaAttrMap[t.Key]; ok {
+				if len(t.Values) == 1 {
+					_ = d.Set(k, t.Values[0])
+				}
+			}
+		}
 	}
 
 	return diag.FromErr(err)
@@ -205,7 +215,7 @@ func resourceNewRelicSyntheticsScriptMonitorUpdate(ctx context.Context, d *schem
 
 	monitorType, ok := d.GetOk("type")
 	if !ok {
-		log.Printf("Not Monitor type specified")
+		log.Printf("No monitor type specified")
 	}
 
 	switch monitorType {

--- a/newrelic/resource_newrelic_synthetics_script_monitor_integration_test.go
+++ b/newrelic/resource_newrelic_synthetics_script_monitor_integration_test.go
@@ -60,9 +60,9 @@ func TestAccNewRelicSyntheticsScriptBrowserMonitor(t *testing.T) {
 	resourceName := "newrelic_synthetics_script_monitor.bar"
 	rName := acctest.RandString(5)
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheckEnvVars(t) },
-		Providers: testAccProviders,
-		// CheckDestroy: testAccCheckNewRelicSyntheticsScriptMonitorDestroy,
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicSyntheticsScriptMonitorDestroy,
 		Steps: []resource.TestStep{
 			//Test: Create
 			{

--- a/newrelic/resource_newrelic_synthetics_script_monitor_integration_test.go
+++ b/newrelic/resource_newrelic_synthetics_script_monitor_integration_test.go
@@ -31,27 +31,22 @@ func TestAccNewRelicSyntheticsScriptAPIMonitor(t *testing.T) {
 					testAccCheckNewRelicSyntheticsScriptMonitorExists(resourceName),
 				),
 			},
-			// //Test: Update
-			// {
-			// 	Config: testAccNewRelicSyntheticsScriptAPIMonitorConfig(fmt.Sprintf("%s-updated", rName), monitorTypeStr),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		testAccCheckNewRelicSyntheticsScriptMonitorExists(resourceName),
-			// 	),
-			// },
+			//Test: Update
+			{
+				Config: testAccNewRelicSyntheticsScriptAPIMonitorConfig(fmt.Sprintf("%s-updated", rName), monitorTypeStr),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicSyntheticsScriptMonitorExists(resourceName),
+				),
+			},
 			// Test: Import
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					// not returned from the API
-					"period",
+					// Technical limitations with the API prevent us from setting the following attributes.
 					"locations_public",
 					"location_private",
-					"status",
-					"runtime_type",
-					"runtime_type_version",
-					"script_language",
 					"tag",
 					"script",
 					"enable_screenshot_on_failure_and_script",

--- a/newrelic/resource_newrelic_synthetics_script_monitor_integration_test.go
+++ b/newrelic/resource_newrelic_synthetics_script_monitor_integration_test.go
@@ -31,13 +31,13 @@ func TestAccNewRelicSyntheticsScriptAPIMonitor(t *testing.T) {
 					testAccCheckNewRelicSyntheticsScriptMonitorExists(resourceName),
 				),
 			},
-			//Test: Update
-			{
-				Config: testAccNewRelicSyntheticsScriptAPIMonitorConfig(fmt.Sprintf("%s-updated", rName), monitorTypeStr),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNewRelicSyntheticsScriptMonitorExists(resourceName),
-				),
-			},
+			// //Test: Update
+			// {
+			// 	Config: testAccNewRelicSyntheticsScriptAPIMonitorConfig(fmt.Sprintf("%s-updated", rName), monitorTypeStr),
+			// 	Check: resource.ComposeTestCheckFunc(
+			// 		testAccCheckNewRelicSyntheticsScriptMonitorExists(resourceName),
+			// 	),
+			// },
 			// Test: Import
 			{
 				ResourceName:      resourceName,
@@ -65,9 +65,9 @@ func TestAccNewRelicSyntheticsScriptBrowserMonitor(t *testing.T) {
 	resourceName := "newrelic_synthetics_script_monitor.bar"
 	rName := acctest.RandString(5)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckEnvVars(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckNewRelicSyntheticsScriptMonitorDestroy,
+		PreCheck:  func() { testAccPreCheckEnvVars(t) },
+		Providers: testAccProviders,
+		// CheckDestroy: testAccCheckNewRelicSyntheticsScriptMonitorDestroy,
 		Steps: []resource.TestStep{
 			//Test: Create
 			{
@@ -89,14 +89,9 @@ func TestAccNewRelicSyntheticsScriptBrowserMonitor(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					// not returned from the API
-					"period",
+					// Technical limitations with the API prevent us from setting the following attributes.
 					"locations_public",
 					"location_private",
-					"status",
-					"runtime_type",
-					"runtime_type_version",
-					"script_language",
 					"tag",
 					"script",
 					"enable_screenshot_on_failure_and_script",
@@ -129,7 +124,7 @@ func testAccNewRelicSyntheticsScriptBrowserMonitorConfig(name string) string {
 	return fmt.Sprintf(`
 		resource "newrelic_synthetics_script_monitor" "bar" {
 			enable_screenshot_on_failure_and_script	=	true
-			locations_public	=	["AP_SOUTH_1"]
+			locations_public	=	["AP_SOUTH_1", "US_EAST_1"]
 			name	=	"%[1]s"
 			period	=	"EVERY_HOUR"
 			runtime_type_version	=	"100"


### PR DESCRIPTION
This pull request facilitates setting the following additional schema attributes for the `newrelic_synthetics_script_monitor` resource. 

- `period`
- `runtime_type`
- `runtime_type_version`
- `script_language` 
- `status`

Fixes: #2078 