### PR TITLE
docs(guide): update synthetics migration guide with correct resource reference to remove state

### DIFF
--- a/website/docs/guides/migration_guide_v3.html.markdown
+++ b/website/docs/guides/migration_guide_v3.html.markdown
@@ -14,7 +14,7 @@ Version 3.x of the provider uses a new underlying API for Synthetics. This resul
 
 The v2 `newrelic_synthetics_monitor_resource` has been split into two new resources: `newrelic_synthetics_monitor_resource` and `newrelic_synthetics_script_monitor_resource`. Previously a monitor script had to be defined separately from a Synthetics Monitor using the `newrelic_synthetics_monitor_script_resource`. In v3 a script is attached directly to a scripted monitor. See the below example for how to migrate to version 3:
 
-v2  
+v2
 ```hcl
 resource "newrelic_synthetics_monitor" "monitor" {
   name      = "monitor-name"
@@ -55,7 +55,7 @@ resource "newrelic_synthetics_script_monitor" "monitor" {
 1. Move the value in `text` from `newrelic_synthetics_monitor_script` to `script` in `newrelic_synthetics_script_monitor`
 2. Remove `AWS_` from the location name, e.g. `AWS_US_EAST_1` becomes `US_EAST_1`
 3. Rename `frequency` to `period` and change to one of the valid values - EVERY_MINUTE, EVERY_5_MINUTES, EVERY_10_MINUTES, EVERY_15_MINUTES, EVERY_30_MINUTES, EVERY_HOUR, EVERY_6_HOURS, EVERY_12_HOURS, or EVERY_DAY
-4. Run `terraform state rm newrelic_synthetics_monitor_script.<your_monitor_name>` and then log in to New Relic to find your monitor guid.
+4. Run `terraform state rm newrelic_synthetics_monitor.<your_monitor_name>` and then log in to New Relic to find your monitor guid.
 5. Using the guid e.g. `MTk2MQxYjk3YWIzLWZlM05JVE9SfDQxYj...` run `terraform import newrelic_synthetics_script_monitor.<your_monitor_name> guid` to continue managing your existing monitor in Terraform. There won't be any down time, only a brief moment where your monitor is not managed by Terraform.
 
 ### Migrating script Synthetics monitor resources with VSE


### PR DESCRIPTION
This PR addresses and issue with our synthetics migration guide that was brought to our attention via our help channel. The docs referenced the new resource name when it needed to reference the _old_ resource name in the `terraform state rm` command.