### PR TITLE
fix(newrelic_synthetics_script_monitor): Populate script argument changes upon modifications.

### DIFF
--- a/newrelic/resource_newrelic_synthetics_script_monitor.go
+++ b/newrelic/resource_newrelic_synthetics_script_monitor.go
@@ -177,10 +177,28 @@ func resourceNewRelicSyntheticsScriptMonitorRead(ctx context.Context, d *schema.
 		return diag.FromErr(err)
 	}
 
-	// This should probably be in go-client so we can use *errors.NotFound
+	// This should probably be in go-client, so we can use *errors.NotFound
 	if *resp == nil {
 		d.SetId("")
 		return nil
+	}
+
+	response, error := client.Synthetics.GetScript(accountID, synthetics.EntityGUID(d.Id()))
+	if error != nil {
+		return diag.FromErr(error)
+	}
+
+	if response == nil {
+		d.SetId("")
+		return nil
+	}
+
+	error = setSyntheticsMonitorAttributes(d, map[string]string{
+		"script": response.Text,
+	})
+
+	if error != nil {
+		return diag.FromErr(error)
 	}
 
 	_ = d.Set("account_id", accountID)


### PR DESCRIPTION
# Description

Provider v3+ doesn't show the script argument differences for newrelic_synthetics_script_monitor resources #2241

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Steps to Reproduce:

Create a newrelic_synthetics_script_monitor.test resource with type SCRIPT_BROWSER
Modify its script using the New Relic UI
Run terraform plan and expect to see No changes. Your infrastructure matches the configuration.

## Expected Behavior

I expect to receive the difference between the script saved as the code and the script saved in New Relic after its manual update, just as it was on the New Relic Terraform Provider v2.
