### PR TITLE
fix(one_dashboard): code changes to support y_axis_left_min=0

### DIFF
--- a/newrelic/resource_newrelic_account_management_test.go
+++ b/newrelic/resource_newrelic_account_management_test.go
@@ -71,9 +71,9 @@ func TestAccNewRelicAccountManagementInCorrectRegion(t *testing.T) {
 
 func testAccNewRelicAccountImportConfig() string {
 	return fmt.Sprintf(`
-resource "newrelic_account_management" "foo"{
-name =""
-	region= "us01"
+resource "newrelic_account_management" "foo" {
+  name   = ""
+  region = "us01"
 }
 `)
 }

--- a/newrelic/structures_newrelic_one_dashboard.go
+++ b/newrelic/structures_newrelic_one_dashboard.go
@@ -496,6 +496,13 @@ func expandDashboardWidgetInput(w map[string]interface{}, meta interface{}, visu
 			l.Max = q.(float64)
 		}
 		cfg.YAxisLeft = &l
+	} else {
+		var l dashboards.DashboardWidgetYAxisLeft
+		l.Min = 0
+		if q, ok := w["y_axis_left_max"]; ok {
+			l.Max = q.(float64)
+		}
+		cfg.YAxisLeft = &l
 	}
 
 	cfg = expandDashboardWidgetNullValuesInput(w, cfg)


### PR DESCRIPTION
# Description

This PR addresses changes to be made to the Provider for [NR-106304](https://issues.newrelic.com/browse/NR-106304), an issue with the attribute `y_axis_left_min=0` not getting applied to the API request sent by client-go (since this attribute is omitted from the request if it is 0).

To fix this, a parallel change has been made to client-go to remove the "omitempty" condition from this attribute - and the changes in this PR ensure that in the event of absence of `y_axis_left_min` in the Terraform Config, the attribute is defaulted to 0 and sent to go-client, ensuring that the equivalent JSON attribute in go-client always receives a value from the calling Terraform Provider, thereby, needing no "omitempty" condition, which would help fix this issue.
 
Fixes 
- [#2324](https://github.com/newrelic/terraform-provider-newrelic/issues/2324)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

### Additional Info
| Before Changes | After Changes |
| --- | --- |
| With `y_axis_left_min = 0`, `y_axis_left_max = 90000` <img width="362" alt="image" src="https://user-images.githubusercontent.com/127438038/231967254-ba82382f-2ed0-4979-8be1-1bdd5c7eefce.png">| With `y_axis_left_min = 0`, `y_axis_left_max = 90000` <img width="351" alt="image" src="https://user-images.githubusercontent.com/127438038/231968485-22248933-c97c-4fc5-931a-7807b1b66630.png"> |
| With `y_axis_left_max = 90000`<img width="354" alt="image" src="https://user-images.githubusercontent.com/127438038/231967691-362e91cf-4ffa-409f-ae88-e3956d76f614.png">| With `y_axis_left_max = 90000` <img width="349" alt="image" src="https://user-images.githubusercontent.com/127438038/231968660-9395fbd7-8956-4947-98e6-70849df9feec.png"> |
| With `y_axis_left_max = 90000` and `y_axis_left_min = 70000`<img width="359" alt="image" src="https://user-images.githubusercontent.com/127438038/231967947-e0ec252e-5cb5-4d41-8485-c09bebb2e1df.png">| With `y_axis_left_max = 90000` and `y_axis_left_min = 70000`<img width="345" alt="image" src="https://user-images.githubusercontent.com/127438038/231968878-fa8d260c-081c-49b4-aff1-91b2b9f3f6b7.png"> |
