### PR TITLE
feat(data/account): Allow reading the provider's `account_id`.

### DIFF
--- a/newrelic/data_source_newrelic_account.go
+++ b/newrelic/data_source_newrelic_account.go
@@ -39,7 +39,8 @@ func dataSourceNewRelicAccount() *schema.Resource {
 }
 
 func dataSourceNewRelicAccountRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*ProviderConfig).NewClient
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
 
 	log.Printf("[INFO] Reading New Relic accounts")
 
@@ -60,7 +61,8 @@ func dataSourceNewRelicAccountRead(ctx context.Context, d *schema.ResourceData, 
 	var account *accounts.AccountOutline
 
 	if !idOk && !nameOk {
-		return diag.FromErr(fmt.Errorf(`one of "name" or "account_id" is required to locate a New Relic account`))
+		// Default to the provider's AccountID if no lookup attributes are provided.
+		id, idOk = selectAccountID(providerConfig, d), true
 	}
 
 	if idOk && nameOk {

--- a/newrelic/data_source_newrelic_account_test.go
+++ b/newrelic/data_source_newrelic_account_test.go
@@ -52,8 +52,10 @@ func TestAccNewRelicAccountDataSource_MissingAttributes(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccNewRelicAccountDataSourceConfigMissingAttributes(),
-				ExpectError: regexp.MustCompile("one of"),
+				Config: testAccNewRelicAccountDataSourceConfigMissingAttributes(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicAccountDataSourceExists("data.newrelic_account.acc"),
+				),
 			},
 		},
 	})

--- a/website/docs/d/account.html.markdown
+++ b/website/docs/d/account.html.markdown
@@ -9,8 +9,8 @@ description: |-
 # Data Source: newrelic\_account
 
 Use this data source to get information about a specific account in New Relic.
-Accounts can be located by ID or name.  Exactly one of the two attributes is
-required.
+Accounts can be located by ID or name.  At most one of the two attributes can
+be provided. If neither are provided, the provider's `account_id` will be used.
 
 ## Example Usage
 


### PR DESCRIPTION
# Description

Right now there doesn't look to be a way to determine what `account_id` is being used by default with the provider. Right now `newrelic_api_access_key` requires specifying the `account_id` but there isn't an easy way to get this information without it being passed along correctly.

With this change, the `newrelic_account` resource would default to the `account_id` of the provider allowing easy access to this information in contexts that might not have easy access (nested modules).

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [X] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Create a data resource like the following: `data "newrelic_account" "acc" {}`
- Note that the returned `account_id` and `name` reflect the `account_id` value on the configured provider.
