### PR TITLE
chore(release): add terraform registry manifest file for release hooks

### DIFF
--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "metadata": {
+    "protocol_versions": [
+      "5.0"
+    ]
+  }
+}


### PR DESCRIPTION
The Terraform registry now requires a manifest file for enable release hooks for [publishing new releases to the registry](https://developer.hashicorp.com/terraform/registry/providers/publishing).