### PR TITLE
refactor(entity): use GetEntitySearchByQuery instead of GetEntitySearch

### DIFF
--- a/newrelic/data_source_newrelic_entity_integration_test.go
+++ b/newrelic/data_source_newrelic_entity_integration_test.go
@@ -39,7 +39,7 @@ func TestAccNewRelicEntityData_Missing(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccNewRelicEntityDataConfig(strings.ToUpper(testAccExpectedApplicationName), testAccountID),
-				ExpectError: regexp.MustCompile(`the name '.*' does not match any New Relic One entity for the given search parameters \(ignore_case: false\)`),
+				ExpectError: regexp.MustCompile(`no entities found`),
 			},
 		},
 	})
@@ -57,36 +57,6 @@ func TestAccNewRelicEntityData_IgnoreCase(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicEntityDataExists(t, "data.newrelic_entity.entity", testAccExpectedApplicationName),
 				),
-			},
-		},
-	})
-}
-
-func TestAccNewRelicEntityData_TypeFail(t *testing.T) {
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccNewRelicEntityDataConfig_InvalidType(strings.ToUpper(testAccExpectedApplicationName), testAccountID),
-				ExpectError: regexp.MustCompile("Argument \"queryBuilder\""),
-			},
-		},
-	})
-}
-
-func TestAccNewRelicEntityData_DomainFail(t *testing.T) {
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccNewRelicEntityDataConfig_InvalidDomain(strings.ToUpper(testAccExpectedApplicationName), testAccountID),
-				ExpectError: regexp.MustCompile("Argument \"queryBuilder\""),
 			},
 		},
 	})

--- a/newrelic/data_source_newrelic_entity_test.go
+++ b/newrelic/data_source_newrelic_entity_test.go
@@ -6,27 +6,94 @@ package newrelic
 import (
 	"testing"
 
-	"github.com/newrelic/newrelic-client-go/v2/pkg/entities"
 	"github.com/stretchr/testify/require"
 )
 
-func TestExpandEntityTag(t *testing.T) {
-	flattened := []interface{}{
+func TestBuildTagsQueryFragment_SingleTag(t *testing.T) {
+	t.Parallel()
+
+	expected := "tags.`tagKey` = 'tagValue'"
+
+	tags := []interface{}{
 		map[string]interface{}{
-			"key":   "my-key",
-			"value": "my-value",
+			"key":   "tagKey",
+			"value": "tagValue",
 		},
 	}
 
-	expected := []entities.EntitySearchQueryBuilderTag{
-		{
-			Key:   "my-key",
-			Value: "my-value",
+	result := buildTagsQueryFragment(tags)
+
+	require.Equal(t, expected, result)
+}
+
+func TestBuildTagsQueryFragment_MultipleTags(t *testing.T) {
+	t.Parallel()
+
+	expected := "tags.`tagKey` = 'tagValue' AND tags.`tagKey2` = 'tagValue2' AND tags.`tagKey3` = 'tagValue3'"
+
+	tags := []interface{}{
+		map[string]interface{}{
+			"key":   "tagKey",
+			"value": "tagValue",
+		},
+		map[string]interface{}{
+			"key":   "tagKey2",
+			"value": "tagValue2",
+		},
+		map[string]interface{}{
+			"key":   "tagKey3",
+			"value": "tagValue3",
 		},
 	}
 
-	expanded := expandEntityTag(flattened)
+	result := buildTagsQueryFragment(tags)
 
-	require.NotNil(t, expanded)
-	require.Equal(t, expected, expanded)
+	require.Equal(t, expected, result)
+}
+
+func TestBuildTagsQueryFragment_EmptyTags(t *testing.T) {
+	t.Parallel()
+
+	expected := ""
+	tags := []interface{}{}
+
+	result := buildTagsQueryFragment(tags)
+
+	require.Equal(t, expected, result)
+}
+
+func TestBuildEntitySearchQuery(t *testing.T) {
+	t.Parallel()
+
+	tags := []interface{}{}
+
+	// Name only
+	expected := "name = 'Dummy App'"
+	result := buildEntitySearchQuery("Dummy App", "", "", tags)
+	require.Equal(t, expected, result)
+
+	// Name & Domain
+	expected = "name = 'Dummy App' AND domain = 'APM'"
+	result = buildEntitySearchQuery("Dummy App", "APM", "", tags)
+	require.Equal(t, expected, result)
+
+	// Name, domain, and type
+	expected = "name = 'Dummy App' AND domain = 'APM' AND type = 'APPLICATION'"
+	result = buildEntitySearchQuery("Dummy App", "APM", "APPLICATION", tags)
+	require.Equal(t, expected, result)
+
+	// Name, domain, type, and tags
+	expected = "name = 'Dummy App' AND domain = 'APM' AND type = 'APPLICATION' AND tags.`tagKey` = 'tagValue' AND tags.`tagKey2` = 'tagValue2'"
+	tags = []interface{}{
+		map[string]interface{}{
+			"key":   "tagKey",
+			"value": "tagValue",
+		},
+		map[string]interface{}{
+			"key":   "tagKey2",
+			"value": "tagValue2",
+		},
+	}
+	result = buildEntitySearchQuery("Dummy App", "APM", "APPLICATION", tags)
+	require.Equal(t, expected, result)
 }

--- a/newrelic/resource_newrelic_cloud_azure_link_account.go
+++ b/newrelic/resource_newrelic_cloud_azure_link_account.go
@@ -66,7 +66,7 @@ func resourceNewRelicCloudAzureLinkAccountCreate(ctx context.Context, d *schema.
 	cloudLinkAccountPayload, err := client.Cloud.CloudLinkAccountWithContext(ctx, accountID, linkAccountInput)
 
 	if err != nil {
-		diag.FromErr(err)
+		return diag.FromErr(err)
 	}
 
 	if len(cloudLinkAccountPayload.Errors) > 0 {

--- a/newrelic/resource_newrelic_cloud_gcp_link_account.go
+++ b/newrelic/resource_newrelic_cloud_gcp_link_account.go
@@ -2,6 +2,7 @@ package newrelic
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -54,7 +55,11 @@ func resourceNewRelicCloudGcpLinkAccountCreate(ctx context.Context, d *schema.Re
 	cloudLinkAccountPayload, err := client.Cloud.CloudLinkAccountWithContext(ctx, accountID, linkAccountInput)
 
 	if err != nil {
-		diag.FromErr(err)
+		return diag.FromErr(err)
+	}
+
+	if cloudLinkAccountPayload == nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] cloudLinkAccountPayload was nil"))
 	}
 
 	if len(cloudLinkAccountPayload.Errors) > 0 {

--- a/newrelic/resource_newrelic_synthetics_secure_credential_test.go
+++ b/newrelic/resource_newrelic_synthetics_secure_credential_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/entities"
@@ -17,10 +18,10 @@ import (
 
 func TestAccNewRelicSyntheticsSecureCredential_Basic(t *testing.T) {
 	resourceName := "newrelic_synthetics_secure_credential.foo"
-	rName := generateNameForIntegrationTestResource()
+	rName := fmt.Sprintf("TF_TEST_%s", acctest.RandString(7))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicSyntheticsSecureCredentialDestroy,
 		Steps: []resource.TestStep{
@@ -57,7 +58,7 @@ func TestAccNewRelicSyntheticsSecureCredential_Error(t *testing.T) {
 	resourceName := "newrelic_synthetics_secure_credential.foo"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicSyntheticsSecureCredentialDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
The PR replaces the use of `GetEntitySearchWithContext` with `GetEntitySearchByQueryWithContext`. This change provides us more precision with regard to querying for entity data. 

Under the hood, this means we're using `entitySearch.query` instead of `entitySearch.queryBuilder`. The `queryBuilder` was less precise due to loose comparisons in the query it constructs. 


👎  `queryBuilder` uses a fuzzy search with `LIKE` which is less precise. 🙁 
```
name LIKE 'app-name'
```
<br>

👍 `query` gives us more control because we can control the operators we use, such as `=` for better precision. 🙂 
```
name = 'app-name'
```

Note: This refactor should _not_ cause a breaking change.