### PR TITLE
fix(nrql_alert_condition): retry when guid is not returned from API

### DIFF
--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -417,6 +417,10 @@ func resourceNewRelicNrqlAlertConditionCreate(ctx context.Context, d *schema.Res
 			return resource.NonRetryableError(err)
 		}
 
+		if condition.EntityGUID == "" {
+			return resource.RetryableError(fmt.Errorf("nrql condition did not return a guid, retrying"))
+		}
+
 		return nil
 	})
 


### PR DESCRIPTION
# Description

Blind fix for API not immediately returning `GUID`. The code will now retry the read until a GUID is returned.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

