### PR TITLE
fix(newrelic_nrql_alert_condition): add default 'violation_time_limit_seconds'

### DIFF
--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -201,8 +201,11 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 				ConflictsWith: []string{"term"},
 			},
 			"violation_time_limit_seconds": {
-				Type:          schema.TypeInt,
-				Optional:      true,
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  259200,
+				// Default value added as expected by the NerdGraph API to prevent discrepancies with `terraform plan`
+				// Reference : https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/alert-violations/how-alert-condition-violations-are-closed/#time-limit
 				Description:   "Sets a time limit, in seconds, that will automatically force-close a long-lasting incident after the time limit you select.  Must be in the range of 300 to 2592000 (inclusive)",
 				ConflictsWith: []string{"violation_time_limit"},
 				ValidateFunc:  validation.IntBetween(300, 2592000),


### PR DESCRIPTION
# Description
- Addresses [NR-97003](https://issues.newrelic.com/browse/NR-97003)
- Adds a default 'violation_time_limit_seconds' of 259200 seconds to the `newrelic_nrql_alert_condition` resource
- Fixes issues identified with re-applying `terraform plan` after the first `terraform apply` is executed, because a null `violation_time_limit_seconds` is defaulted to 259200 seconds (3 days), which is expected behaviour, as specified [here](https://issues.newrelic.com/browse/NR-97003).

Fixes #2245 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.
