### PR TITLE
fix(workflows): stop silently removing channels on workflow updates/deletes

### DIFF
--- a/newrelic/resource_newrelic_notifications_channel_test.go
+++ b/newrelic/resource_newrelic_notifications_channel_test.go
@@ -313,7 +313,8 @@ func testAccCheckNewRelicNotificationChannelExists(n string) resource.TestCheckF
 			return err
 		}
 
-		if string(found.Entities[0].ID) != rs.Primary.ID {
+
+		if len(found.Entities) == 0 || string(found.Entities[0].ID) != rs.Primary.ID {
 			return fmt.Errorf("channel not found: %v - %v", rs.Primary.ID, found)
 		}
 

--- a/newrelic/resource_newrelic_workflow.go
+++ b/newrelic/resource_newrelic_workflow.go
@@ -512,7 +512,7 @@ func resourceNewRelicWorkflowUpdate(ctx context.Context, d *schema.ResourceData,
 	accountID := selectAccountID(providerConfig, d)
 	updatedContext := updateContextWithAccountID(ctx, accountID)
 
-	workflowResponse, err := client.Workflows.AiWorkflowsUpdateWorkflowWithContext(updatedContext, accountID, true, *updateInput)
+	workflowResponse, err := client.Workflows.AiWorkflowsUpdateWorkflowWithContext(updatedContext, accountID, false, *updateInput)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -534,7 +534,7 @@ func resourceNewRelicWorkflowDelete(ctx context.Context, d *schema.ResourceData,
 	accountID := selectAccountID(providerConfig, d)
 	updatedContext := updateContextWithAccountID(ctx, accountID)
 
-	workflowResponse, err := client.Workflows.AiWorkflowsDeleteWorkflowWithContext(updatedContext, accountID, true, d.Id())
+	workflowResponse, err := client.Workflows.AiWorkflowsDeleteWorkflowWithContext(updatedContext, accountID, false, d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
# Description

Currently, if we delete a workflow or update the list of channels it uses, the provider will automatically delete the channels that are no longer used. This behaviour goes against users' IaC intuition because the deleted channels are **still defined** in the TF config and lead to non-empty TF plan.

This PR makes the behaviour more intuitive: if you delete workflow without removing its channel from your config, the channel remains until you remove it from your config as well. Same goes for workflow updates that remove some of the channels from workflow configuration.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

Please see the added workflow resource tests