### PR TITLE
feat(workflows): expose workflow entity guid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.20.3
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.11.2
+	github.com/newrelic/newrelic-client-go/v2 v2.13.0
 	github.com/stretchr/testify v1.8.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,8 @@ github.com/newrelic/go-agent/v3 v3.20.3 h1:hUBAMq/Y2Y9as5/yxQbf0zNde/X7w58cWZkm2
 github.com/newrelic/go-agent/v3 v3.20.3/go.mod h1:rT6ZUxJc5rQbWLyCtjqQCOcfb01lKRFbc1yMQkcboWM=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.11.2 h1:a3LXYYNDFsX2/4AKnMwW6uollYyFcHV9hdUV/Bu4qHg=
-github.com/newrelic/newrelic-client-go/v2 v2.11.2/go.mod h1:xDZ6IDWI6fpl7MhTI4Hk75alJLAIfXzOt/rINEolxhQ=
+github.com/newrelic/newrelic-client-go/v2 v2.13.0 h1:lwkfAtQtvdtQJzTmcmCQ6bnnfAazNS5H3IhYbJ0rJxY=
+github.com/newrelic/newrelic-client-go/v2 v2.13.0/go.mod h1:xDZ6IDWI6fpl7MhTI4Hk75alJLAIfXzOt/rINEolxhQ=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=

--- a/newrelic/resource_newrelic_workflow.go
+++ b/newrelic/resource_newrelic_workflow.go
@@ -227,6 +227,11 @@ func resourceNewRelicWorkflow() *schema.Resource {
 				Computed:    true,
 				Description: "The id of the workflow.",
 			},
+			"guid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Workflow entity GUID",
+			},
 		},
 		SchemaVersion: 1,
 		StateUpgraders: []schema.StateUpgrader{

--- a/newrelic/resource_newrelic_workflow_test.go
+++ b/newrelic/resource_newrelic_workflow_test.go
@@ -28,6 +28,7 @@ func TestNewRelicWorkflow_Webhook(t *testing.T) {
 				Config: testAccNewRelicWorkflowConfigurationWebhook(testAccountID, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicWorkflowExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "guid"),
 				),
 			},
 			// Test: Update

--- a/newrelic/structures_newrelic_workflow.go
+++ b/newrelic/structures_newrelic_workflow.go
@@ -364,6 +364,10 @@ func flattenWorkflow(workflow *workflows.AiWorkflowsWorkflow, d *schema.Resource
 		}
 	}
 
+	if err := d.Set("guid", workflow.GUID); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/newrelic/structures_newrelic_workflow_test.go
+++ b/newrelic/structures_newrelic_workflow_test.go
@@ -205,6 +205,7 @@ func TestFlattenWorkflow(t *testing.T) {
 		}},
 	}
 
+	guid := workflows.EntityGUID("testworkflowentityguid")
 	r := resourceNewRelicWorkflow()
 
 	cases := map[string]struct {
@@ -220,6 +221,7 @@ func TestFlattenWorkflow(t *testing.T) {
 				"destinations_enabled":  true,
 				"enabled":               true,
 				"muting_rules_handling": "NOTIFY_ALL_ISSUES",
+				"guid":                  "testworkflowentityguid",
 				"enrichments": []map[string]interface{}{{
 					"name": "enrichment-test-1",
 					"type": "NRQL",
@@ -252,6 +254,7 @@ func TestFlattenWorkflow(t *testing.T) {
 				Enrichments:               enrichments,
 				DestinationConfigurations: destinationConfigurations,
 				IssuesFilter:              issuesFilter,
+				GUID:                      guid,
 			},
 		},
 		"no_enrichments": {
@@ -261,6 +264,7 @@ func TestFlattenWorkflow(t *testing.T) {
 				"destinations_enabled":  true,
 				"enabled":               true,
 				"muting_rules_handling": "NOTIFY_ALL_ISSUES",
+				"guid":                  "testworkflowentityguid",
 				"issues_filter": map[string]interface{}{
 					"name": "issues-filter-test",
 					"type": "FILTER",
@@ -286,6 +290,7 @@ func TestFlattenWorkflow(t *testing.T) {
 				Enrichments:               []workflows.AiWorkflowsEnrichment{},
 				DestinationConfigurations: destinationConfigurations,
 				IssuesFilter:              issuesFilter,
+				GUID:                      guid,
 			},
 		},
 		"no_notification_triggers": {
@@ -295,6 +300,7 @@ func TestFlattenWorkflow(t *testing.T) {
 				"destinations_enabled":  true,
 				"enabled":               true,
 				"muting_rules_handling": "NOTIFY_ALL_ISSUES",
+				"guid":                  "testworkflowentityguid",
 				"issues_filter": map[string]interface{}{
 					"name": "issues-filter-test",
 					"type": "FILTER",
@@ -319,6 +325,7 @@ func TestFlattenWorkflow(t *testing.T) {
 				Enrichments:               []workflows.AiWorkflowsEnrichment{},
 				DestinationConfigurations: destinationConfigurationsWithNotificationTriggers,
 				IssuesFilter:              issuesFilter,
+				GUID:                      guid,
 			},
 		},
 	}


### PR DESCRIPTION
# Description

In future, this GUID can be used to assign tags to workflows though TF. 
For now though, this is now really feasible as indexing lag can reach several minutes.

I will not be updating documentation with tagging examples until it works quickly and reliably.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

- And workflow should now have a computed GUID field that can be used in the script
