### PR TITLE
fix(newrelic_one_dashboard): addition of the attribute 'zero' and associated code fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.20.3
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.17.1
+	github.com/newrelic/newrelic-client-go/v2 v2.18.1
 	github.com/stretchr/testify v1.8.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -273,8 +273,8 @@ github.com/newrelic/go-agent/v3 v3.20.3 h1:hUBAMq/Y2Y9as5/yxQbf0zNde/X7w58cWZkm2
 github.com/newrelic/go-agent/v3 v3.20.3/go.mod h1:rT6ZUxJc5rQbWLyCtjqQCOcfb01lKRFbc1yMQkcboWM=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.17.1 h1:25c09htIWepqX6sKeauUsfsTQjI/lM5z8Auiztb9tQY=
-github.com/newrelic/newrelic-client-go/v2 v2.17.1/go.mod h1:AX08IIL08pYVbnowsR05EqOdfN1Dz+ZXdIwqS0dkT2c=
+github.com/newrelic/newrelic-client-go/v2 v2.18.1 h1:7VRW32f+z+QCiz7VL5h5Dmo7gYoEMHBobkXNskyCCYE=
+github.com/newrelic/newrelic-client-go/v2 v2.18.1/go.mod h1:AX08IIL08pYVbnowsR05EqOdfN1Dz+ZXdIwqS0dkT2c=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/newrelic/resource_newrelic_one_dashboard.go
+++ b/newrelic/resource_newrelic_one_dashboard.go
@@ -533,6 +533,11 @@ func dashboardWidgetHistogramSchemaElem() *schema.Resource {
 func dashboardWidgetLineSchemaElem() *schema.Resource {
 	s := dashboardWidgetSchemaBase()
 
+	s["y_axis_left_zero"] = &schema.Schema{
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "Specifies if the values on the graph to be rendered need to be fit to scale, or printed within the specified range.",
+	}
 	return &schema.Resource{
 		Schema: s,
 	}

--- a/newrelic/resource_newrelic_one_dashboard_test.go
+++ b/newrelic/resource_newrelic_one_dashboard_test.go
@@ -683,6 +683,7 @@ func testAccCheckNewRelicOneDashboardConfig_PageFull(pageName string, accountID 
       nrql_query {
         query      = "FROM Transaction SELECT 2 TIMESERIES"
       }
+	  y_axis_left_zero = false
     }
 
     widget_markdown {
@@ -906,8 +907,10 @@ func testAccCheckNewRelicOneDashboardConfig_PageFullChanged(pageName string, acc
         query      = "FROM Transaction SELECT 1 TIMESERIES LIMIT 10"
       }
 	  nrql_query {
-        query      = "FROM Transaction SELECT count(*) FACET name LIMIT 10"
+        query      = "FROM Transaction SELECT count(*) FACET name TIMESERIES LIMIT 10"
       }
+      y_axis_left_zero = true
+      y_axis_left_max = 25
     }
 
     widget_markdown {

--- a/website/docs/r/one_dashboard.html.markdown
+++ b/website/docs/r/one_dashboard.html.markdown
@@ -93,6 +93,7 @@ resource "newrelic_one_dashboard" "exampledash" {
       }
       legend_enabled = true
       ignore_time_range = false
+      y_axis_left_zero = true
       y_axis_left_min = 0
       y_axis_left_max = 1 
       
@@ -132,6 +133,7 @@ EOT
       facet_show_other_series = false
       legend_enabled = true
       ignore_time_range = false
+      y_axis_left_zero = true
       y_axis_left_min = 0
       y_axis_left_max = 0
 
@@ -274,6 +276,7 @@ Each widget type supports an additional set of arguments:
     * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql-query-blocks) below for details.
   * `widget_line`
     * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql-query-blocks) below for details.
+    * `y_axis_left_zero` - (Optional) An attribute that specifies if the values on the graph to be rendered need to be fit to scale, or printed within the specified range from `y_axis_left_min` (or 0 if it is not defined) to `y_axis_left_max`. Use `y_axis_left_zero = true` with a combination of `y_axis_left_min` and `y_axis_left_max` to render values from 0 or the specified minimum to the maximum, and `y_axis_left_zero = false` to fit the graph to scale.
   * `widget_markdown`:
     * `text` - (Required) The markdown source to be rendered in the widget.
   * `widget_stacked_bar`
@@ -404,6 +407,7 @@ resource "newrelic_one_dashboard" "multi_page_dashboard" {
         account_id = <Second Account ID>
         query      = "FROM Metric SELECT rate(count(apm.service.transaction.duration), 1 minute) as 'Second Account Throughput' TIMESERIES"
       }
+      y_axis_left_zero = false
     }
   }
 }


### PR DESCRIPTION
# Description

This PR addresses [NR-108075](https://issues.newrelic.com/browse/NR-108075), comprising of the following changes - 
- Addition of an argument `y_axis_left_zero` to the Schema of Line Widgets, which would be mapped to the attribute `Zero` in the API, that supports the option to fit the graph to scale, or render values in within the specified range (`y_axis_left_min` to `y_axis_left_max` ; or 0 to `y_axis_left_max` if `y_axis_left_min` is not specified).
- Associated code changes to conditionally send the attribute `Zero` to the API request based on the calling widget, and conditionally send the attribute `Min` only when `y_axis_left_zero` is `true`.
- Documentation change describing the attribute `y_axis_left_zero`.

Linked changes in dependencies
**newrelic-client-go** : [PR](https://github.com/newrelic/newrelic-client-go/pull/1023)
**newrelic-cli** : [PR](https://github.com/newrelic/newrelic-cli/pull/1450)

Fixes #2327 #2324 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

