### PR TITLE
fix(cloud_tests): adds precheck to cloud tests to delink accounts before test run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,6 +114,7 @@ jobs:
         run: make test-integration cover-report
         env:
           NEW_RELIC_ACCOUNT_ID: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
+          NEW_RELIC_SUBACCOUNT_ID: ${{ secrets.NEW_RELIC_SUBACCOUNT_ID }}
           NEW_RELIC_ADMIN_API_KEY: ${{ secrets.NEW_RELIC_ADMIN_API_KEY }}
           NEW_RELIC_API_KEY: ${{ secrets.NEW_RELIC_API_KEY }}
           NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}

--- a/newrelic/data_source_newrelic_cloud_account_test.go
+++ b/newrelic/data_source_newrelic_cloud_account_test.go
@@ -44,9 +44,9 @@ func TestAccNewRelicCloudAccountDataSource_Error(t *testing.T) {
 func testNewRelicCloudAccountDataSourceBasicConfig() string {
 	return fmt.Sprintf(`
 data "newrelic_cloud_account" "account" {
-	account_id = 3814156
-	name = "NEW-DTK-NAME"
-	cloud_provider = "aws"
+	account_id  	= 3959347
+	name 			= "AWS-Link-For-Acceptance-Test-DO-NOT-DELETE"
+	cloud_provider  = "aws"
 }
 `)
 }
@@ -54,7 +54,7 @@ data "newrelic_cloud_account" "account" {
 func testNewRelicCloudAccountDataSourceErrorConfig() string {
 	return fmt.Sprintf(`
 data "newrelic_cloud_account" "account" {
-	name = "NEW-DTK-NAME"
+	name 		   = "AWS-Link-For-Acceptance-Test-DO-NOT-DELETE"
 	cloud_provider = "aws"
 }
 `)

--- a/newrelic/resource_newrelic_cloud_azure_integrations_test.go
+++ b/newrelic/resource_newrelic_cloud_azure_integrations_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -15,10 +16,14 @@ import (
 )
 
 func TestAccNewRelicCloudAzureIntegration_Basic(t *testing.T) {
-	randName := acctest.RandString(5)
+	testAzureIntegrationName := fmt.Sprintf("tf_cloud_integrations_test_azure_%s", acctest.RandString(5))
 	resourceName := "newrelic_cloud_azure_integrations.bar"
 
-	t.Skip("Skipping test until we can get a better Azure test account")
+	// t.Skip("Skipping test until we can get a better Azure test account")
+
+	if subAccountIDExists := os.Getenv("NEW_RELIC_SUBACCOUNT_ID"); subAccountIDExists == "" {
+		t.Skipf("Skipping this test, as NEW_RELIC_SUBACCOUNT_ID must be set for this test to run.")
+	}
 
 	testAzureApplicationID := os.Getenv("INTEGRATION_TESTING_AZURE_APPLICATION_ID")
 	if testAzureApplicationID == "" {
@@ -40,23 +45,35 @@ func TestAccNewRelicCloudAzureIntegration_Basic(t *testing.T) {
 		t.Skip("INTEGRATION_TESTING_AZURE_TENANT_ID must be set for acceptance test")
 	}
 
+	azureIntegrationsTestConfig := map[string]string{
+		"name":            testAzureIntegrationName,
+		"account_id":      strconv.Itoa(testSubAccountID),
+		"application_id":  testAzureApplicationID,
+		"client_secret":   testAzureClientSecretID,
+		"subscription_id": testAzureSubscriptionID,
+		"tenant_id":       testAzureTenantID,
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccCloudLinkedAccountsCleanup(t, "azure") },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicCloudAzureIntegrationsDestroy,
 		Steps: []resource.TestStep{
 
 			//Test: Create
 			{
-				Config: testAccNewRelicAzureIntegrationsConfig(testAzureApplicationID, testAzureClientSecretID, testAzureSubscriptionID, testAzureTenantID, randName),
+				Config: testAccNewRelicAzureIntegrationsConfig(azureIntegrationsTestConfig),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicCloudAzureIntegrationsExist(resourceName),
 				),
+				PreConfig: func() {
+					time.Sleep(10 * time.Second)
+				},
 			},
 
 			// Test: Update
 			{
-				Config: testAccNewRelicAzureIntegrationsConfigUpdated(testAzureApplicationID, testAzureClientSecretID, testAzureSubscriptionID, testAzureSubscriptionID, randName),
+				Config: testAccNewRelicAzureIntegrationsConfigUpdated(azureIntegrationsTestConfig),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicCloudAzureIntegrationsExist(resourceName),
 				),
@@ -89,7 +106,7 @@ func testAccCheckNewRelicCloudAzureIntegrationsExist(n string) resource.TestChec
 			return fmt.Errorf("error converting string id to int")
 		}
 
-		linkedAccount, err := client.Cloud.GetLinkedAccount(testAccountID, resourceId)
+		linkedAccount, err := client.Cloud.GetLinkedAccount(testSubAccountID, resourceId)
 
 		if err != nil {
 			return err
@@ -106,7 +123,7 @@ func testAccCheckNewRelicCloudAzureIntegrationsExist(n string) resource.TestChec
 func testAccCheckNewRelicCloudAzureIntegrationsDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*ProviderConfig).NewClient
 	for _, r := range s.RootModule().Resources {
-		if r.Type != "newrelic_cloud_azure_integrations" {
+		if r.Type != "newrelic_cloud_azure_integrations" && r.Type != "newrelic_cloud_azure_link_account" {
 			continue
 		}
 
@@ -116,7 +133,7 @@ func testAccCheckNewRelicCloudAzureIntegrationsDestroy(s *terraform.State) error
 			return fmt.Errorf("error converting string id to int")
 		}
 
-		linkedAccount, err := client.Cloud.GetLinkedAccount(testAccountID, resourceId)
+		linkedAccount, err := client.Cloud.GetLinkedAccount(testSubAccountID, resourceId)
 
 		if linkedAccount != nil && err == nil {
 			return fmt.Errorf("linked azure account still exists: #{err}")
@@ -126,18 +143,33 @@ func testAccCheckNewRelicCloudAzureIntegrationsDestroy(s *terraform.State) error
 	return nil
 }
 
-func testAccNewRelicAzureIntegrationsConfig(applicationID string, clientSecretID string, subscriptionID string, tenantID string, name string) string {
+func testAccNewRelicAzureIntegrationsCommonConfig(azureIntegrationsTestConfig map[string]string) string {
 	return fmt.Sprintf(`
-resource "newrelic_cloud_azure_link_account" "foo" {
-  application_id = "%[1]s"
-  client_secret = "%[2]s"
-  subscription_id = "%[3]s"
-  tenant_id = "%[4]s"
-  name  = "%[5]s"
+provider "newrelic" {
+  account_id = "` + azureIntegrationsTestConfig["account_id"] + `"
+  alias      = "cloud-integration-provider"
 }
 
+resource "newrelic_cloud_azure_link_account" "foo" {
+  provider        = newrelic.cloud-integration-provider
+  application_id  = "` + azureIntegrationsTestConfig["application_id"] + `"
+  client_secret   = "` + azureIntegrationsTestConfig["client_secret"] + `"
+  subscription_id = "` + azureIntegrationsTestConfig["subscription_id"] + `"
+  tenant_id       = "` + azureIntegrationsTestConfig["tenant_id"] + `"
+  name            = "` + azureIntegrationsTestConfig["name"] + `"
+  account_id      = "` + azureIntegrationsTestConfig["account_id"] + `"
+}
+`)
+}
+
+func testAccNewRelicAzureIntegrationsConfig(azureIntegrationsTestConfig map[string]string) string {
+	return fmt.Sprintf(`
+` + testAccNewRelicAzureIntegrationsCommonConfig(azureIntegrationsTestConfig) + `
+
 resource "newrelic_cloud_azure_integrations" "bar" {
+  provider          = newrelic.cloud-integration-provider
   linked_account_id = newrelic_cloud_azure_link_account.foo.id
+  account_id        = "` + azureIntegrationsTestConfig["account_id"] + `"
 
   api_management {
     metrics_polling_interval = 3600
@@ -234,23 +266,21 @@ resource "newrelic_cloud_azure_integrations" "bar" {
   mysql {
     metrics_polling_interval = 3600
     resource_groups          = ["beyond"]
-
   }
+
   postgresql {
     metrics_polling_interval = 3600
     resource_groups          = ["beyond"]
-
   }
+
   power_bi_dedicated {
     metrics_polling_interval = 3600
     resource_groups          = ["beyond"]
-
   }
 
   redis_cache {
     metrics_polling_interval = 3600
     resource_groups          = ["beyond"]
-
   }
 
   service_bus {
@@ -276,13 +306,11 @@ resource "newrelic_cloud_azure_integrations" "bar" {
   virtual_machine {
     metrics_polling_interval = 3600
     resource_groups          = ["beyond"]
-
   }
 
   virtual_networks {
     metrics_polling_interval = 3600
     resource_groups          = ["beyond"]
-
   }
 
   vms {
@@ -294,22 +322,17 @@ resource "newrelic_cloud_azure_integrations" "bar" {
     metrics_polling_interval = 3600
     resource_groups          = ["beyond"]
   }
-}
-  `, applicationID, clientSecretID, subscriptionID, tenantID, name)
+}`)
 }
 
-func testAccNewRelicAzureIntegrationsConfigUpdated(applicationID string, clientSecretID string, subscriptionID string, tenantID string, name string) string {
+func testAccNewRelicAzureIntegrationsConfigUpdated(azureIntegrationsTestConfig map[string]string) string {
 	return fmt.Sprintf(`
-resource "newrelic_cloud_azure_link_account" "foo" {
-  application_id  = "%[1]s"
-  client_secret   = "%[2]s"
-  subscription_id = "%[3]s"
-  tenant_id       = "%[4]s"
-  name            = "%[5]s"
-}
+` + testAccNewRelicAzureIntegrationsCommonConfig(azureIntegrationsTestConfig) + `
 
 resource "newrelic_cloud_azure_integrations" "bar" {
+  provider          = newrelic.cloud-integration-provider
   linked_account_id = newrelic_cloud_azure_link_account.foo.id
+  account_id        = "` + azureIntegrationsTestConfig["account_id"] + `"
 
   api_management {
     metrics_polling_interval = 3600
@@ -474,7 +497,5 @@ resource "newrelic_cloud_azure_integrations" "bar" {
     metrics_polling_interval = 3600
     resource_groups          = ["beyond"]
   }
-}
-  `, applicationID, clientSecretID, subscriptionID, tenantID, name)
-
+}`)
 }


### PR DESCRIPTION
### Summary
The changes in this PR propose a solution to failing AWS/Azure/GCP integration tests which currently seem to happen because
- We have one set of credentials per linked account (AWS/Azure/GCP)
- If integration tests are run with the same account and a link/integration exists in the associated New Relic account, this would lead to failing tests, stating that the specified AWs/Azure/GCP account is already linked.

### Changes (High Level Description)
- In order to keep the main account we use for integration tests untouched by cloud integration tests, **tests relating to cloud providers have been modified to use an alternate subaccount**. This would ensure that any integrations set up with the original account (from outside these test cases to any manual feature exploration or testing) would not cause test failures, while the subaccount is used only by these tests to set up cloud integrations.
- Even if the subaccount is used to run these tests, any existing links/integrations need to be discarded to allow the tests cases to pass. **Hence, a PreCheck functionality has been added to remove links of a given provider to the subaccount when its tests are run, which allow the tests to run afresh**.

### Code Changes 
- Changes to AWS/GCP/Azure test cases to use an alternate subaccount from the environment instead of the original account
- Changes to `provider_test.go` to add a cleanup function to clear any AWS/GCP/Azure accounts linked to the aforementioned subaccount
- Refactoring and format changes to Terraform Configuration used in AWS/GCP/Azure test cases
- Addition of a delay of 10 seconds in the **PreConfig** section of AWS/GCP/Azure test cases on cloud integrations, in order to avoid failure when they run in parallel with test cases on linking cloud accounts and the same set of credentials is deemed "already linked" to the aforementioned subaccount
- Modification to `test.yml` to obtain the aforementioned subaccount from the environment to run tests

### Tests
Integration Tests (linked to the resources updated in this PR) are now running successfully. 
If the status in this PR (below) shows "failed" against Integration Tests, please check with the following link
https://github.com/newrelic/terraform-provider-newrelic/actions/runs/5185370258/jobs/9345204302#step:6:321