### PR TITLE
feat(one_dashboard): addition of the attribute zero to widget_line

### DIFF
--- a/newrelic/resource_newrelic_one_dashboard.go
+++ b/newrelic/resource_newrelic_one_dashboard.go
@@ -533,6 +533,11 @@ func dashboardWidgetHistogramSchemaElem() *schema.Resource {
 func dashboardWidgetLineSchemaElem() *schema.Resource {
 	s := dashboardWidgetSchemaBase()
 
+	s["y_axis_left_zero"] = &schema.Schema{
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "Specifies if the values on the graph to be rendered need to be fit to scale, or printed within the specified range.",
+	}
 	return &schema.Resource{
 		Schema: s,
 	}

--- a/newrelic/resource_newrelic_one_dashboard_test.go
+++ b/newrelic/resource_newrelic_one_dashboard_test.go
@@ -683,6 +683,7 @@ func testAccCheckNewRelicOneDashboardConfig_PageFull(pageName string, accountID 
       nrql_query {
         query      = "FROM Transaction SELECT 2 TIMESERIES"
       }
+	  y_axis_left_zero = false
     }
 
     widget_markdown {
@@ -906,8 +907,10 @@ func testAccCheckNewRelicOneDashboardConfig_PageFullChanged(pageName string, acc
         query      = "FROM Transaction SELECT 1 TIMESERIES LIMIT 10"
       }
 	  nrql_query {
-        query      = "FROM Transaction SELECT count(*) FACET name LIMIT 10"
+        query      = "FROM Transaction SELECT count(*) FACET name TIMESERIES LIMIT 10"
       }
+      y_axis_left_zero = true
+      y_axis_left_max = 25
     }
 
     widget_markdown {

--- a/newrelic/structures_newrelic_one_dashboard.go
+++ b/newrelic/structures_newrelic_one_dashboard.go
@@ -489,21 +489,20 @@ func expandDashboardWidgetInput(w map[string]interface{}, meta interface{}, visu
 		l.ShowOtherSeries = q.(bool)
 		cfg.Facet = &l
 	}
-	if q, ok := w["y_axis_left_min"]; ok {
-		var l dashboards.DashboardWidgetYAxisLeft
-		l.Min = q.(*float64)
-		if q, ok := w["y_axis_left_max"]; ok {
-			l.Max = q.(float64)
+
+	if visualisation != "viz.line" {
+		if q, ok := w["y_axis_left_min"]; ok {
+			var l dashboards.DashboardWidgetYAxisLeft
+			min := q.(float64)
+			l.Min = &min
+			if q, ok := w["y_axis_left_max"]; ok {
+				l.Max = q.(float64)
+			}
+			cfg.YAxisLeft = &l
 		}
-		cfg.YAxisLeft = &l
 	} else {
-		var l dashboards.DashboardWidgetYAxisLeft
-		var m float64
-		l.Min = &m
-		if q, ok := w["y_axis_left_max"]; ok {
-			l.Max = q.(float64)
-		}
-		cfg.YAxisLeft = &l
+		lineWidgetYAxisLeft := expandDashboardWidgetYAxisLeft(w)
+		cfg.YAxisLeft = &lineWidgetYAxisLeft
 	}
 
 	cfg = expandDashboardWidgetNullValuesInput(w, cfg)
@@ -531,6 +530,36 @@ func expandDashboardWidgetInput(w map[string]interface{}, meta interface{}, visu
 	return &widget, &cfg, nil
 }
 
+func expandDashboardWidgetYAxisLeft(w map[string]interface{}) dashboards.DashboardWidgetYAxisLeft {
+	var l dashboards.DashboardWidgetYAxisLeft
+	if q, ok := w["y_axis_left_zero"]; ok {
+		yAxisZero := q.(bool)
+		l.Zero = &yAxisZero
+		if !yAxisZero {
+			if yMin, okMin := w["y_axis_left_min"]; okMin {
+				if yMin.(float64) != 0 {
+					min := yMin.(float64)
+					l.Min = &min
+				}
+			}
+			if yMax, okMax := w["y_axis_left_max"]; okMax {
+				if yMax.(float64) != 0 {
+					l.Max = yMax.(float64)
+				}
+			}
+		} else {
+			if yMin, okMin := w["y_axis_left_min"]; okMin {
+				min := yMin.(float64)
+				l.Min = &min
+				if yMax, okMax := w["y_axis_left_max"]; okMax {
+					l.Max = yMax.(float64)
+				}
+			}
+		}
+	}
+
+	return l
+}
 func expandDashboardWidgetUnitsInput(w map[string]interface{}, cfg dashboards.RawConfiguration) dashboards.RawConfiguration {
 	if q, ok := w["units"]; ok {
 		units := q.([]interface{})
@@ -951,6 +980,9 @@ func flattenDashboardWidget(in *entities.DashboardWidget, pageGUID string) (stri
 	case "viz.line":
 		widgetType = "widget_line"
 		out["nrql_query"] = flattenDashboardWidgetNRQLQuery(&rawCfg.NRQLQueries)
+		if rawCfg.YAxisLeft != nil {
+			out["y_axis_left_zero"] = rawCfg.YAxisLeft.Zero
+		}
 	case "viz.markdown":
 		widgetType = "widget_markdown"
 		out["text"] = rawCfg.Text

--- a/website/docs/r/one_dashboard.html.markdown
+++ b/website/docs/r/one_dashboard.html.markdown
@@ -93,6 +93,7 @@ resource "newrelic_one_dashboard" "exampledash" {
       }
       legend_enabled = true
       ignore_time_range = false
+      y_axis_left_zero = true
       y_axis_left_min = 0
       y_axis_left_max = 1 
       
@@ -132,9 +133,9 @@ EOT
       facet_show_other_series = false
       legend_enabled = true
       ignore_time_range = false
+      y_axis_left_zero = true
       y_axis_left_min = 0
       y_axis_left_max = 0
-
       null_values {
         null_value = "default"
 
@@ -274,6 +275,7 @@ Each widget type supports an additional set of arguments:
     * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql-query-blocks) below for details.
   * `widget_line`
     * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql-query-blocks) below for details.
+    * `y_axis_left_zero` - (Optional) An attribute that specifies if the values on the graph to be rendered need to be fit to scale, or printed within the specified range from `y_axis_left_min` (or 0 if it is not defined) to `y_axis_left_max`. Use `y_axis_left_zero = true` with a combination of `y_axis_left_min` and `y_axis_left_max` to render values from 0 or the specified minimum to the maximum, and `y_axis_left_zero = false` to fit the graph to scale.
   * `widget_markdown`:
     * `text` - (Required) The markdown source to be rendered in the widget.
   * `widget_stacked_bar`
@@ -404,6 +406,7 @@ resource "newrelic_one_dashboard" "multi_page_dashboard" {
         account_id = <Second Account ID>
         query      = "FROM Metric SELECT rate(count(apm.service.transaction.duration), 1 minute) as 'Second Account Throughput' TIMESERIES"
       }
+      y_axis_left_zero = false
     }
   }
 }


### PR DESCRIPTION
# Description

[NEW PR] This PR addresses [NR-108075](https://issues.newrelic.com/browse/NR-108075), comprising of the following changes - 
- Addition of an argument `y_axis_left_zero` to the Schema of Line Widgets, which would be mapped to the attribute `Zero` in the API, that supports the option to fit the graph to scale, or render values in within the specified range (`y_axis_left_min` to `y_axis_left_max` ; or 0 to `y_axis_left_max` if `y_axis_left_min` is not specified).
- Associated code changes to conditionally send the attribute `Zero` to the API request based on the calling widget, and conditionally send the attribute `Min` only when `y_axis_left_zero` is `true`.
- Documentation change describing the attribute `y_axis_left_zero`.

Linked changes in dependencies
**newrelic-client-go** : [PR](https://github.com/newrelic/newrelic-client-go/pull/1023)
**newrelic-cli** : [PR](https://github.com/newrelic/newrelic-cli/pull/1450)

Fixes #2327 #2324 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

