### PR TITLE
fix: move s3_configuration block inside http_endpoint_configuration f…

### DIFF
--- a/examples/modules/cloud-integrations/aws/main.tf
+++ b/examples/modules/cloud-integrations/aws/main.tf
@@ -3,7 +3,7 @@ data "aws_iam_policy_document" "newrelic_assume_policy" {
     actions = ["sts:AssumeRole"]
 
     principals {
-      type = "AWS"
+      type        = "AWS"
       // This is the unique identifier for New Relic account on AWS, there is no need to change this
       identifiers = [754728514883]
     }
@@ -141,8 +141,8 @@ resource "aws_kinesis_firehose_delivery_stream" "newrelic_firehose_stream" {
     s3_configuration {
       role_arn           = aws_iam_role.firehose_newrelic_role.arn
       bucket_arn         = aws_s3_bucket.newrelic_aws_bucket.arn
-      buffer_size        = 10
-      buffer_interval    = 400
+      buffering_size     = 10
+      buffering_interval = 400
       compression_format = "GZIP"
     }
   }
@@ -328,7 +328,7 @@ resource "aws_config_configuration_recorder_status" "newrelic_recorder_status" {
 resource "aws_config_delivery_channel" "newrelic_recorder_delivery" {
   name           = "newrelic_configuration_recorder-${var.name}"
   s3_bucket_name = aws_s3_bucket.newrelic_configuration_recorder_s3.bucket
-  depends_on = [
+  depends_on     = [
     aws_config_configuration_recorder.newrelic_recorder
   ]
 }

--- a/examples/modules/cloud-integrations/aws/main.tf
+++ b/examples/modules/cloud-integrations/aws/main.tf
@@ -125,14 +125,6 @@ resource "aws_kinesis_firehose_delivery_stream" "newrelic_firehose_stream" {
   name        = "newrelic_firehose_stream_${var.name}"
   destination = "http_endpoint"
 
-  s3_configuration {
-    role_arn           = aws_iam_role.firehose_newrelic_role.arn
-    bucket_arn         = aws_s3_bucket.newrelic_aws_bucket.arn
-    buffer_size        = 10
-    buffer_interval    = 400
-    compression_format = "GZIP"
-  }
-
   http_endpoint_configuration {
     url                = var.newrelic_account_region == "US" ? "https://aws-api.newrelic.com/cloudwatch-metrics/v1" : "https://aws-api.eu01.nr-data.net/cloudwatch-metrics/v1"
     name               = "New Relic ${var.name}"
@@ -144,6 +136,14 @@ resource "aws_kinesis_firehose_delivery_stream" "newrelic_firehose_stream" {
 
     request_configuration {
       content_encoding = "GZIP"
+    }
+
+    s3_configuration {
+      role_arn           = aws_iam_role.firehose_newrelic_role.arn
+      bucket_arn         = aws_s3_bucket.newrelic_aws_bucket.arn
+      buffer_size        = 10
+      buffer_interval    = 400
+      compression_format = "GZIP"
     }
   }
 }


### PR DESCRIPTION
…or resource aws_kinesis_firehose_delivery_stream

# Description

When using Terraform with `required_version = "~> 1.0"`, the `s3_configuration` needs to be inside `http_endpoint_configuration` in `aws_kinesis_firehose_delivery_stream`.

<img width="1300" alt="Screenshot 2023-06-02 at 10 39 39" src="https://github.com/newrelic/terraform-provider-newrelic/assets/5071701/cd4eff63-57eb-4f0a-8912-12ffadf64981">

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

N/A
