### PR TITLE
docs: add note on 'default_values' to one_dashboard

### DIFF
--- a/website/docs/r/one_dashboard.html.markdown
+++ b/website/docs/r/one_dashboard.html.markdown
@@ -321,7 +321,7 @@ widget_line {
 
 The following arguments are supported:
 
-  * `default_values` - (Optional) A list of default values for this variable.
+  * `default_values` - (Optional) A list of default values for this variable. To select **all** default values, the appropriate value to be used with this argument would be `["*"]`.
   * `is_multi_selection` - (Optional) Indicates whether this variable supports multiple selection or not. Only applies to variables of type `nrql` or `enum`.
   * `item` - (Optional) List of possible values for variables of type `enum`. See [Nested item blocks](#nested-item-blocks) below for details.
   * `name` - (Required) The variable identifier.


### PR DESCRIPTION
# Description

This PR addresses the following via [NR-105334](https://issues.newrelic.com/browse/NR-105334) - 
- A documentation change as specified in this [Slack thread](https://newrelic.slack.com/archives/CP9Q30JDC/p1680705711944979?thread_ts=1680641253.804079&cid=CP9Q30JDC), about the need to let users know about the right use of `default_values` in the `variable` block in the resource `newrelic_one_dashboard`; especially, the use of `*` in `default_values`. 

## Type of change
- [x] This change requires a documentation update

## Checklist:
- [x] I have made corresponding changes to the documentation
