### PR TITLE
docs(alert): Updated NRQL condition term duration max

### DIFF
--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -72,7 +72,7 @@ func termSchema() *schema.Resource {
 			"threshold_duration": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Description: "The duration, in seconds, that the threshold must violate in order to create an incident. Value must be a multiple of the 'aggregation_window' (which has a default of 60 seconds). Value must be within 120-3600 seconds for baseline conditions, and within 60-7200 seconds for static conditions",
+				Description: "The duration, in seconds, that the threshold must violate in order to create an incident. Value must be a multiple of the 'aggregation_window' (which has a default of 60 seconds). Value must be within 120-86400 seconds for baseline conditions, and within 60-86400 seconds for static conditions",
 			},
 		},
 	}

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -99,7 +99,7 @@ func TestAccNewRelicNrqlAlertCondition_NerdGraphThresholdDurationValidationError
 					rNameBaseline,
 					"baseline",
 					20,
-					7200, // outside of accepted range [120, 3600] to test error handling
+					86460, // outside of accepted range [120, 86400] to test error handling
 					"static",
 					"0",
 					conditionalAttrBaseline,
@@ -112,7 +112,7 @@ func TestAccNewRelicNrqlAlertCondition_NerdGraphThresholdDurationValidationError
 					rNameBaseline,
 					"baseline",
 					20,
-					60, // outside of accepted range [120, 3600] to test error handling
+					60, // outside of accepted range [120, 86400] to test error handling
 					"static",
 					"0",
 					conditionalAttrBaseline,

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -116,8 +116,8 @@ The `term` block supports the following arguments:
 - `threshold` - (Required) The value which will trigger an incident.
 <br>For _baseline_ NRQL alert conditions, the value must be in the range [1, 1000]. The value is the number of standard deviations from the baseline that the metric must exceed in order to create an incident.
 - `threshold_duration` - (Optional) The duration, in seconds, that the threshold must violate in order to create an incident. Value must be a multiple of the `aggregation_window` (which has a default of 60 seconds).
-<br>For _baseline_ NRQL alert conditions, the value must be within 120-3600 seconds (inclusive).
-<br>For _static_ NRQL alert conditions, the value must be within 60-7200 seconds (inclusive).
+<br>For _baseline_ NRQL alert conditions, the value must be within 120-86400 seconds (inclusive).
+<br>For _static_ NRQL alert conditions, the value must be within 60-86400 seconds (inclusive).
 
 - `threshold_occurrences` - (Optional) The criteria for how many data points must be in violation for the specified threshold duration. Valid values are: `all` or `at_least_once` (case insensitive).
 - `duration` - (Optional) **DEPRECATED:** Use `threshold_duration` instead. The duration of time, in _minutes_, that the threshold must violate for in order to create an incident. Must be within 1-120 (inclusive).


### PR DESCRIPTION
# Description

Updates the documentation for NRQL alert conditions to reflect up-coming updates to the maximum allowed threshold duration.

Previous maxima:

- **3600** seconds for baseline NRQL conditions
- **7200** seconds for static NRQL conditions

Updated maxima:

- **86_400** seconds for baseline NRQL conditions
- **86_400** seconds for static NRQL conditions

Fixes [NR-69147](https://issues.newrelic.com/browse/NR-69147)

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

Automated tests in `newrelic/resource_newrelic_nrql_alert_condition_test.go` (specifically `testAccNewRelicNrqlAlertConditionNerdGraphConfig`) will reflect this.

**Note:**

Given that the test is verifying validation of the field's defined maximum, it will pass in the feature's current state; however, the updated maximum is gated by a feature flag (`DCON/max_term_duration_24_hours`) and as such, these tests will continue to pass after the FF is at 100%.
