### PR TITLE
docs: add additional example to one_dashboard_json to demonstrate setting thresholds

### DIFF
--- a/website/docs/r/one_dashboard_json.html.markdown
+++ b/website/docs/r/one_dashboard_json.html.markdown
@@ -30,9 +30,9 @@ In addition to all arguments above, the following attributes are exported:
 - `permalink` - The URL for viewing the dashboard.
 - `updated_at` - The date and time when the dashboard was last updated.
 
-## Additional examples
+## Additional Examples
 
-##### Template
+### Template
 
 Below is an example how you can use [templatefile](https://www.terraform.io/language/functions/templatefile) to dynamically generate pages based on a list. We also replace the `account_id` which is usually hardcoded in the json with a variable.
 
@@ -105,5 +105,56 @@ resource "newrelic_one_dashboard_json" "bar" {
   %{ endfor }
   ],
   "variables": []
+}
+```
+### Setting Thresholds
+
+The following example demonstrates setting thresholds on a billboard widget.
+
+`dashboard.json`
+```json
+{
+  "name" : "Sample",
+  "permissions" : "PUBLIC_READ_WRITE",
+  "pages" : [
+    {
+      "name" : "Sample Page",
+      "description" : "A guide to the metrics of daily transactions on the website.",
+      "widgets" : [
+        {
+          "title" : "Transaction Failure Tracker",
+          "layout" : {
+            "column" : 1,
+            "row" : 1,
+            "width" : 3,
+            "height" : 5
+          },
+          "visualization" : {
+            "id" : "viz.billboard"
+          },
+          "rawConfiguration" : {
+            "nrqlQueries" : [
+              {
+                "accountIds" : [
+                  {Your-Account-ID}
+                ],
+                "query" : "SELECT count(*) from Transaction where httpResponseCode!=200 since 1 hour ago"
+              }
+            ],
+            "thresholds" : [
+              {
+                "alertSeverity" : "WARNING",
+                "value" : 15
+              },
+              {
+                "alertSeverity" : "CRITICAL",
+                "value" : 40
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
 }
 ```


### PR DESCRIPTION
# Description

This PR addresses [NR-97070](https://issues.newrelic.com/browse/NR-97070), documentation updates to be made to the `newrelic_one_dashboard_json` resource in the New Relic Terraform Registry, in order to add an additional example, to demonstrate the addition of thresholds, for instance, to the 'billboard' widget.

## Type of change
- [x] This change requires a documentation update

## Checklist:
- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have made corresponding changes to the documentation

