### PR TITLE
fix(newrelic_account): fix to read the account_id from env in the absence of an argument

### DIFF
--- a/newrelic/data_source_newrelic_account.go
+++ b/newrelic/data_source_newrelic_account.go
@@ -39,7 +39,8 @@ func dataSourceNewRelicAccount() *schema.Resource {
 }
 
 func dataSourceNewRelicAccountRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*ProviderConfig).NewClient
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
 
 	log.Printf("[INFO] Reading New Relic accounts")
 
@@ -60,7 +61,8 @@ func dataSourceNewRelicAccountRead(ctx context.Context, d *schema.ResourceData, 
 	var account *accounts.AccountOutline
 
 	if !idOk && !nameOk {
-		return diag.FromErr(fmt.Errorf(`one of "name" or "account_id" is required to locate a New Relic account`))
+		// Default to the provider's AccountID if no lookup attributes are provided.
+		id, idOk = selectAccountID(providerConfig, d), true
 	}
 
 	if idOk && nameOk {

--- a/newrelic/data_source_newrelic_account_test.go
+++ b/newrelic/data_source_newrelic_account_test.go
@@ -52,8 +52,10 @@ func TestAccNewRelicAccountDataSource_MissingAttributes(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccNewRelicAccountDataSourceConfigMissingAttributes(),
-				ExpectError: regexp.MustCompile("one of"),
+				Config: testAccNewRelicAccountDataSourceConfigMissingAttributes(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicAccountDataSourceExists("data.newrelic_account.acc"),
+				),
 			},
 		},
 	})

--- a/website/docs/d/account.html.markdown
+++ b/website/docs/d/account.html.markdown
@@ -9,8 +9,8 @@ description: |-
 # Data Source: newrelic\_account
 
 Use this data source to get information about a specific account in New Relic.
-Accounts can be located by ID or name.  Exactly one of the two attributes is
-required.
+Accounts can be located by ID or name.  At most one of the two attributes can
+be provided. If neither are provided, the provider's `account_id` will be used.
 
 ## Example Usage
 


### PR DESCRIPTION
# Description

This PR has been adopted from https://github.com/newrelic/terraform-provider-newrelic/pull/2314, which addresses a fix to be made to the **newrelic_account** data source to obtain the **account_id** from the environment, when no `account_id` is specified in the argument of the data source.

