### PR TITLE
fix(one_dashboard_json): added retry mechanism to create/update to handle updateAt changes

### DIFF
--- a/newrelic/resource_newrelic_one_dashboard_json.go
+++ b/newrelic/resource_newrelic_one_dashboard_json.go
@@ -110,7 +110,7 @@ func resourceNewRelicOneDashboardJSONCreate(ctx context.Context, d *schema.Resou
 		return diag.FromErr(retryErr)
 	}
 
-	return nil
+	return resourceNewRelicOneDashboardJSONRead(ctx, d, meta)
 }
 
 // resourceNewRelicOneDashboardRead NerdGraph => Terraform reader

--- a/newrelic/resource_newrelic_one_dashboard_json.go
+++ b/newrelic/resource_newrelic_one_dashboard_json.go
@@ -189,9 +189,6 @@ func resourceNewRelicOneDashboardJSONUpdate(ctx context.Context, d *schema.Resou
 		return diag.Errorf("err: newrelic_one_dashboard_json Update failed: %s", errMessages)
 	}
 
-	// Set updated_at as we've updated the dashboard
-	_ = d.Set("updated_at", updated.EntityResult.UpdatedAt)
-
 	// Wait until the API returns the same value as our update call
 	retryErr := resource.RetryContext(ctx, d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 		dashboard, err := client.Dashboards.GetDashboardEntityWithContext(ctx, common.EntityGUID(d.Id()))
@@ -209,6 +206,9 @@ func resourceNewRelicOneDashboardJSONUpdate(ctx context.Context, d *schema.Resou
 	if retryErr != nil {
 		return diag.FromErr(retryErr)
 	}
+
+	// Set updated_at as we've updated the dashboard
+	_ = d.Set("updated_at", updated.EntityResult.UpdatedAt)
 
 	return resourceNewRelicOneDashboardJSONRead(ctx, d, meta)
 }


### PR DESCRIPTION
# Description

Fix for #2175

This change adds a retry mechanism to the create/update functions in dashboard_json to check if the updatedAt returned by create/update matches the get calls value. This was added because there's a delay in the get call returning the correct value as there is an async behaviour on the API side (distributed systems are hard). 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

Check #2175
