### PR TITLE
docs: add additional examples to resources to demonstrate setting thresholds

### DIFF
--- a/website/docs/r/one_dashboard.html.markdown
+++ b/website/docs/r/one_dashboard.html.markdown
@@ -310,6 +310,35 @@ resource "newrelic_one_dashboard" "multi_page_dashboard" {
   }
 }
 ```
+### Setting Thresholds
+
+The following example explains setting thresholds on a billboard widget.
+
+```hcl
+resource "newrelic_one_dashboard" "sample_dashboard" {
+  name = "Sample Dashboard"
+  page {
+    name        = "Transactions Page"
+    description = null
+
+    widget_billboard {
+      title  = "Transaction Latency Tracker"
+      row    = 1
+      column = 1
+      width  = 5
+      height = 5
+
+      nrql_query {
+        query = "select count(*) from Transaction where duration> 0.001 since 1 hour ago"
+      }
+      warning  = 15
+      critical = 40
+    }
+  }
+}
+```
+
+Alternatively, you can also implement the same using the [_newrelic_one_dashboard_json_](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/one_dashboard_json) resource, by adding the attribute `threshold` to the JSON file (which can also be done from the [New Relic Dashboard UI](https://docs.newrelic.com/docs/query-your-data/explore-query-data/dashboards/dashboards-charts-import-export-data/#dashboards)). Please see the [Additional Examples](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/one_dashboard_json#additional-examples) section, under the aforementioned resource.
 
 ## Import
 

--- a/website/docs/r/one_dashboard_json.html.markdown
+++ b/website/docs/r/one_dashboard_json.html.markdown
@@ -30,9 +30,9 @@ In addition to all arguments above, the following attributes are exported:
 - `permalink` - The URL for viewing the dashboard.
 - `updated_at` - The date and time when the dashboard was last updated.
 
-## Additional examples
+## Additional Examples
 
-##### Template
+### Template
 
 Below is an example how you can use [templatefile](https://www.terraform.io/language/functions/templatefile) to dynamically generate pages based on a list. We also replace the `account_id` which is usually hardcoded in the json with a variable.
 
@@ -105,5 +105,63 @@ resource "newrelic_one_dashboard_json" "bar" {
   %{ endfor }
   ],
   "variables": []
+}
+```
+### Setting Thresholds
+
+Similar to the feature of setting warning/critical thresholds via the 'Edit Widget' option in the UI of New Relic Dashboards, thresholds may be configured using this resource, by adding the `thresholds` attribute to the JSON (which can also be done from the [New Relic Dashboard UI](https://docs.newrelic.com/docs/query-your-data/explore-query-data/dashboards/dashboards-charts-import-export-data/#dashboards), so as to add the `threshold` attribute to the exported JSON). The following example demonstrates setting thresholds on a billboard widget.
+
+```hcl
+resource "newrelic_one_dashboard_json" "sample_json_dashboard" {
+  json = file("dashboard.json")
+}
+```
+
+`dashboard.json`
+```json
+{
+  "name" : "Sample",
+  "description" : null,
+  "permissions" : "PUBLIC_READ_WRITE",
+  "pages" : [
+    {
+      "name" : "Transaction Failure Tracker",
+      "description" : null,
+      "widgets" : [
+        {
+          "title" : "Transaction Failure Tracker",
+          "layout" : {
+            "column" : 1,
+            "row" : 1,
+            "width" : 10,
+            "height" : 5
+          },
+          "visualization" : {
+            "id" : "viz.billboard"
+          },
+          "rawConfiguration" : {
+            "nrqlQueries" : [
+              {
+                "accountIds" : [
+                  <Your Account ID>
+                ],
+                "query" : "SELECT count(*) from Transaction where httpResponseCode!=200 since 1 hour ago"
+              }
+            ],
+            "thresholds" : [
+              {
+                "alertSeverity" : "WARNING",
+                "value" : 12
+              },
+              {
+                "alertSeverity" : "CRITICAL",
+                "value" : 40
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
 }
 ```


### PR DESCRIPTION
# Description

(current status: Work in Progress)

This PR addresses [NR-97070](https://issues.newrelic.com/browse/NR-97070), documentation updates to be made to the `newrelic_one_dashboard_json` and the `newrelic_one_dashboard` resources in the New Relic Terraform Registry, in order to add additional examples, to demonstrate the addition of thresholds, for instance, to the 'billboard' widget.

## Type of change
- [x] This change requires a documentation update

## Checklist:
- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have made corresponding changes to the documentation

