### PR TITLE
docs(service_level_alert_helper): update to documentation

### DIFF
--- a/website/docs/d/service_level_alert_helper.html.markdown
+++ b/website/docs/d/service_level_alert_helper.html.markdown
@@ -74,7 +74,7 @@ resource "newrelic_nrql_alert_condition" "your_condition" {
   }
 
   critical {
-    operator = "above"
+    operator = "above_or_equals"
     threshold = data.newrelic_service_level_alert_helper.foo_custom.threshold
     threshold_duration = data.newrelic_service_level_alert_helper.foo_custom.evaluation_period
     threshold_occurrences = "at_least_once"


### PR DESCRIPTION
# Description
via @NilVentosa (original PR : https://github.com/newrelic/terraform-provider-newrelic/pull/2360)
We changed the recommended alert for service level and the documentation of the service level alert helper data source has an example that became outdated.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have made corresponding changes to the documentation

## How to test this change?

No testing needed, only a documentation change
