### PR TITLE
feat: added newrelic install data source that helps generate CLI installation commands for use with other providers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/newrelic/terraform-provider-newrelic/v2
 go 1.18
 
 require (
+	github.com/google/uuid v1.1.2
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.20.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.20.1

--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,8 @@ github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
+github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gordonklaus/ineffassign v0.0.0-20190601041439-ed7b1b5ee0f8/go.mod h1:cuNKsD1zp2v6XfE/orVX2QE1LC+i254ceGcVeDT3pTU=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=

--- a/newrelic/data_source_newrelic_install.go
+++ b/newrelic/data_source_newrelic_install.go
@@ -1,0 +1,192 @@
+package newrelic
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func dataSourceNewRelicInstall() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceNewRelicInstallRead,
+		Schema: map[string]*schema.Schema{
+			"account_id": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The ID of the account in New Relic.",
+			},
+			"api_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The API key to use, will default to the one provided to Terraform.",
+			},
+			"os": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "Target operating system (linux, windows, darwin)",
+				ValidateFunc: validation.StringInSlice([]string{"linux", "windows", "darwin"}, false),
+			},
+			"recipe": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Define a list of recipes you want to run. By default the CLI will automatically detected the right recipes to run for your system.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"download_cli": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: `By default the command will download the latest version of the CLI. You can disable this behaviour to use the one already on the system.`,
+			},
+			"assume_yes": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: `Assume yes on all prompts by the installation.`,
+			},
+			"tag": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "A tag applied to the agents installed.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The tag key.",
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The tag value.",
+						},
+					},
+				},
+			},
+			"command": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Auto generated command to use in other parts of your Terraform environment, or externally.",
+			},
+		},
+	}
+}
+
+func dataSourceNewRelicInstallRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	os := d.Get("os").(string)
+	command := ""
+
+	if os == "linux" || os == "darwin" {
+		command = buildForLinux(d, meta)
+	} else if os == "windows" {
+		command = buildForWindow(d, meta)
+	} else {
+		return diag.Errorf("Unknown OS")
+	}
+
+	id := uuid.New()
+	d.SetId(id.String())
+
+	if err := d.Set("command", command); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func getAPIKey(providerConfig *ProviderConfig, d *schema.ResourceData) string {
+	resourceAPIKey := d.Get("api_key").(string)
+
+	if resourceAPIKey != "" {
+		return resourceAPIKey
+	}
+
+	return providerConfig.PersonalAPIKey
+}
+
+func buildForLinux(d *schema.ResourceData, meta interface{}) string {
+	providerConfig := meta.(*ProviderConfig)
+
+	command := ""
+	if attr, ok := d.GetOk("download_cli"); ok && attr.(bool) {
+		command += "curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash && "
+	}
+
+	command += fmt.Sprintf(
+		"sudo NEW_RELIC_API_KEY=%s NEW_RELIC_ACCOUNT_ID=%d /usr/local/bin/newrelic install %s %s",
+		getAPIKey(providerConfig, d),
+		selectAccountID(providerConfig, d),
+		buildAdditionalParams(d, meta),
+		buildRecipe(d, meta),
+	)
+
+	return command
+}
+
+func buildForWindow(d *schema.ResourceData, meta interface{}) string {
+	providerConfig := meta.(*ProviderConfig)
+
+	command := ""
+	if attr, ok := d.GetOk("download_cli"); ok && attr.(bool) {
+		command += "[Net.ServicePointManager]::SecurityProtocol = 'tls12, tls'; (New-Object System.Net.WebClient).DownloadFile(\"https://download.newrelic.com/install/newrelic-cli/scripts/install.ps1\", \"$env:TEMP\\install.ps1\"); & PowerShell.exe -ExecutionPolicy Bypass -File $env:TEMP\\install.ps1; "
+	}
+
+	command += fmt.Sprintf(
+		"$env:NEW_RELIC_API_KEY='%s'; $env:NEW_RELIC_ACCOUNT_ID='%d'; & 'C:\\Program Files\\New Relic\\New Relic CLI\\newrelic.exe' install %s %s",
+		getAPIKey(providerConfig, d),
+		selectAccountID(providerConfig, d),
+		buildAdditionalParams(d, meta),
+		buildRecipe(d, meta),
+	)
+
+	return command
+}
+
+func buildRecipe(d *schema.ResourceData, meta interface{}) string {
+	if recipes, ok := d.GetOk("recipe"); ok {
+		recipeNames := recipes.([]interface{})
+		recipeArray := make([]string, len(recipes.([]interface{})))
+		for i := range recipeNames {
+			recipeArray[i] = recipeNames[i].(string)
+		}
+
+		return "-n " + strings.Join(recipeArray, ",")
+	}
+
+	return ""
+}
+
+func buildAdditionalParams(d *schema.ResourceData, meta interface{}) string {
+	additionalParams := ""
+
+	// Assume yes
+	if attr, ok := d.GetOk("assume_yes"); ok && attr.(bool) {
+		additionalParams += "-y "
+	}
+
+	// Tags
+	tagsRaw := d.Get("tag").([]interface{})
+	tags := make([]string, 0, len(tagsRaw))
+
+	for _, t := range tagsRaw {
+		tag := t.(map[string]interface{})
+		if k, ok := tag["key"]; ok {
+			if v, ok := tag["value"]; ok {
+				tags = append(tags, fmt.Sprintf("%s:%s", k.(string), v.(string)))
+			}
+		}
+	}
+
+	if len(tags) > 0 {
+		additionalParams += fmt.Sprintf("--tag %s", strings.Join(tags, ",")) + " "
+	}
+
+	return additionalParams
+}

--- a/newrelic/data_source_newrelic_install_test.go
+++ b/newrelic/data_source_newrelic_install_test.go
@@ -1,0 +1,240 @@
+//go:build integration
+// +build integration
+
+package newrelic
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccNewRelicInstallDataSourceBasicLinux(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testNewRelicInstallBasicConfig("linux"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicInstallDataSourceIsCorrectOS("data.newrelic_install.basic", "linux"),
+					testAccCheckNewRelicInstallDataSourceHasCLIInstall("data.newrelic_install.basic", "linux", true),
+					testAccCheckNewRelicInstallDataSourceHasAssumeYes("data.newrelic_install.basic"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNewRelicInstallDataSourceBasicWindows(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testNewRelicInstallBasicConfig("windows"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicInstallDataSourceIsCorrectOS("data.newrelic_install.basic", "windows"),
+					testAccCheckNewRelicInstallDataSourceHasCLIInstall("data.newrelic_install.basic", "windows", true),
+					testAccCheckNewRelicInstallDataSourceHasAssumeYes("data.newrelic_install.basic"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNewRelicInstallDataSourceBasicLinuxWithoutCLIDownload(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testNewRelicInstallBasicConfigWithoutDownload("linux"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicInstallDataSourceIsCorrectOS("data.newrelic_install.basic", "linux"),
+					testAccCheckNewRelicInstallDataSourceHasCLIInstall("data.newrelic_install.basic", "linux", false),
+					testAccCheckNewRelicInstallDataSourceHasAssumeYes("data.newrelic_install.basic"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNewRelicInstallDataSourceBasicWindowsWithoutCLIDownload(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testNewRelicInstallBasicConfigWithoutDownload("windows"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicInstallDataSourceIsCorrectOS("data.newrelic_install.basic", "windows"),
+					testAccCheckNewRelicInstallDataSourceHasCLIInstall("data.newrelic_install.basic", "windows", false),
+					testAccCheckNewRelicInstallDataSourceHasAssumeYes("data.newrelic_install.basic"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNewRelicInstallDataSourceTagsLinux(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testNewRelicInstallBasicConfigWithTags("linux"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicInstallDataSourceIsCorrectOS("data.newrelic_install.basic", "linux"),
+					testAccCheckNewRelicInstallDataSourceHasCLIInstall("data.newrelic_install.basic", "linux", true),
+					testAccCheckNewRelicInstallDataSourceHasTags("data.newrelic_install.basic"),
+					testAccCheckNewRelicInstallDataSourceHasAssumeYes("data.newrelic_install.basic"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNewRelicInstallDataSourceRecipeLinux(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testNewRelicInstallBasicConfigWithRecipe("linux"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicInstallDataSourceIsCorrectOS("data.newrelic_install.basic", "linux"),
+					testAccCheckNewRelicInstallDataSourceHasCLIInstall("data.newrelic_install.basic", "linux", true),
+					testAccCheckNewRelicInstallDataSourceHasRecipe("data.newrelic_install.basic", "samwise"),
+					testAccCheckNewRelicInstallDataSourceHasAssumeYes("data.newrelic_install.basic"),
+				),
+			},
+		},
+	})
+}
+
+func testNewRelicInstallBasicConfig(os string) string {
+	return fmt.Sprintf(`
+data "newrelic_install" "basic" {
+	os = "%s"
+}`, os)
+}
+
+func testNewRelicInstallBasicConfigWithoutDownload(os string) string {
+	return fmt.Sprintf(`
+data "newrelic_install" "basic" {
+	os = "%s"
+	download_cli = false
+}`, os)
+}
+
+func testNewRelicInstallBasicConfigWithTags(os string) string {
+	return fmt.Sprintf(`
+data "newrelic_install" "basic" {
+	os = "%s"
+	tag {
+        key = "whatabout"
+        value = "second_breakfast"
+    }
+
+    tag {
+        key = "afternoon_tea"
+        value = "false"
+    }
+}`, os)
+}
+
+func testNewRelicInstallBasicConfigWithRecipe(os string) string {
+	return fmt.Sprintf(`
+data "newrelic_install" "basic" {
+	os = "%s"
+	recipe = [
+		"frodo",
+		"samwise",
+		"pippin",
+		"merry",
+	]
+}`, os)
+}
+
+func testAccCheckNewRelicInstallDataSourceGetCommand(s *terraform.State, n string) string {
+	r := s.RootModule().Resources[n]
+	return r.Primary.Attributes["command"]
+}
+
+func testAccCheckNewRelicInstallDataSourceHasCLIInstall(n string, os string, needsCommand bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		command := testAccCheckNewRelicInstallDataSourceGetCommand(s, n)
+		hasCommand := false
+		switch os {
+		case "linux":
+			hasCommand = strings.Contains(command, "curl")
+		case "windows":
+			hasCommand = strings.Contains(command, "DownloadFile")
+		default:
+			return fmt.Errorf("unknown OS cannot continue: %s", os)
+		}
+
+		if hasCommand == needsCommand {
+			return nil
+		}
+
+		return fmt.Errorf("download CLI command expecation (%t) does not line up with result (%t): %s", needsCommand, hasCommand, command)
+	}
+}
+
+func testAccCheckNewRelicInstallDataSourceIsCorrectOS(n string, os string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		command := testAccCheckNewRelicInstallDataSourceGetCommand(s, n)
+		switch os {
+		case "linux":
+			if strings.Contains(command, "/newrelic") {
+				return nil
+			}
+		case "windows":
+			if strings.Contains(command, "newrelic.exe") {
+				return nil
+			}
+		default:
+			return fmt.Errorf("unknown OS cannot continue: %s", os)
+		}
+
+		return fmt.Errorf("incorrect OS found in command, was expecting %s but found: %s", os, command)
+	}
+}
+
+func testAccCheckNewRelicInstallDataSourceHasTags(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		command := testAccCheckNewRelicInstallDataSourceGetCommand(s, n)
+		if strings.Contains(command, "--tag") {
+			return nil
+		}
+
+		return fmt.Errorf("was expecting tags, no tags found: %s", command)
+	}
+}
+
+func testAccCheckNewRelicInstallDataSourceHasRecipe(n string, recipe string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		command := testAccCheckNewRelicInstallDataSourceGetCommand(s, n)
+		if strings.Contains(command, "-n") && strings.Contains(command, recipe) {
+			return nil
+		}
+
+		return fmt.Errorf("was expecting a recipe, supplied recipe (%s) not found: %s", recipe, command)
+	}
+}
+
+func testAccCheckNewRelicInstallDataSourceHasAssumeYes(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		command := testAccCheckNewRelicInstallDataSourceGetCommand(s, n)
+		if strings.Contains(command, "-y") {
+			return nil
+		}
+
+		return fmt.Errorf("assume yes not found in command: %s", command)
+	}
+}

--- a/newrelic/provider.go
+++ b/newrelic/provider.go
@@ -122,6 +122,7 @@ func Provider() *schema.Provider {
 			"newrelic_application":                  dataSourceNewRelicApplication(),
 			"newrelic_cloud_account":                dataSourceNewRelicCloudAccount(),
 			"newrelic_entity":                       dataSourceNewRelicEntity(),
+			"newrelic_install":                      dataSourceNewRelicInstall(),
 			"newrelic_key_transaction":              dataSourceNewRelicKeyTransaction(),
 			"newrelic_obfuscation_expression":       dataSourceNewRelicObfuscationExpression(),
 			"newrelic_synthetics_private_location":  dataSourceNewRelicSyntheticsPrivateLocation(),


### PR DESCRIPTION
# Description

Added helper resource to improve experience when using New Relic with cloud providers, for example: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html

This removes the need to copy & paste the command into your code.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

Please delete options that are not relevant.

- [] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [] I have performed a self-review of my own code
- [] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Step 1
- Step 2
- etc
