### PR TITLE
chore(imports): refactoring imports in files showing lint warnings

### DIFF
--- a/newrelic/data_source_newrelic_obfuscation_expression.go
+++ b/newrelic/data_source_newrelic_obfuscation_expression.go
@@ -3,12 +3,12 @@ package newrelic
 import (
 	"context"
 	"errors"
-	"github.com/newrelic/newrelic-client-go/v2/newrelic"
-	"github.com/newrelic/newrelic-client-go/v2/pkg/logconfigurations"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/newrelic/newrelic-client-go/v2/newrelic"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/logconfigurations"
 )
 
 func dataSourceNewRelicObfuscationExpression() *schema.Resource {

--- a/newrelic/data_source_newrelic_obfuscation_expression_test.go
+++ b/newrelic/data_source_newrelic_obfuscation_expression_test.go
@@ -6,10 +6,11 @@ package newrelic
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"testing"
 )
 
 func TestAccNewRelicObfuscationExpressionDataSource_Basic(t *testing.T) {

--- a/newrelic/data_source_newrelic_test_grok_pattern.go
+++ b/newrelic/data_source_newrelic_test_grok_pattern.go
@@ -2,14 +2,13 @@ package newrelic
 
 import (
 	"context"
+	"log"
 	"math/rand"
 	"strconv"
 
-	"github.com/newrelic/newrelic-client-go/v2/pkg/logconfigurations"
-	"log"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/logconfigurations"
 )
 
 func dataSourceNewRelicTestGrokPattern() *schema.Resource {

--- a/newrelic/data_source_newrelic_test_grok_pattern_test.go
+++ b/newrelic/data_source_newrelic_test_grok_pattern_test.go
@@ -5,10 +5,11 @@ package newrelic
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"regexp"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccNewRelicTestGrokDataSource_Basic(t *testing.T) {

--- a/newrelic/resource_newrelic_log_parsing_rule.go
+++ b/newrelic/resource_newrelic_log_parsing_rule.go
@@ -3,11 +3,12 @@ package newrelic
 import (
 	"context"
 	"errors"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/newrelic/newrelic-client-go/v2/newrelic"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/logconfigurations"
-	"log"
 )
 
 func resourceNewRelicLogParsingRule() *schema.Resource {

--- a/newrelic/resource_newrelic_synthetics_private_location.go
+++ b/newrelic/resource_newrelic_synthetics_private_location.go
@@ -3,13 +3,13 @@ package newrelic
 import (
 	"context"
 	"fmt"
-	"github.com/newrelic/newrelic-client-go/v2/pkg/errors"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/entities"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/errors"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/synthetics"
 )
 

--- a/newrelic/resource_newrelic_synthetics_secure_credential.go
+++ b/newrelic/resource_newrelic_synthetics_secure_credential.go
@@ -3,16 +3,15 @@ package newrelic
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"log"
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/entities"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/synthetics"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceNewRelicSyntheticsSecureCredential() *schema.Resource {

--- a/newrelic/structures_newrelic_notifications_destination.go
+++ b/newrelic/structures_newrelic_notifications_destination.go
@@ -3,6 +3,7 @@ package newrelic
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/ai"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/notifications"


### PR DESCRIPTION
# Description

This PR addresses refactoring of imports in resource/data source files in the `newrelic` directory of the provider which currently show lint warnings and corrections, upon running `make lint` locally. 

The corrections made by `make lint` have been rechecked using the **sort imports** feature in the GoLand IDE.

## Checklist:
- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
