### PR TITLE
chore(workflows): remove outdated workflow documentation block

### DIFF
--- a/website/docs/r/workflow.html.markdown
+++ b/website/docs/r/workflow.html.markdown
@@ -160,10 +160,6 @@ details to include into the email body
 
 Destinations can be reused across multiple channels. But each channel can only be used in a single workflow (at least for now).
 
-When a workflow is deleted, all channels associated with it are also deleted. We might change this behaviour in the future, 
-but please keep this behaviour in mind when managing workflows right now. 
-If you only delete a workflow resource and not its channel resource, the next time you run TF it will report state drift.
-
 Each workflow resource requires one or more `destination` blocks. These blocks define notification channels to use for the
 workflow.
 


### PR DESCRIPTION
# Description

Automatic channel deletion has been disabled starting from v3.10.0, but the docs were not updated to reflect that


## Type of change

Please delete options that are not relevant.

- [x] Documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have performed a self-review of my own code

