### PR TITLE
chore(alerts): deprecate legacy alert resources and data sources

### DIFF
--- a/newrelic/data_source_newrelic_alert_channel.go
+++ b/newrelic/data_source_newrelic_alert_channel.go
@@ -19,7 +19,8 @@ func dataSourceNewRelicAlertChannel() *schema.Resource {
 	}
 
 	return &schema.Resource{
-		ReadContext: dataSourceNewRelicAlertChannelRead,
+		DeprecationMessage: "The `newrelic_alert_channel` data source is deprecated and will be removed in the next major release.",
+		ReadContext:        dataSourceNewRelicAlertChannelRead,
 		Schema: map[string]*schema.Schema{
 			"account_id": {
 				Type:        schema.TypeInt,

--- a/newrelic/resource_newrelic_alert_channel.go
+++ b/newrelic/resource_newrelic_alert_channel.go
@@ -55,8 +55,9 @@ func resourceNewRelicAlertChannel() *schema.Resource {
 	}
 
 	return &schema.Resource{
-		CreateContext: resourceNewRelicAlertChannelCreate,
-		ReadContext:   resourceNewRelicAlertChannelRead,
+		DeprecationMessage: "The `newrelic_alert_channel` resource is deprecated and will be removed in the next major release. Please use `newrelic_notification_channel` instead.",
+		CreateContext:      resourceNewRelicAlertChannelCreate,
+		ReadContext:        resourceNewRelicAlertChannelRead,
 		// Update: Not currently supported in API
 		DeleteContext: resourceNewRelicAlertChannelDelete,
 		Importer: &schema.ResourceImporter{

--- a/newrelic/resource_newrelic_alert_condition.go
+++ b/newrelic/resource_newrelic_alert_condition.go
@@ -78,10 +78,11 @@ func resourceNewRelicAlertCondition() *schema.Resource {
 	}
 
 	return &schema.Resource{
-		CreateContext: resourceNewRelicAlertConditionCreate,
-		ReadContext:   resourceNewRelicAlertConditionRead,
-		UpdateContext: resourceNewRelicAlertConditionUpdate,
-		DeleteContext: resourceNewRelicAlertConditionDelete,
+		DeprecationMessage: "The `newrelic_alert_condition` resource is deprecated and will be removed in the next major release. Please use `newrelic_nrql_alert_condition` instead.",
+		CreateContext:      resourceNewRelicAlertConditionCreate,
+		ReadContext:        resourceNewRelicAlertConditionRead,
+		UpdateContext:      resourceNewRelicAlertConditionUpdate,
+		DeleteContext:      resourceNewRelicAlertConditionDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/newrelic/resource_newrelic_infra_alert_condition.go
+++ b/newrelic/resource_newrelic_infra_alert_condition.go
@@ -58,10 +58,11 @@ func resourceNewRelicInfraAlertCondition() *schema.Resource {
 	}
 
 	return &schema.Resource{
-		CreateContext: resourceNewRelicInfraAlertConditionCreate,
-		ReadContext:   resourceNewRelicInfraAlertConditionRead,
-		UpdateContext: resourceNewRelicInfraAlertConditionUpdate,
-		DeleteContext: resourceNewRelicInfraAlertConditionDelete,
+		DeprecationMessage: "The `newrelic_infra_alert_condition` resource is deprecated. Please use `newrelic_nrql_alert_condition` instead.",
+		CreateContext:      resourceNewRelicInfraAlertConditionCreate,
+		ReadContext:        resourceNewRelicInfraAlertConditionRead,
+		UpdateContext:      resourceNewRelicInfraAlertConditionUpdate,
+		DeleteContext:      resourceNewRelicInfraAlertConditionDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/newrelic/resource_newrelic_synthetics_alert_condition.go
+++ b/newrelic/resource_newrelic_synthetics_alert_condition.go
@@ -13,10 +13,11 @@ import (
 
 func resourceNewRelicSyntheticsAlertCondition() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceNewRelicSyntheticsAlertConditionCreate,
-		ReadContext:   resourceNewRelicSyntheticsAlertConditionRead,
-		UpdateContext: resourceNewRelicSyntheticsAlertConditionUpdate,
-		DeleteContext: resourceNewRelicSyntheticsAlertConditionDelete,
+		DeprecationMessage: "The `newrelic_synthetics_alert_condition` resource is deprecated. Please use `newrelic_nrql_alert_condition` instead.",
+		CreateContext:      resourceNewRelicSyntheticsAlertConditionCreate,
+		ReadContext:        resourceNewRelicSyntheticsAlertConditionRead,
+		UpdateContext:      resourceNewRelicSyntheticsAlertConditionUpdate,
+		DeleteContext:      resourceNewRelicSyntheticsAlertConditionDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/newrelic/resource_newrelic_synthetics_multilocation_alert_condition.go
+++ b/newrelic/resource_newrelic_synthetics_multilocation_alert_condition.go
@@ -26,10 +26,11 @@ func syntheticsMultiLocationConditionTermSchema() *schema.Resource {
 
 func resourceNewRelicSyntheticsMultiLocationAlertCondition() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceNewRelicSyntheticsMultiLocationAlertConditionCreate,
-		ReadContext:   resourceNewRelicSyntheticsMultiLocationAlertConditionRead,
-		UpdateContext: resourceNewRelicSyntheticsMultiLocationAlertConditionUpdate,
-		DeleteContext: resourceNewRelicSyntheticsMultiLocationAlertConditionDelete,
+		DeprecationMessage: "The `newrelic_synthetics_multilocation_alert_condition` resource is deprecated. Please use `newrelic_nrql_alert_condition` instead.",
+		CreateContext:      resourceNewRelicSyntheticsMultiLocationAlertConditionCreate,
+		ReadContext:        resourceNewRelicSyntheticsMultiLocationAlertConditionRead,
+		UpdateContext:      resourceNewRelicSyntheticsMultiLocationAlertConditionUpdate,
+		DeleteContext:      resourceNewRelicSyntheticsMultiLocationAlertConditionDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/website/docs/d/alert_channel.html.markdown
+++ b/website/docs/d/alert_channel.html.markdown
@@ -8,7 +8,10 @@ description: |-
 
 # Data Source: newrelic\_alert\_channel
 
-Use this data source to get information about a specific alert channel in New Relic that already exists.  More information on Terraform's data sources can be found [here](https://www.terraform.io/language/data-sources).
+Use this data source to get information about a specific alert channel in New Relic that already exists. More information on Terraform's data sources can be found [here](https://www.terraform.io/language/data-sources).
+
+-> **WARNING:** The `newrelic_alert_channel` data source is deprecated and will be removed in the next major release.
+
 
 ## Example Usage
 

--- a/website/docs/r/alert_channel.html.markdown
+++ b/website/docs/r/alert_channel.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Use this resource to create and manage New Relic alert channels.
 
-~> **NOTE:** This is a legacy resource. For managing channel resources in Workflows, use [`newrelic_notification_channel`](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/notification_channel).
+-> **WARNING:** The `newrelic_alert_channel` resource is deprecated and will be removed in the next major release. For managing channel resources in Workflows, use [`newrelic_notification_channel`](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/notification_channel).
 
 ## Example Usage
 

--- a/website/docs/r/alert_condition.html.markdown
+++ b/website/docs/r/alert_condition.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Use this resource to create and manage alert conditions for APM, Browser, and Mobile in New Relic.
 
--> **WARNING:** The  newrelic_alert_condition resource will be deprecated in the near future and will no longer receive product updates. Please use the [newrelic_nrql_alert_condition](nrql_alert_condition.html) resource to avoid being impacted by these changes.
+-> **WARNING:** The `newrelic_alert_condition` resource is deprecated and will be removed in the next major release. Please use the [newrelic_nrql_alert_condition](nrql_alert_condition.html) resource to avoid being impacted by these changes.
 
 ## Example Usage
 

--- a/website/docs/r/synthetics_alert_condition.html.markdown
+++ b/website/docs/r/synthetics_alert_condition.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Use this resource to create and manage synthetics alert conditions in New Relic.
 
--> **WARNING:** The  newrelic_synthetics_alert_condition resource will be deprecated in the near future and will no longer receive product updates. Please use the [newrelic_nrql_alert_condition](nrql_alert_condition.html) resource to avoid being impacted by these changes.
+-> **WARNING:** The `newrelic_synthetics_alert_condition` resource is deprecated and will be removed in the next major release. Please use the [newrelic_nrql_alert_condition](nrql_alert_condition.html) resource to avoid being impacted by these changes.
 
 ## Example Usage
 

--- a/website/docs/r/synthetics_multilocation_alert_condition.markdown
+++ b/website/docs/r/synthetics_multilocation_alert_condition.markdown
@@ -10,7 +10,9 @@ description: |-
 
 Use this resource to create, update, and delete a New Relic Synthetics Location Alerts.
 
--> **NOTE:** The [newrelic_nrql_alert_condition](nrql_alert_condition.html) resource is preferred for configuring alerts conditions. In most cases feature parity can be achieved with a NRQL query. Other condition types may be deprecated in the future and receive fewer product updates.
+-> **NOTE:** The `newrelic_synthetics_multilocation_alert_condition` resource is deprecated and will be removed in the next major release. Please use the [newrelic_nrql_alert_condition](nrql_alert_condition.html) resource to avoid being impacted by these changes.
+
+
 
 ## Example Usage
 
@@ -74,4 +76,3 @@ New Relic Synthetics MultiLocation Conditions can be imported using a concatenat
 ```bash
 $ terraform import newrelic_synthetics_multilocation_alert_condition.example 12345678:1456
 ```
-


### PR DESCRIPTION
Deprecated Data Sources (EOL June 2023)
- `newrelic_alert_channel`

Deprecated Resources (EOL June 2023)
- `newrelic_alert_channel`
- `newrelic_alert_condition`
- `newrelic_infra_alert_condition`
- `newrelic_synthetics_alert_condition`
- `newrelic_synthetics_multilocation_alert_condition`