### PR TITLE
docs(one_dashboard_json): addition of a multipage dashboard example and other corrections

### DIFF
--- a/website/docs/r/notification_channel.html.markdown
+++ b/website/docs/r/notification_channel.html.markdown
@@ -77,7 +77,7 @@ Each notification channel type supports a specific set of arguments for the `pro
   * `email` - (Required) Specifies the user email for integrating with Pagerduty.
   * `customDetails` - (Optional) Free text that *replaces* the content of the alert.
 * `SLACK`
-  * `channelId` - (Required) Specifies the Slack channel id. This can be found in slack browser via the url. Example - https://app.slack.com/client/<UserId>/<ChannelId>.
+  * `channelId` - (Required) Specifies the Slack channel id. This can be found in slack browser via the url. Example - https://app.slack.com/client/\<UserId>/\<ChannelId>.
   * `customDetailsSlack` - (Optional) A map of key/value pairs that represents the slack custom details. Must be compatible with Slack's blocks api. 
 
 ## Attributes Reference

--- a/website/docs/r/one_dashboard_json.html.markdown
+++ b/website/docs/r/one_dashboard_json.html.markdown
@@ -280,7 +280,223 @@ The following example demonstrates creating a dashboard with multiple pages, wit
 }
 ```
 
+### Configuring Multiple Dashboards with a Fixed Set of Pages
 
+The following example demonstrates using a pre-defined set of pages across a variable number of dashboards, by specifying a list of the required pages as arguments in the dashboards to be created. This helps reuse pages and the widgets they comprise, across multiple dashboards.
+
+`main.tf`
+```tf
+resource "newrelic_one_dashboard_json" "dashboard_one" {
+  json = templatefile("dashboard.json.tftpl", {
+    name        = "Multipage Dashboard One",
+    description = "The first sample multipage dashboard in a set of three.",
+    permissions = "PUBLIC_READ_WRITE",
+    pages       = ["page_one.json", "page_two.json"]
+  })
+}
+
+resource "newrelic_one_dashboard_json" "dashboard_two" {
+  json = templatefile("dashboard.json.tftpl", {
+    name        = "Multipage Dashboard Two",
+    description = "The second sample multipage dashboard in a set of three.",
+    permissions = "PUBLIC_READ_WRITE",
+    pages       = ["page_two.json", "page_three.json"]
+  })
+}
+
+resource "newrelic_one_dashboard_json" "dashboard_three" {
+  json = templatefile("dashboard.json.tftpl", {
+    name        = "Multipage Dashboard Three",
+    description = "The third sample multipage dashboard in a set of three.",
+    permissions = "PUBLIC_READ_WRITE",
+    pages       = ["page_one.json", "page_two.json", "page_three.json"]
+  })
+}
+```
+
+`dashboard.json.tftpl`
+```tftpl
+{
+  "name": "${name}",
+  "description": "${description}",
+  "permissions": "${permissions}",
+  "pages": [
+    %{ for index, page_name in pages }
+    %{ if index!=0 }, %{ endif }
+    ${ file("${page_name}") }
+    %{ endfor }
+  ]
+}
+```
+
+`page_one.json`
+```json
+{
+  "name": "Memory Metrics",
+  "description": "Widgets displaying metrics on memory utilization.",
+  "widgets": [
+    {
+      "title": "Memory Utilization",
+      "layout": {
+        "column": 1,
+        "row": 1,
+        "width": 4,
+        "height": 3
+      },
+      "linkedEntityGuids": null,
+      "visualization": {
+        "id": "viz.line"
+      },
+      "rawConfiguration": {
+        "facet": {
+          "showOtherSeries": false
+        },
+        "legend": {
+          "enabled": true
+        },
+        "nrqlQueries": [
+          {
+            "accountIds": [
+              {Account-IDs}
+            ],
+            "query": "FROM Metric SELECT average(apm.service.memory.physical) as avgMem WHERE appName='Dummy App' TIMESERIES 2 days since 2 months ago"
+          }
+        ],
+        "platformOptions": {
+          "ignoreTimeRange": false
+        },
+        "yAxisLeft": {
+          "zero": true
+        }
+      }
+    }
+  ]
+} 
+```
+
+`page_two.json`
+```json
+{
+  "name": "Transaction Metrics",
+  "description": "Widgets displaying metrics on Transactions.",
+  "widgets": [
+    {
+      "title": "Total Transaction Count Across Apps",
+      "layout": {
+        "column": 1,
+        "row": 1,
+        "width": 4,
+        "height": 3
+      },
+      "linkedEntityGuids": null,
+      "visualization": {
+        "id": "viz.line"
+      },
+      "rawConfiguration": {
+        "colors": {
+          "seriesOverrides": [
+            {
+              "color": "#418ba4",
+              "seriesName": "Dummy App"
+            }
+          ]
+        },
+        "facet": {
+          "showOtherSeries": false
+        },
+        "legend": {
+          "enabled": true
+        },
+        "nrqlQueries": [
+          {
+            "accountIds": [
+              {Account-IDs}
+            ],
+            "query": "select count(*) from Transaction facet appName since 1 month ago TIMESERIES 1 day"
+          }
+        ],
+        "platformOptions": {
+          "ignoreTimeRange": false
+        },
+        "yAxisLeft": {
+          "zero": true
+        }
+      }
+    },
+    {
+      "title": "Response Headers Summary",
+      "layout": {
+        "column": 5,
+        "row": 1,
+        "width": 4,
+        "height": 3
+      },
+      "linkedEntityGuids": null,
+      "visualization": {
+        "id": "viz.billboard"
+      },
+      "rawConfiguration": {
+        "facet": {
+          "showOtherSeries": false
+        },
+        "nrqlQueries": [
+          {
+            "accountIds": [
+              {Account-IDs}
+            ],
+            "query": "SELECT count(*) from Transaction facet response.headers.contentType since 2 months ago"
+          }
+        ],
+        "platformOptions": {
+          "ignoreTimeRange": false
+        }
+      }
+    }
+  ]
+} 
+```
+
+`page_three.json`
+```json
+{
+  "name": "Log Metrics",
+  "description": "Widgets displaying metrics on Logs.",
+  "widgets": [
+    {
+      "title": "Log Tracker",
+      "layout": {
+        "column": 1,
+        "row": 1,
+        "width": 4,
+        "height": 3
+      },
+      "linkedEntityGuids": null,
+      "visualization": {
+        "id": "viz.stacked-bar"
+      },
+      "rawConfiguration": {
+        "facet": {
+          "showOtherSeries": false
+        },
+        "legend": {
+          "enabled": true
+        },
+        "nrqlQueries": [
+          {
+            "accountIds": [
+              {Account-IDs}
+            ],
+            "query": "SELECT count(*) from Log since 48 hours ago TIMESERIES 3 hours"
+          }
+        ],
+        "platformOptions": {
+          "ignoreTimeRange": false
+        }
+      }
+    }
+  ]
+} 
+```
 ### Setting Thresholds
 
 The following example demonstrates setting thresholds on a billboard widget.

--- a/website/docs/r/one_dashboard_json.html.markdown
+++ b/website/docs/r/one_dashboard_json.html.markdown
@@ -110,6 +110,11 @@ resource "newrelic_one_dashboard_json" "bar" {
 ### Dashboard With Multiple Pages
 
 The following example demonstrates creating a dashboard with multiple pages, with each page comprising a couple of widgets.
+```hcl
+resource "newrelic_one_dashboard_json" "foo" {
+   json = file("dashboard.json")
+}
+```
 
 `dashboard.json`
 ```json
@@ -144,7 +149,7 @@ The following example demonstrates creating a dashboard with multiple pages, wit
             "nrqlQueries": [
               {
                 "accountIds": [
-                  {Account-IDs}
+                  account_id
                 ],
                 "query": "FROM Metric SELECT average(apm.service.memory.physical) as avgMem WHERE appName='Dummy App' TIMESERIES 2 days since 2 months ago"
               }
@@ -193,7 +198,7 @@ The following example demonstrates creating a dashboard with multiple pages, wit
             "nrqlQueries": [
               {
                 "accountIds": [
-                  {Account-IDs}
+                  account_id
                 ],
                 "query": "select count(*) from Transaction facet appName since 1 month ago TIMESERIES 1 day"
               }
@@ -225,7 +230,7 @@ The following example demonstrates creating a dashboard with multiple pages, wit
             "nrqlQueries": [
               {
                 "accountIds": [
-                  {Account-IDs}
+                  account_id
                 ],
                 "query": "SELECT count(*) from Transaction facet response.headers.contentType since 2 months ago"
               }
@@ -263,7 +268,7 @@ The following example demonstrates creating a dashboard with multiple pages, wit
             "nrqlQueries": [
               {
                 "accountIds": [
-                  {Account-IDs}
+                  account_id
                 ],
                 "query": "SELECT count(*) from Log since 48 hours ago TIMESERIES 3 hours"
               }
@@ -284,7 +289,6 @@ The following example demonstrates creating a dashboard with multiple pages, wit
 
 The following example demonstrates using a pre-defined set of pages across a variable number of dashboards, by specifying a list of the required pages as arguments in the dashboards to be created. This helps reuse pages and the widgets they comprise, across multiple dashboards.
 
-`main.tf`
 ```tf
 resource "newrelic_one_dashboard_json" "dashboard_one" {
   json = templatefile("dashboard.json.tftpl", {
@@ -357,7 +361,7 @@ resource "newrelic_one_dashboard_json" "dashboard_three" {
         "nrqlQueries": [
           {
             "accountIds": [
-              {Account-IDs}
+              account_id
             ],
             "query": "FROM Metric SELECT average(apm.service.memory.physical) as avgMem WHERE appName='Dummy App' TIMESERIES 2 days since 2 months ago"
           }
@@ -410,7 +414,7 @@ resource "newrelic_one_dashboard_json" "dashboard_three" {
         "nrqlQueries": [
           {
             "accountIds": [
-              {Account-IDs}
+              account_id
             ],
             "query": "select count(*) from Transaction facet appName since 1 month ago TIMESERIES 1 day"
           }
@@ -442,7 +446,7 @@ resource "newrelic_one_dashboard_json" "dashboard_three" {
         "nrqlQueries": [
           {
             "accountIds": [
-              {Account-IDs}
+              account_id
             ],
             "query": "SELECT count(*) from Transaction facet response.headers.contentType since 2 months ago"
           }
@@ -484,7 +488,7 @@ resource "newrelic_one_dashboard_json" "dashboard_three" {
         "nrqlQueries": [
           {
             "accountIds": [
-              {Account-IDs}
+              account_id
             ],
             "query": "SELECT count(*) from Log since 48 hours ago TIMESERIES 3 hours"
           }
@@ -526,7 +530,7 @@ The following example demonstrates setting thresholds on a billboard widget.
             "nrqlQueries" : [
               {
                 "accountIds" : [
-                  {Your-Account-ID}
+                  account_id
                 ],
                 "query" : "SELECT count(*) from Transaction where httpResponseCode!=200 since 1 hour ago"
               }
@@ -549,6 +553,13 @@ The following example demonstrates setting thresholds on a billboard widget.
 }
 ```
 
+### More Complex Examples
+
+The following examples show more intricate use cases of creating dashboards from JSON files, using this resource.
+- [This example](https://github.com/newrelic-experimental/nr-terraform-json-dashboard-examples/blob/main/dash_composed.tf) illustrates the use of a variable list of items to create a dashboard, that may be used iteratively to populate queries and other arguments of widgets, using Terraform template files.
+- [This example](https://github.com/newrelic-experimental/nr-terraform-json-dashboard-examples/blob/main/dash_nrql_composed.tf) elaborates on the use of an apt Terraform configuration with additional dependencies, to instrument the use of values obtained from a GraphQL API response iteratively to configure widgets in the dashboard for each item in the response, using the Terraform `jsondecode` function.
+
+More of such examples may be found in ths [GitHub repository](https://github.com/newrelic-experimental/nr-terraform-json-dashboard-examples/tree/main).
 
 ## Import
 

--- a/website/docs/r/one_dashboard_json.html.markdown
+++ b/website/docs/r/one_dashboard_json.html.markdown
@@ -112,12 +112,14 @@ resource "newrelic_one_dashboard_json" "bar" {
 The following example demonstrates creating a dashboard with multiple pages, with each page comprising a couple of widgets.
 ```hcl
 resource "newrelic_one_dashboard_json" "foo" {
-   json = file("dashboard.json")
+  json = templatefile("dashboard.json.tftpl", {
+    account_id = 123456
+  })
 }
 ```
 
-`dashboard.json`
-```json
+`dashboard.json.tftpl`
+```tftpl
 {
   "name": "Multi - Page Dashboard Sample",
   "description": "An example that demonstrates creating a dashboard with multiple widgets, across a couple of pages.",
@@ -149,9 +151,9 @@ resource "newrelic_one_dashboard_json" "foo" {
             "nrqlQueries": [
               {
                 "accountIds": [
-                  account_id
+                  "${account_id}"
                 ],
-                "query": "FROM Metric SELECT average(apm.service.memory.physical) as avgMem WHERE appName='Dummy App' TIMESERIES 2 days since 2 months ago"
+                "query": "FROM Metric SELECT average(apm.service.memory.physical) as avgMem WHERE appName='sampleApp' TIMESERIES 2 days since 2 months ago"
               }
             ],
             "platformOptions": {
@@ -185,7 +187,7 @@ resource "newrelic_one_dashboard_json" "foo" {
               "seriesOverrides": [
                 {
                   "color": "#418ba4",
-                  "seriesName": "Dummy App"
+                  "seriesName": "sampleApp"
                 }
               ]
             },
@@ -198,7 +200,7 @@ resource "newrelic_one_dashboard_json" "foo" {
             "nrqlQueries": [
               {
                 "accountIds": [
-                  account_id
+                  "${account_id}"
                 ],
                 "query": "select count(*) from Transaction facet appName since 1 month ago TIMESERIES 1 day"
               }
@@ -230,7 +232,7 @@ resource "newrelic_one_dashboard_json" "foo" {
             "nrqlQueries": [
               {
                 "accountIds": [
-                  account_id
+                  "${account_id}"
                 ],
                 "query": "SELECT count(*) from Transaction facet response.headers.contentType since 2 months ago"
               }
@@ -268,7 +270,7 @@ resource "newrelic_one_dashboard_json" "foo" {
             "nrqlQueries": [
               {
                 "accountIds": [
-                  account_id
+                  "${account_id}"
                 ],
                 "query": "SELECT count(*) from Log since 48 hours ago TIMESERIES 3 hours"
               }
@@ -289,7 +291,7 @@ resource "newrelic_one_dashboard_json" "foo" {
 
 The following example demonstrates using a pre-defined set of pages across a variable number of dashboards, by specifying a list of the required pages as arguments in the dashboards to be created. This helps reuse pages and the widgets they comprise, across multiple dashboards.
 
-```tf
+```hcl
 resource "newrelic_one_dashboard_json" "dashboard_one" {
   json = templatefile("dashboard.json.tftpl", {
     name        = "Multipage Dashboard One",
@@ -363,7 +365,7 @@ resource "newrelic_one_dashboard_json" "dashboard_three" {
             "accountIds": [
               account_id
             ],
-            "query": "FROM Metric SELECT average(apm.service.memory.physical) as avgMem WHERE appName='Dummy App' TIMESERIES 2 days since 2 months ago"
+            "query": "FROM Metric SELECT average(apm.service.memory.physical) as avgMem WHERE appName='sampleApp' TIMESERIES 2 days since 2 months ago"
           }
         ],
         "platformOptions": {
@@ -401,7 +403,7 @@ resource "newrelic_one_dashboard_json" "dashboard_three" {
           "seriesOverrides": [
             {
               "color": "#418ba4",
-              "seriesName": "Dummy App"
+              "seriesName": "sampleApp"
             }
           ]
         },

--- a/website/docs/r/one_dashboard_json.html.markdown
+++ b/website/docs/r/one_dashboard_json.html.markdown
@@ -107,6 +107,180 @@ resource "newrelic_one_dashboard_json" "bar" {
   "variables": []
 }
 ```
+### Dashboard With Multiple Pages
+
+The following example demonstrates creating a dashboard with multiple pages, with each page comprising a couple of widgets.
+
+`dashboard.json`
+```json
+{
+  "name": "Multi - Page Dashboard Sample",
+  "description": "An example that demonstrates creating a dashboard with multiple widgets, across a couple of pages.",
+  "permissions": "PUBLIC_READ_WRITE",
+  "pages": [
+    {
+      "name": "Memory Metrics",
+      "description": "Widgets displaying metrics on memory utilization.",
+      "widgets": [
+        {
+          "title": "Memory Utilization",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [
+                  {Account-IDs}
+                ],
+                "query": "FROM Metric SELECT average(apm.service.memory.physical) as avgMem WHERE appName='Dummy App' TIMESERIES 2 days since 2 months ago"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Transaction Metrics",
+      "description": "Widgets displaying metrics on Transactions.",
+      "widgets": [
+        {
+          "title": "Total Transaction Count Across Apps",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "colors": {
+              "seriesOverrides": [
+                {
+                  "color": "#418ba4",
+                  "seriesName": "Dummy App"
+                }
+              ]
+            },
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [
+                  {Account-IDs}
+                ],
+                "query": "select count(*) from Transaction facet appName since 1 month ago TIMESERIES 1 day"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            },
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Response Headers Summary",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [
+                  {Account-IDs}
+                ],
+                "query": "SELECT count(*) from Transaction facet response.headers.contentType since 2 months ago"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Log Metrics",
+      "description": "Widgets displaying metrics on Logs.",
+      "widgets": [
+        {
+          "title": "Log Tracker",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "linkedEntityGuids": null,
+          "visualization": {
+            "id": "viz.stacked-bar"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountIds": [
+                  {Account-IDs}
+                ],
+                "query": "SELECT count(*) from Log since 48 hours ago TIMESERIES 3 hours"
+              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "variables": []
+}
+```
+
+
 ### Setting Thresholds
 
 The following example demonstrates setting thresholds on a billboard widget.


### PR DESCRIPTION
# Description

This PR addresses [NR-108017](https://issues.newrelic.com/browse/NR-108017)
- Addition of an example to demonstrate creating a dashboard with multiple pages, using the resource **newrelic_one_dashboard_json**
- A tiny correction to a link in **newrelic_notification_channel**. Despite the presence of the right Slack sample URL in the following code snippet (with \<userId>/\<channelId>) 

https://github.com/newrelic/terraform-provider-newrelic/blob/77bab1b281a8ad5882956b39d5a1644e16d37028/website/docs/r/notification_channel.html.markdown?plain=1#L80

, the link is [seen to be rendered incorrect](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/notification_channel#SLACK) in the docs of **newrelic_notification_channel**. An escape character has been added to the symbols to help render the right link (this is found to be working in the Terraform Doc Preview Tool.)

<img width="1316" alt="image" src="https://user-images.githubusercontent.com/127438038/235106281-28095405-a826-4b4e-86f3-302dc359ad38.png">


**Fixes** #2180 #2192 

## Type of change
- [x] This change requires a documentation update

## Checklist:
Please delete options that are not relevant.
- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have made corresponding changes to the documentation