### PR TITLE
fix(newrelic_one_dashboard): fix for null pointer when using thresholds in widget_billboard

### DIFF
--- a/newrelic/structures_newrelic_one_dashboard.go
+++ b/newrelic/structures_newrelic_one_dashboard.go
@@ -763,6 +763,11 @@ func flattenDashboardWidget(in *entities.DashboardWidget, pageGUID string) (stri
 		out["nrql_query"] = flattenDashboardWidgetNRQLQuery(&rawCfg.NRQLQueries)
 		if len(rawCfg.Thresholds) > 0 {
 			for _, v := range rawCfg.Thresholds {
+				// Double check if we have a value, the API sometimes returns a null
+				if v.Value == nil {
+					continue
+				}
+
 				switch v.AlertSeverity {
 				case entities.DashboardAlertSeverityTypes.CRITICAL:
 					out["critical"] = strconv.FormatFloat(*v.Value, 'f', -1, 64)

--- a/newrelic/structures_newrelic_one_dashboard_test.go
+++ b/newrelic/structures_newrelic_one_dashboard_test.go
@@ -1,0 +1,91 @@
+package newrelic
+
+import (
+	"testing"
+
+	"github.com/newrelic/newrelic-client-go/v2/pkg/entities"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpandDashboardBillboardThreshold(t *testing.T) {
+	dashboard := entities.DashboardWidget{
+		ID: "abcde",
+		Visualization: entities.DashboardWidgetVisualization{
+			ID: "viz.billboard",
+		},
+		RawConfiguration: []byte(`
+		{
+			"facet": {
+				"showOtherSeries": false
+			},
+		 	"nrqlQueries": [
+				{
+					"accountId": 1606862,
+					"query": "FROM Transaction SELECT average(duration) WHERE appName = 'WebPortal' "
+				}
+			],
+			"platformOptions": {
+				"ignoreTimeRange": false
+			},
+		  	"thresholds": [
+				{
+					"alertSeverity": "WARNING",
+					"value": 1
+				},
+				{
+					"alertSeverity": "CRITICAL",
+					"value": 2
+				}
+		  	]
+		}
+		`),
+	}
+	widgetType, out := flattenDashboardWidget(&dashboard, "abcde")
+	assert.Equal(t, "widget_billboard", widgetType)
+	assert.Contains(t, out, "nrql_query")
+	assert.Contains(t, out, "critical")
+	assert.Contains(t, out, "warning")
+	assert.Equal(t, out["critical"], "2")
+	assert.Equal(t, out["warning"], "1")
+}
+
+func TestExpandDashboardBillboardThresholdNullValue(t *testing.T) {
+	dashboard := entities.DashboardWidget{
+		ID: "abcde",
+		Visualization: entities.DashboardWidgetVisualization{
+			ID: "viz.billboard",
+		},
+		RawConfiguration: []byte(`
+		{
+			"facet": {
+				"showOtherSeries": false
+			},
+		 	"nrqlQueries": [
+				{
+					"accountId": 1606862,
+					"query": "FROM Transaction SELECT average(duration) WHERE appName = 'WebPortal' "
+				}
+			],
+			"platformOptions": {
+				"ignoreTimeRange": false
+			},
+		  	"thresholds": [
+				{
+					"alertSeverity": "WARNING",
+					"value": null
+				},
+				{
+					"alertSeverity": "CRITICAL",
+					"value": 2
+				}
+		  	]
+		}
+		`),
+	}
+	widgetType, out := flattenDashboardWidget(&dashboard, "abcde")
+	assert.Equal(t, "widget_billboard", widgetType)
+	assert.Contains(t, out, "nrql_query")
+	assert.Contains(t, out, "critical")
+	assert.NotContains(t, out, "warning")
+	assert.Equal(t, out["critical"], "2")
+}


### PR DESCRIPTION
# Description

Possible fix for #2204. More details in ticket where the bug is coming from. 

I was unable to reproduce it locally because it looks like an API issue. Other dashboards remove the thresholds instead of setting a null value. The result is the same so the code now checks for nil value before resuming. 

As I was unable to reproduce, the code is a blind fix which needs to be confirmed with customer. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

