### PR TITLE
chore(github): add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# Global
+*                                               @newrelic/virtuoso
+
+# Documentation
+/website/                                       @kidk
+
+# Service Levels
+/newrelic/*newrelic_service_level*              virtuoso@newrelic.com #?
+
+# Workflows
+/newrelic/*newrelic_workflow*                   incident-workflows-team@newrelic.com
+/newrelic/*newrelic_notification_channel*       incident-workflows-team@newrelic.com
+/newrelic/*newrelic_notification_destination*   incident-workflows-team@newrelic.com
+
+# Workloads
+/newrelic/*newrelic_workload*                   team_workloads@newrelic.com


### PR DESCRIPTION
# Description

This adds a [`CODEOWNERS`](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file inside the `.github` folder.

## Type of change

- [x] Github Workflow: Define individuals or teams that are responsible for code

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

## How to test this change?

- Once approved and merged, we will need to submit a test PR containing a tiny modification to `newrelic/structures_newrelic_service_level.go`. This way we can confirm the codeowner will be notified.

NOTES: 
- For testing purposes, temporarily, `virtuoso` is set as owner for `/newrelic/*newrelic_service_level*`. This will be updated later to reflect the correct team for **Service Levels** .
- All teams mentioned in the CODEOWNERS file will need to have a team created inside `github` with `write` permissions to this repo.
