### PR TITLE
Set entity_guid after creating NRQL alert condition

### DIFF
--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -418,7 +418,7 @@ func resourceNewRelicNrqlAlertConditionCreate(ctx context.Context, d *schema.Res
 	}
 
 	retryErr := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		_, err := client.Alerts.GetNrqlConditionQueryWithContext(ctx, accountID, strconv.Itoa(conditionID))
+		condition, err = client.Alerts.GetNrqlConditionQueryWithContext(ctx, accountID, strconv.Itoa(conditionID))
 		if err != nil {
 			if _, ok := err.(*errors.NotFound); ok {
 				return resource.RetryableError(fmt.Errorf("nrql condition was not created"))
@@ -435,7 +435,7 @@ func resourceNewRelicNrqlAlertConditionCreate(ctx context.Context, d *schema.Res
 
 	d.SetId(serializeIDs([]int{d.Get("policy_id").(int), conditionID})) // set to correct ID
 
-	return nil
+	return diag.FromErr(flattenNrqlAlertCondition(accountID, condition, d))
 }
 
 func resourceNewRelicNrqlAlertConditionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
Fixes issue created in https://github.com/newrelic/terraform-provider-newrelic/pull/2082 where the `entity_guid` property is no longer set when a newrelic_nrql_alert_condition has been created.

# Description

Restores the call to `flattenNrqlAlertCondition` which was lost when `resourceNewRelicAlertPolicyChannelRead` stopped being called. `flattenNrqlAlertCondition` sets a number of properties on the resource including the `entity_guid`.

Fixes #2150 #2115

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [X] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [X] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Create a `newrelic_nrql_alert_condition` and assign tags to it using `newrelic_entity_tags`
  ```
  resource "newrelic_alert_policy" "foo" {
    name = "foo"
  }
  
  
  resource "newrelic_nrql_alert_condition" "foo" {
    account_id                     = <Your Account ID>
    policy_id                      = newrelic_alert_policy.foo.id
    type                           = "static"
    name                           = "foo"
    description                    = "Alert when transactions are taking too long"
    runbook_url                    = "https://www.example.com"
    enabled                        = true
    violation_time_limit_seconds   = 3600
    fill_option                    = "static"
    fill_value                     = 1.0
    aggregation_window             = 60
    aggregation_method             = "event_flow"
    aggregation_delay              = 120
    expiration_duration            = 120
    open_violation_on_expiration   = true
    close_violations_on_expiration = true
    slide_by                       = 30
  
    nrql {
      query = "SELECT average(duration) FROM Transaction where appName = 'Your App'"
    }
  
    critical {
      operator              = "above"
      threshold             = 5.5
      threshold_duration    = 300
      threshold_occurrences = "ALL"
    }
  
    warning {
      operator              = "above"
      threshold             = 3.5
      threshold_duration    = 600
      threshold_occurrences = "ALL"
    }
  }
  
  resource "newrelic_entity_tags" "foo" {
    guid = newrelic_nrql_alert_condition.foo.entity_guid
  
    tag {
      key    = "my-key"
      values = ["my-value", "my-other-value"]
    }
  
    tag {
      key    = "my-key-2"
      values = ["my-value-2"]
    }
  }
  ```
