### PR TITLE
tests: fix service level and workflow tests

### DIFF
--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -19,7 +19,7 @@ func TestAccNewRelicNrqlAlertCondition_Basic(t *testing.T) {
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
 		Steps: []resource.TestStep{
@@ -59,7 +59,7 @@ func TestAccNewRelicNrqlAlertCondition_MissingPolicy(t *testing.T) {
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
 		Steps: []resource.TestStep{
@@ -89,7 +89,7 @@ func TestAccNewRelicNrqlAlertCondition_NerdGraphThresholdDurationValidationError
 	conditionalAttrBaseline := `baseline_direction = "lower_only"`
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
 		Steps: []resource.TestStep{
@@ -130,7 +130,7 @@ func TestAccNewRelicNrqlAlertCondition_NerdGraphBaseline(t *testing.T) {
 	conditionalAttr := `baseline_direction = "lower_only"` // value transformed to UPPERCASE in expand/flatten
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
 		Steps: []resource.TestStep{
@@ -220,7 +220,7 @@ func TestAccNewRelicNrqlAlertCondition_NerdGraphStatic(t *testing.T) {
 	conditionalAttr := `value_function = "Single_valuE"` // value transformed to UPPERCASE in expand/flatten
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
 		Steps: []resource.TestStep{
@@ -309,7 +309,7 @@ func TestAccNewRelicNrqlAlertCondition_NerdGraphStreamingMethods(t *testing.T) {
 	timer := "null"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
 		Steps: []resource.TestStep{
@@ -347,7 +347,7 @@ func TestAccNewRelicNrqlAlertCondition_AggregationDelayZero(t *testing.T) {
 	timer := "null"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
 		Steps: []resource.TestStep{
@@ -388,7 +388,7 @@ func TestAccNewRelicNrqlAlertCondition_NerdGraphNrqlEvaluationOffset(t *testing.
 	method := "null"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
 		Steps: []resource.TestStep{
@@ -439,7 +439,7 @@ func TestAccNewRelicNrqlAlertCondition_NerdGraphValidationErrorBadUserInputOnCre
 	rNameStatic := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
 		Steps: []resource.TestStep{
@@ -464,7 +464,7 @@ func TestAccNewRelicNrqlAlertCondition_RevertToDeprecatedSinceValue(t *testing.T
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
 		Steps: []resource.TestStep{
@@ -502,7 +502,7 @@ func TestAccNewRelicNrqlAlertCondition_StreamingMethodsDefaults(t *testing.T) {
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
 		Steps: []resource.TestStep{
@@ -527,7 +527,7 @@ func TestAccNewRelicNrqlAlertCondition_StaticConditionOptionalValueFunction(t *t
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
 		Steps: []resource.TestStep{
@@ -559,7 +559,7 @@ func TestAccNewRelicNrqlAlertCondition_StaticConditionConvertSumToSlideBy(t *tes
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
 		Steps: []resource.TestStep{
@@ -591,7 +591,7 @@ func TestAccNewRelicNrqlAlertCondition_StaticConditionSlideByNoValueFunction(t *
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
 		Steps: []resource.TestStep{
@@ -941,7 +941,7 @@ func testAccNewRelicNrqlAlertConditionSinceValue(
       name = "tf-test-%[1]s"
 	}
 
-	
+
 	resource "newrelic_nrql_alert_condition" "since_value" {
       policy_id                      = newrelic_alert_policy.foo.id
 	  type                           = "static"
@@ -952,7 +952,7 @@ func testAccNewRelicNrqlAlertConditionSinceValue(
 	  violation_time_limit_seconds   = 86400
 	  expiration_duration            = 120
 	  close_violations_on_expiration = true
-	
+
 	  nrql {
 		query       = <<-EOT
 			SELECT count(*) FROM TestEvent

--- a/newrelic/resource_newrelic_service_level_test.go
+++ b/newrelic/resource_newrelic_service_level_test.go
@@ -5,6 +5,7 @@ package newrelic
 
 import (
 	"fmt"
+	"log"
 	"testing"
 	"time"
 
@@ -12,14 +13,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/entities"
 )
 
 func TestAccNewRelicServiceLevel_Basic(t *testing.T) {
 	resourceName := "newrelic_service_level.sli"
-	rName := acctest.RandString(5)
+	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
+
+	defer cleanupDanglingServiceLevelResources()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicServiceLevelDestroy,
 		Steps: []resource.TestStep{
@@ -43,7 +47,6 @@ func TestAccNewRelicServiceLevel_Basic(t *testing.T) {
 
 func testAccNewRelicServiceLevelConfig(name string) string {
 	return fmt.Sprintf(`
-
 resource "newrelic_workload" "workload" {
 	name = "%[2]s"
 	account_id = %[1]d
@@ -53,7 +56,7 @@ resource "newrelic_workload" "workload" {
 resource "newrelic_service_level" "sli" {
 	guid = newrelic_workload.workload.guid
 	name = "%[2]s"
-	
+
 	events {
 		account_id = %[1]d
 		valid_events {
@@ -68,22 +71,21 @@ resource "newrelic_service_level" "sli" {
 		}
 	}
 
-    objective {
-        target = 99.00
-        time_window {
-            rolling {
-                count = 7
-                unit = "DAY"
-            }
-        }
-    }
+	objective {
+		target = 99.00
+		time_window {
+			rolling {
+				count = 7
+				unit = "DAY"
+			}
+		}
+	}
 }
 `, testAccountID, name)
 }
 
 func testAccNewRelicServiceLevelConfigUpdated(name string) string {
 	return fmt.Sprintf(`
-
 resource "newrelic_workload" "workload" {
 	name = "%[2]s"
 	account_id = %[1]d
@@ -93,7 +95,7 @@ resource "newrelic_workload" "workload" {
 resource "newrelic_service_level" "sli" {
 	guid = newrelic_workload.workload.guid
 	name = "%[2]s-updated"
-	
+
 	events {
 		account_id = %[1]d
 		valid_events {
@@ -108,15 +110,15 @@ resource "newrelic_service_level" "sli" {
 		}
 	}
 
-    objective {
-        target = 99.00
-        time_window {
-            rolling {
-                count = 7
-                unit = "DAY"
-            }
-        }
-    }
+	objective {
+		target = 99.00
+		time_window {
+			rolling {
+				count = 7
+				unit = "DAY"
+			}
+		}
+	}
 }
 `, testAccountID, name)
 }
@@ -170,6 +172,38 @@ func testAccCheckNewRelicServiceLevelDestroy(s *terraform.State) error {
 		if err == nil {
 			return fmt.Errorf("SLI still exists")
 		}
+	}
+
+	return nil
+}
+
+func cleanupDanglingServiceLevelResources() error {
+	client := testAccProvider.Meta().(*ProviderConfig).NewClient
+	query := "domain = 'EXT' AND type = 'SERVICE_LEVEL' AND name LIKE '%tf-test-%'"
+
+	fmt.Printf("\n[INFO] cleaning up any dangling integration test resources... \n")
+	time.Sleep(1 * time.Second)
+
+	matches, err := client.Entities.GetEntitySearchByQuery(
+		entities.EntitySearchOptions{},
+		query,
+		[]entities.EntitySearchSortCriteria{},
+	)
+
+	if err != nil {
+		return fmt.Errorf("error cleaning up dangling synthetics resources: %s", err)
+	}
+
+	if matches != nil {
+		resources := matches.Results.Entities
+		for _, r := range resources {
+			_, err := client.ServiceLevel.ServiceLevelDelete(common.EntityGUID(string(r.GetGUID())))
+			if err != nil {
+				log.Printf("[ERROR] error deleting dangling resource: %s", err)
+			}
+		}
+
+		fmt.Printf("\n[INFO] deleted %d dangling resources \n", len(resources))
 	}
 
 	return nil

--- a/newrelic/resource_newrelic_synthetics_alert_condition_test.go
+++ b/newrelic/resource_newrelic_synthetics_alert_condition_test.go
@@ -17,7 +17,7 @@ func TestAccNewRelicSyntheticsAlertCondition_Basic(t *testing.T) {
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicSyntheticsAlertConditionDestroy,
 		Steps: []resource.TestStep{
@@ -56,7 +56,7 @@ func TestAccNewRelicSyntheticsAlertCondition_MissingPolicy(t *testing.T) {
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicSyntheticsAlertConditionDestroy,
 		Steps: []resource.TestStep{

--- a/newrelic/resource_newrelic_workflow_test.go
+++ b/newrelic/resource_newrelic_workflow_test.go
@@ -242,14 +242,14 @@ func TestNewRelicWorkflow_WithUpdatedNotificationTriggers(t *testing.T) {
 
 			// Test: Create workflow
 			{
-				Config: testAccNewRelicWorkflowConfigurationWithNotificationTriggers(testAccountID, rName, "[ACTIVATED]"),
+				Config: testAccNewRelicWorkflowConfigurationWithNotificationTriggers(testAccountID, rName, `["ACTIVATED"]`),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicWorkflowExists(resourceName),
 				),
 			},
 			// Test: Update
 			{
-				Config: testAccNewRelicWorkflowConfigurationWithNotificationTriggers(testAccountID, fmt.Sprintf("%s-updated", rName), "[ACTIVATED, CLOSED]"),
+				Config: testAccNewRelicWorkflowConfigurationWithNotificationTriggers(testAccountID, fmt.Sprintf("%s-updated", rName), `["ACTIVATED", "CLOSED"]`),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicWorkflowExists(resourceName),
 				),


### PR DESCRIPTION
This PR introduces the following updates:
- uses `testAccPreCheckEnvVars()` instead of `testAccPreCheck()` in some tests that do not require an application entity to be created. This reduces associated test execution times.
- fixes an HCL syntax issue in some workflow tests
- adds a cleanup/sweeper function to delete any dangling service level resources so we don't exceed the limit for service level rules in our integration testing account