### PR TITLE
tests: add sweeper function for dangling workload resources, add test resource name helper

### DIFF
--- a/newrelic/provider_test.go
+++ b/newrelic/provider_test.go
@@ -199,3 +199,12 @@ func testAccApplicationsCleanup(t *testing.T) {
 
 	testAccCleanupComplete = true
 }
+
+// Facilitates using a standardized name when creating test resources.
+// The name will always be prefixed with "tf-test-". This ensures when
+// we attempt to delete any dangling extraneous resources, we only delete
+// resources with names that start with "tf-test-". This helps avoid
+// deleting any resources that might be cross-account, such as workloads.
+func generateNameForIntegrationTestResource() string {
+	return fmt.Sprintf("tf_test_%s", acctest.RandString(5))
+}

--- a/newrelic/provider_unit_test.go
+++ b/newrelic/provider_unit_test.go
@@ -5,10 +5,18 @@ package newrelic
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestProvider(t *testing.T) {
 	if err := Provider().InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
+}
+
+func TestGenerateNameForIntegrationTestResource(t *testing.T) {
+	result := generateNameForIntegrationTestResource()
+
+	require.Contains(t, result, "tf_test_")
 }

--- a/newrelic/resource_newrelic_alert_channel_test.go
+++ b/newrelic/resource_newrelic_alert_channel_test.go
@@ -17,7 +17,7 @@ import (
 func TestAccNewRelicAlertChannel_Basic(t *testing.T) {
 	resourceName := "newrelic_alert_channel.foo"
 	rand := acctest.RandString(5)
-	rName := fmt.Sprintf("tf-test-%s", rand)
+	rName := generateNameForIntegrationTestResource()
 	rNameUpdated := fmt.Sprintf("tf-test-updated-%s", rand)
 	rNameDeprecatedUpdated := fmt.Sprintf("tf-test-deprecated-updated-%s", rand)
 
@@ -73,8 +73,7 @@ func TestAccNewRelicAlertChannel_Webhook(t *testing.T) {
 	t.Skip("Skipping test due to odd API error. Needs investigation.")
 
 	resourceName := "newrelic_alert_channel.foo"
-	rand := acctest.RandString(5)
-	rName := fmt.Sprintf("tf-test-%s", rand)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -116,8 +115,7 @@ func TestAccNewRelicAlertChannel_Webhook(t *testing.T) {
 func TestAccNewRelicAlertChannel_WebhookPayloadHeaderStringConflicts(t *testing.T) {
 	t.Skip("Skipping test due to odd API error. Needs investigation.")
 
-	rand := acctest.RandString(5)
-	rName := fmt.Sprintf("tf-test-%s", rand)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -159,8 +157,7 @@ func TestAccNewRelicAlertChannel_WebhookPayloadHeaderString(t *testing.T) {
 	t.Skip("Skipping test due to odd API error. Needs investigation.")
 
 	resourceName := "newrelic_alert_channel.foo"
-	rand := acctest.RandString(5)
-	rName := fmt.Sprintf("tf-test-%s", rand)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -186,8 +183,7 @@ func TestAccNewRelicAlertChannel_Slack(t *testing.T) {
 	t.Skip("Skipping test due to odd API error. Needs investigation.")
 
 	resourceName := "newrelic_alert_channel.foo"
-	rand := acctest.RandString(5)
-	rName := fmt.Sprintf("tf-test-%s", rand)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -225,8 +221,7 @@ func TestAccNewRelicAlertChannel_PagerDuty(t *testing.T) {
 	t.Skip("Skipping test due to odd API error. Needs investigation.")
 
 	resourceName := "newrelic_alert_channel.foo"
-	rand := acctest.RandString(5)
-	rName := fmt.Sprintf("tf-test-%s", rand)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -274,8 +269,7 @@ func TestAccNewRelicAlertChannel_OpsGenie(t *testing.T) {
 	t.Skip("Skipping test due to odd API error. Needs investigation.")
 
 	resourceName := "newrelic_alert_channel.foo"
-	rand := acctest.RandString(5)
-	rName := fmt.Sprintf("tf-test-%s", rand)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -316,8 +310,7 @@ func TestAccNewRelicAlertChannel_VictorOps(t *testing.T) {
 	t.Skip("Skipping test due to odd API error. Needs investigation.")
 
 	resourceName := "newrelic_alert_channel.foo"
-	rand := acctest.RandString(5)
-	rName := fmt.Sprintf("tf-test-%s", rand)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -353,8 +346,7 @@ func TestAccNewRelicAlertChannel_VictorOps(t *testing.T) {
 func TestAccNewRelicAlertChannel_WebhookPayloadValidation(t *testing.T) {
 	t.Skip("Skipping test due to odd API error. Needs investigation.")
 
-	rand := acctest.RandString(5)
-	rName := fmt.Sprintf("tf-test-%s", rand)
+	rName := generateNameForIntegrationTestResource()
 	expectedErrorMsg, _ := regexp.Compile(`payload_type is required when using payload`)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -377,8 +369,8 @@ func TestAccNewRelicAlertChannel_WebhookPayloadValidation(t *testing.T) {
 }
 
 func TestAccNewRelicAlertChannel_ResourceNotFound(t *testing.T) {
-	rand := acctest.RandString(5)
-	rName := fmt.Sprintf("tf-test-%s", rand)
+
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/newrelic/resource_newrelic_service_level_test.go
+++ b/newrelic/resource_newrelic_service_level_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
@@ -18,9 +17,7 @@ import (
 
 func TestAccNewRelicServiceLevel_Basic(t *testing.T) {
 	resourceName := "newrelic_service_level.sli"
-	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
-
-	defer cleanupDanglingServiceLevelResources()
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckEnvVars(t) },
@@ -185,7 +182,7 @@ func testAccCheckNewRelicServiceLevelDestroy(s *terraform.State) error {
 
 func cleanupDanglingServiceLevelResources() error {
 	client := testAccProvider.Meta().(*ProviderConfig).NewClient
-	query := "domain = 'EXT' AND type = 'SERVICE_LEVEL' AND name LIKE '%tf-test-%'"
+	query := "domain = 'EXT' AND type = 'SERVICE_LEVEL' AND (name LIKE '%tf-test-%' OR name LIKE '%tf_test_%')"
 
 	fmt.Printf("\n[INFO] cleaning up any dangling integration test resources... \n")
 	time.Sleep(1 * time.Second)

--- a/newrelic/resource_newrelic_synthetics_alert_condition_test.go
+++ b/newrelic/resource_newrelic_synthetics_alert_condition_test.go
@@ -7,14 +7,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccNewRelicSyntheticsAlertCondition_Basic(t *testing.T) {
 	resourceName := "newrelic_synthetics_alert_condition.foo"
-	rName := acctest.RandString(5)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckEnvVars(t) },
@@ -53,7 +52,7 @@ func TestAccNewRelicSyntheticsAlertCondition_Basic(t *testing.T) {
 }
 
 func TestAccNewRelicSyntheticsAlertCondition_MissingPolicy(t *testing.T) {
-	rName := acctest.RandString(5)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckEnvVars(t) },

--- a/newrelic/resource_newrelic_synthetics_broken_links_monitor_test.go
+++ b/newrelic/resource_newrelic_synthetics_broken_links_monitor_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
@@ -15,7 +14,7 @@ import (
 
 func TestAccNewRelicSyntheticsBrokenLinksMonitor(t *testing.T) {
 	resourceName := "newrelic_synthetics_broken_links_monitor.foo"
-	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckEnvVars(t) },

--- a/newrelic/resource_newrelic_synthetics_cert_check_test.go
+++ b/newrelic/resource_newrelic_synthetics_cert_check_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
@@ -15,7 +14,7 @@ import (
 
 func TestAccNewRelicSyntheticsCertCheckMonitor(t *testing.T) {
 	resourceName := "newrelic_synthetics_cert_check_monitor.foo"
-	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckEnvVars(t) },

--- a/newrelic/resource_newrelic_synthetics_monitor_test.go
+++ b/newrelic/resource_newrelic_synthetics_monitor_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
@@ -16,7 +15,7 @@ import (
 
 func TestAccNewRelicSyntheticsSimpleMonitor(t *testing.T) {
 	resourceName := "newrelic_synthetics_monitor.foo"
-	rName := acctest.RandString(5)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckEnvVars(t) },
@@ -110,7 +109,7 @@ resource "newrelic_synthetics_monitor" "foo" {
 
 func TestAccNewRelicSyntheticsSimpleBrowserMonitor(t *testing.T) {
 	resourceName := "newrelic_synthetics_monitor.bar"
-	rName := acctest.RandString(5)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckEnvVars(t) },

--- a/newrelic/resource_newrelic_synthetics_multilocation_alert_condition_integration_test.go
+++ b/newrelic/resource_newrelic_synthetics_multilocation_alert_condition_integration_test.go
@@ -7,14 +7,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccNewRelicSyntheticsMultiLocationAlertCondition_Basic(t *testing.T) {
 	resourceName := "newrelic_synthetics_multilocation_alert_condition.foo"
-	rName := acctest.RandString(5)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/newrelic/resource_newrelic_synthetics_private_location_test.go
+++ b/newrelic/resource_newrelic_synthetics_private_location_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
@@ -15,7 +14,7 @@ import (
 
 func TestAccNewRelicSyntheticsPrivateLocation_Basic(t *testing.T) {
 	resourceName := "newrelic_synthetics_private_location.bar"
-	rName := acctest.RandString(5)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/newrelic/resource_newrelic_synthetics_script_monitor_integration_test.go
+++ b/newrelic/resource_newrelic_synthetics_script_monitor_integration_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestAccNewRelicSyntheticsScriptAPIMonitor(t *testing.T) {
 	resourceName := "newrelic_synthetics_script_monitor.foo"
-	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
+	rName := generateNameForIntegrationTestResource()
 	monitorTypeStr := string(SyntheticsMonitorTypes.SCRIPT_API)
 
 	resource.Test(t, resource.TestCase{

--- a/newrelic/resource_newrelic_synthetics_secure_credential_test.go
+++ b/newrelic/resource_newrelic_synthetics_secure_credential_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/entities"
@@ -18,7 +17,7 @@ import (
 
 func TestAccNewRelicSyntheticsSecureCredential_Basic(t *testing.T) {
 	resourceName := "newrelic_synthetics_secure_credential.foo"
-	rName := acctest.RandString(5)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -132,7 +131,7 @@ func testAccCheckNewRelicSyntheticsSecureCredentialDestroy(s *terraform.State) e
 func testAccNewRelicSyntheticsSecureCredentialConfig(name string) string {
 	return fmt.Sprintf(`
 resource "newrelic_synthetics_secure_credential" "foo" {
-	key          = "tf_test_%[1]s"
+	key          = "%[1]s"
 	value        = "Test Value"
 	description  = "Test Description"
 }
@@ -142,7 +141,7 @@ resource "newrelic_synthetics_secure_credential" "foo" {
 func testAccNewRelicSyntheticsSecureCredentialConfigUpdated(name string) string {
 	return fmt.Sprintf(`
 resource "newrelic_synthetics_secure_credential" "foo" {
-	key         = "tf_test_%[1]s"
+	key         = "%[1]s"
 	value        = "Test Value Updated"
 	description  = "Test Description"
 }

--- a/newrelic/resource_newrelic_synthetics_step_monitor_test.go
+++ b/newrelic/resource_newrelic_synthetics_step_monitor_test.go
@@ -6,13 +6,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccNewRelicSyntheticsStepMonitor(t *testing.T) {
 	resourceName := "newrelic_synthetics_step_monitor.foo"
-	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
+	rName := generateNameForIntegrationTestResource()
 	updateStep := `steps {
 		ordinal = 1
 		type    = "ASSERT_TITLE"

--- a/newrelic/resource_newrelic_workflow_test.go
+++ b/newrelic/resource_newrelic_workflow_test.go
@@ -15,15 +15,13 @@ import (
 
 func TestNewRelicWorkflow_Webhook(t *testing.T) {
 	resourceName := "newrelic_workflow.foo"
-	rand := acctest.RandString(5)
-	rName := fmt.Sprintf("tf-workflow-test-%s", rand)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccNewRelicWorkflowDestroy,
 		Steps: []resource.TestStep{
-
 			// Test: Create workflow
 			{
 				Config: testAccNewRelicWorkflowConfigurationWebhook(testAccountID, rName),
@@ -44,15 +42,13 @@ func TestNewRelicWorkflow_Webhook(t *testing.T) {
 
 func TestNewRelicWorkflow_Email(t *testing.T) {
 	resourceName := "newrelic_workflow.foo"
-	rand := acctest.RandString(5)
-	rName := fmt.Sprintf("tf-workflow-test-%s", rand)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccNewRelicWorkflowDestroy,
 		Steps: []resource.TestStep{
-
 			// Test: Create workflow
 			{
 				Config: testAccNewRelicWorkflowConfigurationEmail(testAccountID, rName),
@@ -82,7 +78,6 @@ func TestNewRelicWorkflow_DeleteWorkflowWithoutRemovingChannels(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccNewRelicWorkflowDestroy,
 		Steps: []resource.TestStep{
-
 			// Test: Create workflow
 			{
 				Config: channelResources + workflowResource,
@@ -100,15 +95,13 @@ func TestNewRelicWorkflow_DeleteWorkflowWithoutRemovingChannels(t *testing.T) {
 
 func TestNewRelicWorkflow_MinimalConfig(t *testing.T) {
 	resourceName := "newrelic_workflow.foo"
-	rand := acctest.RandString(5)
-	rName := fmt.Sprintf("tf-workflow-test-%s", rand)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccNewRelicWorkflowDestroy,
 		Steps: []resource.TestStep{
-
 			// Test: Create workflow
 			{
 				Config: testAccNewRelicWorkflowConfigurationMinimal(testAccountID, rName),
@@ -166,7 +159,7 @@ func TestNewRelicWorkflow_UpdateChannels(t *testing.T) {
 func TestNewRelicWorkflow_RemoveEnrichments(t *testing.T) {
 	resourceName := "newrelic_workflow.foo"
 	channelResourceName := "foo"
-	workflowName := acctest.RandString(5)
+	workflowName := generateNameForIntegrationTestResource()
 	enrichmentsSection := `
 enrichments {
 	nrql {
@@ -186,7 +179,6 @@ enrichments {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccNewRelicWorkflowDestroy,
 		Steps: []resource.TestStep{
-
 			// Test: Create workflow
 			{
 				Config: channelResources + workflowWithEnrichment,
@@ -204,15 +196,13 @@ enrichments {
 
 func TestNewRelicWorkflow_WithCreatedNotificationTriggers(t *testing.T) {
 	resourceName := "newrelic_workflow.foo"
-	rand := acctest.RandString(5)
-	rName := fmt.Sprintf("tf-workflow-test-%s", rand)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccNewRelicWorkflowDestroy,
 		Steps: []resource.TestStep{
-
 			// Test: Create workflow
 			{
 				Config: testAccNewRelicWorkflowConfigurationWithNotificationTriggers(testAccountID, rName, `["ACTIVATED"]`),
@@ -233,15 +223,13 @@ func TestNewRelicWorkflow_WithCreatedNotificationTriggers(t *testing.T) {
 
 func TestNewRelicWorkflow_WithNonCreatedNotificationTriggers(t *testing.T) {
 	resourceName := "newrelic_workflow.foo"
-	rand := acctest.RandString(5)
-	rName := fmt.Sprintf("tf-workflow-test-%s", rand)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccNewRelicWorkflowDestroy,
 		Steps: []resource.TestStep{
-
 			// Test: Create workflow
 			{
 				Config: testAccNewRelicWorkflowConfigurationWithNotificationTriggers(testAccountID, rName, ""),
@@ -262,15 +250,13 @@ func TestNewRelicWorkflow_WithNonCreatedNotificationTriggers(t *testing.T) {
 
 func TestNewRelicWorkflow_WithUpdatedNotificationTriggers(t *testing.T) {
 	resourceName := "newrelic_workflow.foo"
-	rand := acctest.RandString(5)
-	rName := fmt.Sprintf("tf-workflow-test-%s", rand)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccNewRelicWorkflowDestroy,
 		Steps: []resource.TestStep{
-
 			// Test: Create workflow
 			{
 				Config: testAccNewRelicWorkflowConfigurationWithNotificationTriggers(testAccountID, rName, `["ACTIVATED"]`),

--- a/newrelic/resource_newrelic_workload_test.go
+++ b/newrelic/resource_newrelic_workload_test.go
@@ -5,17 +5,24 @@ package newrelic
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"testing"
+	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/entities"
 )
 
 func TestAccNewRelicWorkload_Basic(t *testing.T) {
 	resourceName := "newrelic_workload.foo"
-	rName := acctest.RandString(5)
+	rName := generateNameForIntegrationTestResource()
+
+	// TODO: Need to move this to Terraform sweeper so this runs
+	//       after all tests have completed.
+	// defer cleanupDanglingWorkloadResources()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -37,19 +44,19 @@ func TestAccNewRelicWorkload_Basic(t *testing.T) {
 				),
 			},
 			// Test: Import
-			//{
-			//	ResourceName:            resourceName,
-			//	ImportState:             true,
-			//	ImportStateVerify:       true,
-			//	ImportStateVerifyIgnore: []string{"status_config_automatic"},
-			//},
+			// {
+			// 	ResourceName:            resourceName,
+			// 	ImportState:             true,
+			// 	ImportStateVerify:       true,
+			// 	ImportStateVerifyIgnore: []string{"status_config_automatic"},
+			// },
 		},
 	})
 }
 
 func TestAccNewRelicWorkload_EntitiesOnly(t *testing.T) {
 	resourceName := "newrelic_workload.foo"
-	rName := acctest.RandString(5)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -68,7 +75,7 @@ func TestAccNewRelicWorkload_EntitiesOnly(t *testing.T) {
 
 func TestAccNewRelicWorkload_EntitySearchQueriesOnly(t *testing.T) {
 	resourceName := "newrelic_workload.foo"
-	rName := acctest.RandString(5)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -87,7 +94,7 @@ func TestAccNewRelicWorkload_EntitySearchQueriesOnly(t *testing.T) {
 
 func TestAccNewRelicWorkload_EntityMultiSearchQueriesOnly(t *testing.T) {
 	resourceName := "newrelic_workload.foo"
-	rName := acctest.RandString(5)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -105,7 +112,7 @@ func TestAccNewRelicWorkload_EntityMultiSearchQueriesOnly(t *testing.T) {
 }
 
 func TestAccNewRelicWorkload_EntityScopeAccountsOnly(t *testing.T) {
-	rName := acctest.RandString(5)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -122,7 +129,7 @@ func TestAccNewRelicWorkload_EntityScopeAccountsOnly(t *testing.T) {
 
 func TestAccNewRelicWorkload_BasicOnly(t *testing.T) {
 	resourceName := "newrelic_workload.foo"
-	rName := acctest.RandString(5)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -155,7 +162,7 @@ func TestAccNewRelicWorkload_BasicOnly(t *testing.T) {
 
 func TestAccNewRelicWorkload_StaticOnly(t *testing.T) {
 	resourceName := "newrelic_workload.foo"
-	rName := acctest.RandString(5)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -174,7 +181,7 @@ func TestAccNewRelicWorkload_StaticOnly(t *testing.T) {
 
 func TestAccNewRelicWorkload_AutomaticOnly(t *testing.T) {
 	resourceName := "newrelic_workload.foo"
-	rName := acctest.RandString(5)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -193,7 +200,7 @@ func TestAccNewRelicWorkload_AutomaticOnly(t *testing.T) {
 
 func TestAccNewRelicWorkload_AutomaticEnabledOnly(t *testing.T) {
 	resourceName := "newrelic_workload.foo"
-	rName := acctest.RandString(5)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -212,7 +219,7 @@ func TestAccNewRelicWorkload_AutomaticEnabledOnly(t *testing.T) {
 
 func TestAccNewRelicWorkload_AutomaticRemainingEntitiesOnly(t *testing.T) {
 	resourceName := "newrelic_workload.foo"
-	rName := acctest.RandString(5)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -231,7 +238,7 @@ func TestAccNewRelicWorkload_AutomaticRemainingEntitiesOnly(t *testing.T) {
 
 func TestAccNewRelicWorkload_AutomaticRuleOnly(t *testing.T) {
 	resourceName := "newrelic_workload.foo"
-	rName := acctest.RandString(5)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -250,7 +257,7 @@ func TestAccNewRelicWorkload_AutomaticRuleOnly(t *testing.T) {
 
 func TestAccNewRelicWorkload_AutomaticRulesOnly(t *testing.T) {
 	resourceName := "newrelic_workload.foo"
-	rName := acctest.RandString(5)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -269,7 +276,7 @@ func TestAccNewRelicWorkload_AutomaticRulesOnly(t *testing.T) {
 
 func TestAccNewRelicWorkload_AutomaticRuleRollupOnly(t *testing.T) {
 	resourceName := "newrelic_workload.foo"
-	rName := acctest.RandString(5)
+	rName := generateNameForIntegrationTestResource()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -337,6 +344,44 @@ func testAccCheckNewRelicWorkloadDestroy(s *terraform.State) error {
 	return nil
 }
 
+func cleanupDanglingWorkloadResources() error {
+	client := testAccProvider.Meta().(*ProviderConfig).NewClient
+	query := "domain = 'NR1' AND type = 'WORKLOAD' AND (name LIKE '%tf-test-%' OR name LIKE '%tf_test_%')"
+
+	fmt.Printf("\n[INFO] cleaning up any dangling integration test resources... \n")
+	time.Sleep(1 * time.Second)
+
+	for {
+		matches, err := client.Entities.GetEntitySearchByQuery(
+			entities.EntitySearchOptions{},
+			query,
+			[]entities.EntitySearchSortCriteria{},
+		)
+
+		if err != nil {
+			return fmt.Errorf("error cleaning up dangling synthetics resources: %s", err)
+		}
+
+		if matches != nil {
+			resources := matches.Results.Entities
+			for _, r := range resources {
+				_, err := client.Workloads.WorkloadDelete(common.EntityGUID(string(r.GetGUID())))
+				if err != nil {
+					log.Printf("[ERROR] error deleting dangling resource: %s", err)
+				}
+			}
+
+			fmt.Printf("\n[INFO] deleted %d dangling resources", len(resources))
+		}
+
+		if matches.Results.NextCursor == "" {
+			break
+		}
+	}
+
+	return nil
+}
+
 func testAccNewRelicWorkloadConfig(name string) string {
 	return fmt.Sprintf(`
 
@@ -381,7 +426,7 @@ resource "newrelic_workload" "foo" {
 			}
 		}
 	}
-	
+
 	status_config_static {
 	description = "test"
 	enabled = true
@@ -437,7 +482,7 @@ resource "newrelic_workload" "foo" {
 			}
 		}
 	}
-	
+
 	status_config_static {
 	description = "test"
 	enabled = true


### PR DESCRIPTION
 
This PR also includes a new helper function 

- `generateNameForIntegrationTestResource()`: Facilitates standardizing the names of our test resources. This will help ensure we only delete dangling extraneous resources with names that start with "tf-test-". This helps avoid deleting any resources that might be cross-account, such as service levels, workflows, workloads, etc.