### PR TITLE
docs(synthetics): remove unnecessary quotes around private location guid

### DIFF
--- a/website/docs/r/synthetics_monitor.html.markdown
+++ b/website/docs/r/synthetics_monitor.html.markdown
@@ -136,7 +136,7 @@ resource "newrelic_synthetics_monitor" "monitor" {
   period           = "EVERY_MINUTE"
   uri              = "https://www.one.newrelic.com"
   type             = "SIMPLE"
-  locations_private = ["newrelic_synthetics_private_location.location.id"]
+  locations_private = [newrelic_synthetics_private_location.location.id]
 
   custom_header {
     name  = "some_name"
@@ -169,7 +169,7 @@ resource "newrelic_synthetics_monitor" "monitor" {
   uri               = "https://www.one.newrelic.com"
   name              = "monitor"
   period            = "EVERY_MINUTE"
-  locations_private = ["newrelic_synthetics_private_location.location.id"]
+  locations_private = [newrelic_synthetics_private_location.location.id]
 
   custom_header {
     name  = "some_name"

--- a/website/docs/r/synthetics_monitor_broken_links.html.markdown
+++ b/website/docs/r/synthetics_monitor_broken_links.html.markdown
@@ -64,7 +64,7 @@ resource "newrelic_synthetics_private_location" "location" {
 resource "newrelic_synthetics_broken_links_monitor" "monitor" {
   name              = "broken-links-monitor"
   uri               = "https://www.one.example.com"
-  locations_private = ["newrelic_synthetics_private_location.location.id"]
+  locations_private = [newrelic_synthetics_private_location.location.id]
   period            = "EVERY_6_HOURS"
   status            = "ENABLED"
   tag {

--- a/website/docs/r/synthetics_monitor_cert_check.html.markdown
+++ b/website/docs/r/synthetics_monitor_cert_check.html.markdown
@@ -67,7 +67,7 @@ resource "newrelic_synthetics_private_location" "location" {
 resource "newrelic_synthetics_cert_check_monitor" "monitor" {
   name              = "cert_check_monitor"
   uri               = "https://www.one.example.com"
-  locations_private = ["newrelic_synthetics_private_location.location.id"]
+  locations_private = [newrelic_synthetics_private_location.location.id]
   period            = "EVERY_6_HOURS"
   status            = "ENABLED"
   tag {

--- a/website/docs/r/synthetics_monitor_step.html.markdown
+++ b/website/docs/r/synthetics_monitor_step.html.markdown
@@ -87,7 +87,7 @@ resource "newrelic_synthetics_step_monitor" "bar" {
   name = "step_monitor"
   uri  = "https://www.one.example.com"
   location_private {
-    guid         = "newrelic_synthetics_private_location.location.id"
+    guid         = newrelic_synthetics_private_location.location.id
     vse_password = "secret"
   }
   period = "EVERY_6_HOURS"

--- a/website/docs/r/synthetics_script_monitor.html.markdown
+++ b/website/docs/r/synthetics_script_monitor.html.markdown
@@ -123,7 +123,7 @@ resource "newrelic_synthetics_script_monitor" "monitor" {
   name   = "script_monitor"
   type   = "SCRIPT_API"
   location_private {
-    guid         = "newrelic_synthetics_private_location.location.id"
+    guid         = newrelic_synthetics_private_location.location.id
     vse_password = "secret"
   }
   period = "EVERY_6_HOURS"
@@ -157,7 +157,7 @@ resource "newrelic_synthetics_script_monitor" "monitor" {
 
   enable_screenshot_on_failure_and_script = false
   location_private {
-    guid         = "newrelic_synthetics_private_location.location.id"
+    guid         = newrelic_synthetics_private_location.location.id
     vse_password = "secret"
   }
 


### PR DESCRIPTION
# Description

This PR removes the quotes around private location GUID references in Synthetics docs examples

Fixes #2168

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
