### PR TITLE
fix(newrelic_entity): add helpers to escape single quotes in NRQL que…

### DIFF
--- a/newrelic/data_source_newrelic_entity.go
+++ b/newrelic/data_source_newrelic_entity.go
@@ -94,6 +94,7 @@ func dataSourceNewRelicEntityRead(ctx context.Context, d *schema.ResourceData, m
 	log.Printf("[INFO] Reading New Relic entities")
 
 	name := d.Get("name").(string)
+	name = escapeSingleQuote(name)
 	ignoreCase := d.Get("ignore_case").(bool)
 	entityType := strings.ToUpper(d.Get("type").(string))
 	domain := strings.ToUpper(d.Get("domain").(string))
@@ -124,6 +125,7 @@ func dataSourceNewRelicEntityRead(ctx context.Context, d *schema.ResourceData, m
 		str := e.GetName()
 		str = strings.TrimSpace(str)
 
+		name = revertEscapedSingleQuote(name)
 		if strings.Compare(str, name) == 0 || (ignoreCase && strings.EqualFold(str, name)) {
 			entity = &e
 			break

--- a/newrelic/data_source_newrelic_entity_integration_test.go
+++ b/newrelic/data_source_newrelic_entity_integration_test.go
@@ -30,6 +30,25 @@ func TestAccNewRelicEntityData_Basic(t *testing.T) {
 	})
 }
 
+// This test case checks if an entity with a single quote "'" in its name
+// is created, and is subsequently, fetched by the data source.
+func TestAccNewRelicSingleQuotedEntityData_Basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccSingleQuotedPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNewRelicEntityDataConfig(testAccExpectedSingleQuotedApplicationName, testAccountID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicEntityDataExists(t, "data.newrelic_entity.entity", testAccExpectedSingleQuotedApplicationName),
+				),
+			},
+		},
+	})
+}
+
 func TestAccNewRelicEntityData_Missing(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {

--- a/newrelic/helpers.go
+++ b/newrelic/helpers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -129,4 +130,32 @@ func mergeSchemas(schemas ...map[string]*schema.Schema) map[string]*schema.Schem
 		}
 	}
 	return schema
+}
+
+// This method helps identify single quotes in the argument 'name', to
+// prefix the '\' escape character before single quotes, in order to allow
+// NRQL to parse the query without errors caused by the single quote '.
+func escapeSingleQuote(name string) string {
+	unescapedSingleQuoteRegex := regexp.MustCompile(`'`)
+	quoteFormattedName := unescapedSingleQuoteRegex.ReplaceAllString(name, "\\'")
+	if strings.Compare(quoteFormattedName, name) != 0 {
+		log.Printf("Changing the name ( %s ---> %s ) since a single quote has been identified.", name, quoteFormattedName)
+		name = quoteFormattedName
+	}
+
+	return name
+}
+
+// This method helps identify escape characters preceding single quotes (')
+// and eliminates the escape characters to match it with the NRQL expression
+// parsed by the Terraform Provider.
+func revertEscapedSingleQuote(name string) string {
+	escapedSingleQuoteRegex := regexp.MustCompile(`\\'`)
+	quoteFormattedName := escapedSingleQuoteRegex.ReplaceAllString(name, "'")
+	if strings.Compare(quoteFormattedName, name) != 0 {
+		log.Printf("Reverting the name ( %s ---> %s ) since a single quote has been identified.", quoteFormattedName, name)
+		name = quoteFormattedName
+	}
+
+	return name
 }


### PR DESCRIPTION
## Description

This PR addresses [NR-97004](https://issues.newrelic.com/browse/NR-97004) (GitHub Issue [2223](https://github.com/newrelic/terraform-provider-newrelic/issues/2223)), addition of code to the ```newrelic_entity``` data source, in order to accomodate the usage of single quotes (') with the ```name``` attribute, which is currently failing, since NRQL queries cannot be parsed with both double quotes and single quotes.


Fixes # ([2223](https://github.com/newrelic/terraform-provider-newrelic/issues/2223))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?
- Step 1
Pull this branch, and run **make compile** to create a local copy of the binary-file version of the Terraform Provider. Also, run the following command in the terminal to use the local provider - ```EXPORT TF_CLI_CONFIG_FILE=dev.tfrc```.
- Step 2
Shift to the **testing** folder in this repo from the terminal. Add the following data source to the ```main.tf``` file. 
```
data newrelic_entity sample_data_source {
  name = "App with ' in it"
}
```
- Step 3
Run **terraform plan** followed by **terraform apply**. If you see no error (i.e. the data source has been fetched), since the name of the data source used in **main.tf** comprises of a single quote, the test may be deemed successful.