### PR TITLE
docs(script_monitor): corrections to details on private, public locations

### DIFF
--- a/website/docs/r/synthetics_script_monitor.html.markdown
+++ b/website/docs/r/synthetics_script_monitor.html.markdown
@@ -68,8 +68,8 @@ The following are the common arguments supported for `SCRIPT_API` and `SCRIPT_BR
 * `status` - (Required) The run state of the monitor: `ENABLED` or `DISABLED`
 * `name` - (Required) The name for the monitor.
 * `type` - (Required) The plaintext representing the monitor script. Valid values are SCRIPT_BROWSER or SCRIPT_API
-* `locations_public` - (Required) The location the monitor will run from. Valid public locations are https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips/. You don't need the `AWS_` prefix as the provider uses NerdGraph. At least one of either `locations_public` or `location_private` is required.
-* `location_private` - (Required) The location the monitor will run from. See [Nested location_private blocks](#nested-location-private-blocks) below for details. At least one of either `locations_public` or `location_private` is required.
+* `locations_public` - (Optional) The location the monitor will run from. Check out [this page](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips/) for a list of valid public locations. The `AWS_` prefix is not needed, as the provider uses NerdGraph. **At least one of either** `locations_public` **or** `location_private` **is required**.
+* `location_private` - (Optional) The location the monitor will run from. See [Nested location_private blocks](#nested-location-private-blocks) below for details. **At least one of either** `locations_public` **or** `location_private` **is required**.
 * `period` - (Required) The interval at which this monitor should run. Valid values are EVERY_MINUTE, EVERY_5_MINUTES, EVERY_10_MINUTES, EVERY_15_MINUTES, EVERY_30_MINUTES, EVERY_HOUR, EVERY_6_HOURS, EVERY_12_HOURS, or EVERY_DAY.
 * `script` - (Required) The script that the monitor runs.
 * `runtime_type` - (Optional) The runtime that the monitor will use to run jobs.


### PR DESCRIPTION
# Description

This PR corrects `locations_public` and `location_private` arguments in the docs of the `newrelic_synthetics_script_monitor` resource

#### Current Docs
<img width="667" alt="image" src="https://github.com/newrelic/terraform-provider-newrelic/assets/127438038/99f8f4fe-d7e9-408f-b766-d0acedbc5807">


#### Changes Made
<img width="700" alt="image" src="https://github.com/newrelic/terraform-provider-newrelic/assets/127438038/562d9b62-6908-486d-ace7-cd2606478070">


