### PR TITLE
docs(synthetics_step_monitor): moved list of valid values to correct argument

### DIFF
--- a/website/docs/r/synthetics_step_monitor.html.markdown
+++ b/website/docs/r/synthetics_step_monitor.html.markdown
@@ -51,15 +51,15 @@ The following are the common arguments supported for `STEP` monitor:
 All nested `location_private` blocks support the following common arguments:
 
 * `guid` - (Required) The unique identifier for the Synthetics private location in New Relic.
-* `vse_password` - (Optional) The location's Verified Script Execution password, Only necessary if Verified Script Execution is enabled for the location.
+* `vse_password` - (Optional) The location's Verified Script Execution password, only necessary if Verified Script Execution is enabled for the location.
 
 ### Nested `steps` blocks
 
 All nested `steps` blocks support the following common arguments:
 
 * `ordinal` - (Required) The position of the step within the script ranging from 0-100.
-* `type` - (Required) Name of the tag key.
-* `values` - (Optional) The metadata values related to the step. valid values are ASSERT_ELEMENT, ASSERT_MODAL, ASSERT_TEXT, ASSERT_TITLE, CLICK_ELEMENT, DISMISS_MODAL, DOUBLE_CLICK_ELEMENT, HOVER_ELEMENT, NAVIGATE, SECURE_TEXT_ENTRY, SELECT_ELEMENT, TEXT_ENTRY.
+* `type` - (Required) Name of the tag key. Valid values are ASSERT_ELEMENT, ASSERT_MODAL, ASSERT_TEXT, ASSERT_TITLE, CLICK_ELEMENT, DISMISS_MODAL, DOUBLE_CLICK_ELEMENT, HOVER_ELEMENT, NAVIGATE, SECURE_TEXT_ENTRY, SELECT_ELEMENT, TEXT_ENTRY.
+* `values` - (Optional) The metadata values related to the step.
 
 ### Nested `tag` blocks
 


### PR DESCRIPTION
# Description

Noticed that a list of valid values for the `type` argument under the `steps` nested block were incorrectly placed under the `values` argument.  Have moved the list to be under the `type` argument. Also corrected a capitalised `O` to lowercase.

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
