### PR TITLE
feat(Alerts): Expose entity_guid for legacy alert conditions

### DIFF
--- a/newrelic/condition_helpers.go
+++ b/newrelic/condition_helpers.go
@@ -1,0 +1,12 @@
+package newrelic
+
+import (
+	"fmt"
+	"encoding/base64"
+)
+
+// Builds a condition entity guid of the format "[accountID]|AIOPS|CONDITION|[conditionID]"
+func getConditionEntityGUID(conditionID int, accountID int) string {
+	rawGUID := fmt.Sprintf("%d|AIOPS|CONDITION|%d", accountID, conditionID)
+	return base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(rawGUID))
+}

--- a/newrelic/condition_helpers.go
+++ b/newrelic/condition_helpers.go
@@ -1,8 +1,8 @@
 package newrelic
 
 import (
-	"fmt"
 	"encoding/base64"
+	"fmt"
 )
 
 // Builds a condition entity guid of the format "[accountID]|AIOPS|CONDITION|[conditionID]"

--- a/newrelic/resource_newrelic_infra_alert_condition.go
+++ b/newrelic/resource_newrelic_infra_alert_condition.go
@@ -174,6 +174,11 @@ func resourceNewRelicInfraAlertCondition() *schema.Resource {
 				Optional:    true,
 				Description: "The description of the Infrastructure alert condition.",
 			},
+			"entity_guid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The unique entity identifier of the condition in New Relic.",
+			},
 		},
 	}
 }
@@ -233,7 +238,7 @@ func resourceNewRelicInfraAlertConditionRead(ctx context.Context, d *schema.Reso
 		return diag.FromErr(err)
 	}
 
-	return diag.FromErr(flattenInfraAlertCondition(condition, d))
+	return diag.FromErr(flattenInfraAlertCondition(condition, accountID, d))
 }
 
 func resourceNewRelicInfraAlertConditionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/newrelic/resource_newrelic_synthetics_alert_condition.go
+++ b/newrelic/resource_newrelic_synthetics_alert_condition.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"log"
 	"strconv"
-	"encoding/base64"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -74,11 +72,6 @@ func expandSyntheticsCondition(d *schema.ResourceData, monitorID string) *alerts
 	return &condition
 }
 
-func getSyntheticsConditionEntityGUID(condition *alerts.SyntheticsCondition, accountID int) string {
-	rawGUID := fmt.Sprintf("%d|AIOPS|CONDITION|%d", accountID, condition.ID)
-	return base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(rawGUID))
-}
-
 func flattenSyntheticsCondition(condition *alerts.SyntheticsCondition, accountID int, d *schema.ResourceData) error {
 	ids, err := parseIDs(d.Id(), 2)
 	if err != nil {
@@ -86,7 +79,7 @@ func flattenSyntheticsCondition(condition *alerts.SyntheticsCondition, accountID
 	}
 
 	policyID := ids[0]
-	entityGUID := getSyntheticsConditionEntityGUID(condition, accountID)
+	entityGUID := getConditionEntityGUID(condition.ID, accountID)
 
 	_ = d.Set("policy_id", policyID)
 	_ = d.Set("name", condition.Name)

--- a/newrelic/resource_newrelic_synthetics_alert_condition.go
+++ b/newrelic/resource_newrelic_synthetics_alert_condition.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"log"
 	"strconv"
+	"encoding/base64"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -49,6 +51,11 @@ func resourceNewRelicSyntheticsAlertCondition() *schema.Resource {
 				Default:     true,
 				Description: "Set whether to enable the alert condition. Defaults to true.",
 			},
+			"entity_guid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The unique entity identifier of the condition in New Relic.",
+			},
 		},
 	}
 }
@@ -67,18 +74,25 @@ func expandSyntheticsCondition(d *schema.ResourceData, monitorID string) *alerts
 	return &condition
 }
 
-func flattenSyntheticsCondition(condition *alerts.SyntheticsCondition, d *schema.ResourceData) error {
+func getSyntheticsConditionEntityGUID(condition *alerts.SyntheticsCondition, accountID int) string {
+	rawGUID := fmt.Sprintf("%d|AIOPS|CONDITION|%d", accountID, condition.ID)
+	return base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(rawGUID))
+}
+
+func flattenSyntheticsCondition(condition *alerts.SyntheticsCondition, accountID int, d *schema.ResourceData) error {
 	ids, err := parseIDs(d.Id(), 2)
 	if err != nil {
 		return err
 	}
 
 	policyID := ids[0]
+	entityGUID := getSyntheticsConditionEntityGUID(condition, accountID)
 
 	_ = d.Set("policy_id", policyID)
 	_ = d.Set("name", condition.Name)
 	_ = d.Set("runbook_url", condition.RunbookURL)
 	_ = d.Set("enabled", condition.Enabled)
+	_ = d.Set("entity_guid", entityGUID)
 
 	return nil
 }
@@ -140,7 +154,7 @@ func resourceNewRelicSyntheticsAlertConditionRead(ctx context.Context, d *schema
 		return diag.FromErr(err)
 	}
 
-	return diag.FromErr(flattenSyntheticsCondition(condition, d))
+	return diag.FromErr(flattenSyntheticsCondition(condition, accountID, d))
 }
 
 func resourceNewRelicSyntheticsAlertConditionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/newrelic/resource_newrelic_synthetics_multilocation_alert_condition.go
+++ b/newrelic/resource_newrelic_synthetics_multilocation_alert_condition.go
@@ -85,6 +85,11 @@ func resourceNewRelicSyntheticsMultiLocationAlertCondition() *schema.Resource {
 				ValidateFunc: validation.IntInSlice([]int{0, 3600, 7200, 14400, 28800, 43200, 86400}),
 				Description:  "The maximum number of seconds an incident can remain open before being closed by the system.  Must be one of: 0, 3600, 7200, 14400, 28800, 43200, 86400",
 			},
+			"entity_guid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The unique entity identifier of the condition in New Relic.",
+			},
 		},
 	}
 }
@@ -144,7 +149,7 @@ func resourceNewRelicSyntheticsMultiLocationAlertConditionRead(ctx context.Conte
 		return diag.FromErr(err)
 	}
 
-	return diag.FromErr(flattenMultiLocationSyntheticsCondition(condition, d))
+	return diag.FromErr(flattenMultiLocationSyntheticsCondition(condition, accountID, d))
 }
 
 func resourceNewRelicSyntheticsMultiLocationAlertConditionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/newrelic/structures_newrelic_alert_condition.go
+++ b/newrelic/structures_newrelic_alert_condition.go
@@ -3,7 +3,6 @@ package newrelic
 import (
 	"fmt"
 	"strconv"
-	"encoding/base64"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/alerts"
@@ -73,13 +72,8 @@ func expandAlertConditionTerms(terms []interface{}) []alerts.ConditionTerm {
 	return perms
 }
 
-func getEntityGUID(condition *alerts.Condition, accountID int) string {
-	rawGUID := fmt.Sprintf("%d|AIOPS|CONDITION|%d", accountID, condition.ID)
-	return base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(rawGUID))
-}
-
 func flattenAlertCondition(condition *alerts.Condition, accountID int, d *schema.ResourceData) error {
-	entityGUID := getEntityGUID(condition, accountID)
+	entityGUID := getConditionEntityGUID(condition.ID, accountID)
 
 	_ = d.Set("name", condition.Name)
 	_ = d.Set("enabled", condition.Enabled)

--- a/newrelic/structures_newrelic_alert_condition.go
+++ b/newrelic/structures_newrelic_alert_condition.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strconv"
 	"encoding/base64"
-	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/alerts"
@@ -74,15 +73,13 @@ func expandAlertConditionTerms(terms []interface{}) []alerts.ConditionTerm {
 	return perms
 }
 
-func getEntityGuid(condition *alerts.Condition, accountID int) string {
-	rawGuid := fmt.Sprintf("%d|AIOPS|CONDITION|%d", accountID, condition.ID)
-	return base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(rawGuid))
+func getEntityGUID(condition *alerts.Condition, accountID int) string {
+	rawGUID := fmt.Sprintf("%d|AIOPS|CONDITION|%d", accountID, condition.ID)
+	return base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(rawGUID))
 }
 
 func flattenAlertCondition(condition *alerts.Condition, accountID int, d *schema.ResourceData) error {
-
-	entityGuid := getEntityGuid(condition, accountID)
-	log.Printf("[INFO] +++ %s", entityGuid)
+	entityGUID := getEntityGUID(condition, accountID)
 
 	_ = d.Set("name", condition.Name)
 	_ = d.Set("enabled", condition.Enabled)
@@ -93,7 +90,7 @@ func flattenAlertCondition(condition *alerts.Condition, accountID int, d *schema
 	_ = d.Set("gc_metric", condition.GCMetric)
 	_ = d.Set("user_defined_metric", condition.UserDefined.Metric)
 	_ = d.Set("user_defined_value_function", condition.UserDefined.ValueFunction)
-	_ = d.Set("entity_guid", entityGuid)
+	_ = d.Set("entity_guid", entityGUID)
 
 	// The condition_scope field is not always returned by the API. This conditional
 	// handles flattening for all cases.

--- a/newrelic/structures_newrelic_infra_alert_condition.go
+++ b/newrelic/structures_newrelic_infra_alert_condition.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 	"time"
-	"encoding/base64"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/alerts"
@@ -80,11 +79,6 @@ func expandInfraAlertThreshold(v interface{}) *alerts.InfrastructureConditionThr
 	return alertInfraThreshold
 }
 
-func getInfrastructureConditionEntityGUID(condition *alerts.InfrastructureCondition, accountID int) string {
-	rawGUID := fmt.Sprintf("%d|AIOPS|CONDITION|%d", accountID, condition.ID)
-	return base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(rawGUID))
-}
-
 func flattenInfraAlertCondition(condition *alerts.InfrastructureCondition, accountID int, d *schema.ResourceData) error {
 	ids, err := parseIDs(d.Id(), 2)
 	if err != nil {
@@ -92,7 +86,7 @@ func flattenInfraAlertCondition(condition *alerts.InfrastructureCondition, accou
 	}
 
 	policyID := ids[0]
-	entityGUID := getInfrastructureConditionEntityGUID(condition, accountID)
+	entityGUID := getConditionEntityGUID(condition.ID, accountID)
 
 	_ = d.Set("policy_id", policyID)
 	_ = d.Set("name", condition.Name)

--- a/newrelic/structures_newrelic_synthetics_multilocation_alert_condition.go
+++ b/newrelic/structures_newrelic_synthetics_multilocation_alert_condition.go
@@ -3,7 +3,6 @@ package newrelic
 import (
 	"fmt"
 	"strings"
-	"encoding/base64"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/alerts"
@@ -86,11 +85,6 @@ func expandMultiLocationSyntheticsConditionTerm(term map[string]interface{}, pri
 	}, nil
 }
 
-func getMultiLocationSyntheticsConditionEntityGUID(condition *alerts.MultiLocationSyntheticsCondition, accountID int) string {
-	rawGUID := fmt.Sprintf("%d|AIOPS|CONDITION|%d", accountID, condition.ID)
-	return base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(rawGUID))
-}
-
 func flattenMultiLocationSyntheticsCondition(condition *alerts.MultiLocationSyntheticsCondition, accountID int, d *schema.ResourceData) error {
 	ids, err := parseIDs(d.Id(), 2)
 	if err != nil {
@@ -98,7 +92,7 @@ func flattenMultiLocationSyntheticsCondition(condition *alerts.MultiLocationSynt
 	}
 
 	policyID := ids[0]
-	entityGUID := getMultiLocationSyntheticsConditionEntityGUID(condition, accountID)
+	entityGUID := getConditionEntityGUID(condition.ID, accountID)
 
 	_ = d.Set("policy_id", policyID)
 	_ = d.Set("name", condition.Name)

--- a/newrelic/structures_newrelic_synthetics_multilocation_alert_condition_test.go
+++ b/newrelic/structures_newrelic_synthetics_multilocation_alert_condition_test.go
@@ -197,7 +197,10 @@ func TestFlattenMultiLocationSyntheticsCondition(t *testing.T) {
 			id := fmt.Sprintf("%d:%d", tc.Data["policy_id"], tc.Flattened.ID)
 			d.SetId(id)
 
-			err := flattenMultiLocationSyntheticsCondition(tc.Flattened, d)
+			accountID := 1
+
+
+			err := flattenMultiLocationSyntheticsCondition(tc.Flattened, accountID, d)
 			assert.NoError(t, err)
 
 			for k, v := range tc.Data {

--- a/website/docs/r/alert_condition.html.markdown
+++ b/website/docs/r/alert_condition.html.markdown
@@ -126,6 +126,7 @@ The `term` mapping supports the following arguments:
 In addition to all arguments above, the following attributes are exported:
 
   * `id` - The ID of the alert condition.
+  * `entity_guid` - The unique entity identifier of the condition in New Relic.
 
 ## Import
 
@@ -133,4 +134,51 @@ Alert conditions can be imported using notation `alert_policy_id:alert_condition
 
 ```
 $ terraform import newrelic_alert_condition.main 123456:6789012345
+```
+
+## Tags
+
+Manage alert condition tags with `newrelic_entity_tags`. For up-to-date documentation about the tagging resource, please check [newrelic_entity_tags](entity_tags.html#example-usage)
+
+```hcl
+data "newrelic_entity" "foo" {
+  name = "foo entitiy"
+}
+
+resource "newrelic_alert_policy" "foo" {
+  name = "foo policy"
+}
+
+resource "newrelic_alert_condition" "foo" {
+  policy_id = newrelic_alert_policy.foo.id
+
+  name            = "foo condition"
+  type            = "apm_app_metric"
+  entities        = [data.newrelic_entity.foo.application_id]
+  metric          = "apdex"
+  runbook_url     = "https://www.example.com"
+  condition_scope = "application"
+
+  term {
+    duration      = 5
+    operator      = "below"
+    priority      = "critical"
+    threshold     = "0.75"
+    time_function = "all"
+  }
+}
+
+resource "newrelic_entity_tags" "my_condition_entity_tags" {
+  guid = newrelic_alert_condition.foo.entity_guid
+
+  tag {
+    key = "my-key"
+    values = ["my-value", "my-other-value"]
+  }
+
+  tag {
+    key = "my-key-2"
+    values = ["my-value-2"]
+  }
+}
 ```

--- a/website/docs/r/infra_alert_condition.html.markdown
+++ b/website/docs/r/infra_alert_condition.html.markdown
@@ -123,6 +123,7 @@ In addition to all arguments above, the following attributes are exported:
   * `id` - The ID of the Infrastructure alert condition.
   * `created_at` - The timestamp the alert condition was created.
   * `updated_at` - The timestamp the alert condition was last updated.
+  * `entity_guid` - The unique entity identifier of the condition in New Relic.
 
 ## Thresholds
 
@@ -140,3 +141,52 @@ Infrastructure alert conditions can be imported using a composite ID of `<policy
 ```
 $ terraform import newrelic_infra_alert_condition.main 12345:67890
 ```
+
+## Tags
+
+Manage infra alert condition tags with `newrelic_entity_tags`. For up-to-date documentation about the tagging resource, please check [newrelic_entity_tags](entity_tags.html#example-usage)
+
+```hcl
+resource "newrelic_alert_policy" "foo" {
+  name = "foo policy"
+}
+
+resource "newrelic_infra_alert_condition" "foo" {
+  policy_id = newrelic_alert_policy.foo.id
+
+  name        = "foo infra condition"
+  description = "Warning if disk usage goes above 80% and critical alert if goes above 90%"
+  type        = "infra_metric"
+  event       = "StorageSample"
+  select      = "diskUsedPercent"
+  comparison  = "above"
+  where       = "(hostname LIKE '%frontend%')"
+
+  critical {
+    duration      = 25
+    value         = 90
+    time_function = "all"
+  }
+
+  warning {
+    duration      = 10
+    value         = 80
+    time_function = "all"
+  }
+}
+
+resource "newrelic_entity_tags" "my_condition_entity_tags" {
+  guid = newrelic_infra_alert_condition.foo.entity_guid
+
+  tag {
+    key = "my-key"
+    values = ["my-value", "my-other-value"]
+  }
+
+  tag {
+    key = "my-key-2"
+    values = ["my-value-2"]
+  }
+}
+```
+

--- a/website/docs/r/synthetics_alert_condition.html.markdown
+++ b/website/docs/r/synthetics_alert_condition.html.markdown
@@ -43,6 +43,7 @@ Warning: This resource will use the account ID linked to your API key. At the mo
 In addition to all arguments above, the following attributes are exported:
 
   * `id` - The ID of the Synthetics alert condition.
+  * `entity_guid` - The unique entity identifier of the condition in New Relic.
 
 
 ## Import
@@ -51,4 +52,61 @@ Synthetics alert conditions can be imported using a composite ID of `<policy_id>
 
 ```
 $ terraform import newrelic_synthetics_alert_condition.main 12345:67890
+```
+
+## Tags
+
+Manage synthetics alert condition tags with `newrelic_entity_tags`. For up-to-date documentation about the tagging resource, please check [newrelic_entity_tags](entity_tags.html#example-usage)
+
+```hcl
+resource "newrelic_alert_policy" "foo" {
+  name = "foo policy"
+}
+
+resource "newrelic_synthetics_monitor" "foo" {
+  status           = "ENABLED"
+  name             = "foo monitor"
+  period           = "EVERY_MINUTE"
+  uri              = "https://www.one.newrelic.com"
+  type             = "SIMPLE"
+  locations_public = ["AP_EAST_1"]
+
+  custom_header {
+    name  = "some_name"
+    value = "some_value"
+  }
+
+  treat_redirect_as_failure = true
+  validation_string         = "success"
+  bypass_head_request       = true
+  verify_ssl                = true
+
+  tag {
+    key    = "some_key"
+    values = ["some_value"]
+  }
+}
+
+resource "newrelic_synthetics_alert_condition" "foo" {
+  policy_id = newrelic_alert_policy.foo.id
+
+  name        = "foo synthetics condition"
+  monitor_id  = newrelic_synthetics_monitor.foo.id
+  runbook_url = "https://www.example.com"
+}
+
+resource "newrelic_entity_tags" "my_condition_entity_tags" {
+  guid = newrelic_synthetics_alert_condition.foo.entity_guid
+
+
+  tag {
+    key = "my-key"
+    values = ["my-value", "my-other-value"]
+  }
+
+  tag {
+    key = "my-key-2"
+    values = ["my-value-2"]
+  }
+}
 ```

--- a/website/docs/r/synthetics_multilocation_alert_condition.markdown
+++ b/website/docs/r/synthetics_multilocation_alert_condition.markdown
@@ -66,6 +66,12 @@ The following arguments are supported:
 Warning: This resource will use the account ID linked to your API key. At the moment it is not possible to dynamically set the account ID.
 ```
 
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+  * `entity_guid` - The unique entity identifier of the condition in New Relic.
+
 ## Import
 
 New Relic Synthetics MultiLocation Conditions can be imported using a concatenated string of the format
@@ -74,3 +80,74 @@ New Relic Synthetics MultiLocation Conditions can be imported using a concatenat
 ```bash
 $ terraform import newrelic_synthetics_multilocation_alert_condition.example 12345678:1456
 ```
+
+## Tags
+
+Manage synthetics multilocation alert condition tags with `newrelic_entity_tags`. For up-to-date documentation about the tagging resource, please check [newrelic_entity_tags](entity_tags.html#example-usage)
+
+```hcl
+resource "newrelic_alert_policy" "foo" {
+  name = "foo policy"
+}
+
+resource "newrelic_synthetics_monitor" "foo" {
+  status           = "ENABLED"
+  name             = "foo monitor"
+  period           = "EVERY_MINUTE"
+  uri              = "https://www.one.newrelic.com"
+  type             = "SIMPLE"
+  locations_public = ["AP_EAST_1"]
+
+  custom_header {
+    name  = "some_name"
+    value = "some_value"
+  }
+
+  treat_redirect_as_failure = true
+  validation_string         = "success"
+  bypass_head_request       = true
+  verify_ssl                = true
+
+  tag {
+    key    = "some_key"
+    values = ["some_value"]
+  }
+}
+
+resource "newrelic_synthetics_multilocation_alert_condition" "foo" {
+  policy_id = newrelic_alert_policy.foo.id
+
+  name                         = "foo condition"
+  runbook_url                  = "https://example.com"
+  enabled                      = true
+  violation_time_limit_seconds = "3600"
+
+  entities = [
+    newrelic_synthetics_monitor.foo.id
+  ]
+
+  critical {
+    threshold = 2
+  }
+
+  warning {
+    threshold = 1
+  }
+}
+
+
+resource "newrelic_entity_tags" "my_condition_entity_tags" {
+  guid = newrelic_synthetics_multilocation_alert_condition.foo.entity_guid
+
+  tag {
+    key = "my-key"
+    values = ["my-value", "my-other-value"]
+  }
+
+  tag {
+    key = "my-key-2"
+    values = ["my-value-2"]
+  }
+}
+```
+


### PR DESCRIPTION
# Description

This PR generates and exposes the `entity_guid` for the following condition types:

- newrelic_alert_condition
- newrelic_infra_alert_condition
- newrelic_synthetics_alert_condition
- newrelic_synthetics_multilocation_alert_condition

This will allow users to add tags to these condition types via the terraform provider `newrelic_entity_tags` resource which requires an `entity_guid`:

Fixes # (issue)

https://issues.newrelic.com/browse/NR-98729

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Checklist:

- [X] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

The resources changed in this PR are not well tested and these are legacy alert conditions which will are already somewhat obsolete and will be fully deprecated soon, so I opted not to write new tests for the changes included in this PR.

To manually test, run this PR locally and create each of the following resources and then attempt to add tags to each.  

- newrelic_alert_condition
- newrelic_infra_alert_condition
- newrelic_synthetics_alert_condition
- newrelic_synthetics_multilocation_alert_condition

Note: I was not able to manually test `newrelic_synthetics_multilocation_alert_condition` due to an issue not caused by the changes in this PR.

Sample HCL is provided below:

```
data "newrelic_entity" "foo" {
  name = "foo entitiy"
}

resource "newrelic_alert_policy" "foo" {
  name = "foo policy"
}

resource "newrelic_alert_condition" "foo" {
  policy_id = newrelic_alert_policy.foo.id

  name            = "foo condition"
  type            = "apm_app_metric"
  entities        = [data.newrelic_entity.foo.application_id]
  metric          = "apdex"
  runbook_url     = "https://www.example.com"
  condition_scope = "application"

  term {
    duration      = 5
    operator      = "below"
    priority      = "critical"
    threshold     = "0.75"
    time_function = "all"
  }
}

resource "newrelic_entity_tags" "my_condition_entity_tags" {
  guid = newrelic_alert_condition.foo.entity_guid

  tag {
    key = "my-key"
    values = ["my-value", "my-other-value"]
  }

  tag {
    key = "my-key-2"
    values = ["my-value-2"]
  }
}
```
-------------
```
resource "newrelic_alert_policy" "foo" {
  name = "foo policy"
}

resource "newrelic_infra_alert_condition" "foo" {
  policy_id = newrelic_alert_policy.foo.id

  name        = "foo infra condition"
  description = "Warning if disk usage goes above 80% and critical alert if goes above 90%"
  type        = "infra_metric"
  event       = "StorageSample"
  select      = "diskUsedPercent"
  comparison  = "above"
  where       = "(hostname LIKE '%frontend%')"

  critical {
    duration      = 25
    value         = 90
    time_function = "all"
  }

  warning {
    duration      = 10
    value         = 80
    time_function = "all"
  }
}

resource "newrelic_entity_tags" "my_condition_entity_tags" {
  guid = newrelic_infra_alert_condition.foo.entity_guid

  tag {
    key = "my-key"
    values = ["my-value", "my-other-value"]
  }

  tag {
    key = "my-key-2"
    values = ["my-value-2"]
  }
}
```
-------------
```
resource "newrelic_alert_policy" "foo" {
  name = "foo policy"
}

resource "newrelic_synthetics_monitor" "foo" {
  status           = "ENABLED"
  name             = "foo monitor"
  period           = "EVERY_MINUTE"
  uri              = "https://www.one.newrelic.com"
  type             = "SIMPLE"
  locations_public = ["AP_EAST_1"]

  custom_header {
    name  = "some_name"
    value = "some_value"
  }

  treat_redirect_as_failure = true
  validation_string         = "success"
  bypass_head_request       = true
  verify_ssl                = true

  tag {
    key    = "some_key"
    values = ["some_value"]
  }
}

resource "newrelic_synthetics_alert_condition" "foo" {
  policy_id = newrelic_alert_policy.foo.id

  name        = "foo synthetics condition"
  monitor_id  = newrelic_synthetics_monitor.foo.id
  runbook_url = "https://www.example.com"
}

resource "newrelic_entity_tags" "my_condition_entity_tags" {
  guid = newrelic_synthetics_alert_condition.foo.entity_guid


  tag {
    key = "my-key"
    values = ["my-value", "my-other-value"]
  }

  tag {
    key = "my-key-2"
    values = ["my-value-2"]
  }
}
```
-------------
```
resource "newrelic_alert_policy" "foo" {
  name = "foo policy"
}

resource "newrelic_synthetics_monitor" "foo" {
  status           = "ENABLED"
  name             = "foo monitor"
  period           = "EVERY_MINUTE"
  uri              = "https://www.one.newrelic.com"
  type             = "SIMPLE"
  locations_public = ["AP_EAST_1"]

  custom_header {
    name  = "some_name"
    value = "some_value"
  }

  treat_redirect_as_failure = true
  validation_string         = "success"
  bypass_head_request       = true
  verify_ssl                = true

  tag {
    key    = "some_key"
    values = ["some_value"]
  }
}

resource "newrelic_synthetics_multilocation_alert_condition" "foo" {
  policy_id = newrelic_alert_policy.foo.id

  name                         = "foo condition"
  runbook_url                  = "https://example.com"
  enabled                      = true
  violation_time_limit_seconds = "3600"

  entities = [
    newrelic_synthetics_monitor.foo.id
  ]

  critical {
    threshold = 2
  }

  warning {
    threshold = 1
  }
}


resource "newrelic_entity_tags" "my_condition_entity_tags" {
  guid = newrelic_synthetics_multilocation_alert_condition.foo.entity_guid

  tag {
    key = "my-key"
    values = ["my-value", "my-other-value"]
  }

  tag {
    key = "my-key-2"
    values = ["my-value-2"]
  }
}
```


