### PR TITLE
feat(data_source_newrelic_notifications_destination): Support name in destination data source

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.20.3
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.19.1
+	github.com/newrelic/newrelic-client-go/v2 v2.19.2
 	github.com/stretchr/testify v1.8.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -273,8 +273,8 @@ github.com/newrelic/go-agent/v3 v3.20.3 h1:hUBAMq/Y2Y9as5/yxQbf0zNde/X7w58cWZkm2
 github.com/newrelic/go-agent/v3 v3.20.3/go.mod h1:rT6ZUxJc5rQbWLyCtjqQCOcfb01lKRFbc1yMQkcboWM=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.19.1 h1:3JZ92M/i73HC+cmWoaKZuDF/T7OWusRoheVYT8cnWPQ=
-github.com/newrelic/newrelic-client-go/v2 v2.19.1/go.mod h1:AX08IIL08pYVbnowsR05EqOdfN1Dz+ZXdIwqS0dkT2c=
+github.com/newrelic/newrelic-client-go/v2 v2.19.2 h1:+ftufW63uuLtZl/Jk50Ibavr6fhePOU4wGqgZyGD0P8=
+github.com/newrelic/newrelic-client-go/v2 v2.19.2/go.mod h1:AX08IIL08pYVbnowsR05EqOdfN1Dz+ZXdIwqS0dkT2c=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/newrelic/data_source_newrelic_notifications_destination.go
+++ b/newrelic/data_source_newrelic_notifications_destination.go
@@ -92,11 +92,11 @@ func dataSourceNewRelicNotificationDestinationRead(ctx context.Context, d *schem
 	}
 
 	if len(destinationResponse.Entities) == 0 {
-		if !idOk || (idValue != "" && nameValue == "") {
-			d.SetId("")
+		d.SetId("")
+		if idValue != "" && nameValue == "" {
 			return diag.FromErr(fmt.Errorf("the id provided does not match any New Relic notification destination"))
 		}
-		if !nameOk || (nameValue != "" && idValue == "") {
+		if nameValue != "" && idValue == "" {
 			return diag.FromErr(fmt.Errorf("the name provided does not match any New Relic notification destination"))
 		}
 	}

--- a/newrelic/data_source_newrelic_notifications_destination.go
+++ b/newrelic/data_source_newrelic_notifications_destination.go
@@ -92,11 +92,11 @@ func dataSourceNewRelicNotificationDestinationRead(ctx context.Context, d *schem
 	}
 
 	if len(destinationResponse.Entities) == 0 {
-		d.SetId("")
-		if !idOk || idValue == "" {
+		if !idOk || (idValue != "" && nameValue == "") {
+			d.SetId("")
 			return diag.FromErr(fmt.Errorf("the id provided does not match any New Relic notification destination"))
 		}
-		if !nameOk || nameValue == "" {
+		if !nameOk || (nameValue != "" && idValue == "") {
 			return diag.FromErr(fmt.Errorf("the name provided does not match any New Relic notification destination"))
 		}
 	}

--- a/newrelic/data_source_newrelic_notifications_destination.go
+++ b/newrelic/data_source_newrelic_notifications_destination.go
@@ -93,7 +93,12 @@ func dataSourceNewRelicNotificationDestinationRead(ctx context.Context, d *schem
 
 	if len(destinationResponse.Entities) == 0 {
 		d.SetId("")
-		return diag.FromErr(fmt.Errorf("the id or name you provided does not match any New Relic notification destination"))
+		if !idOk || idValue == "" {
+			return diag.FromErr(fmt.Errorf("the id provided does not match any New Relic notification destination"))
+		}
+		if !nameOk || nameValue == "" {
+			return diag.FromErr(fmt.Errorf("the name provided does not match any New Relic notification destination"))
+		}
 	}
 
 	errors := buildAiNotificationsResponseErrors(destinationResponse.Errors)

--- a/newrelic/data_source_newrelic_notifications_destination.go
+++ b/newrelic/data_source_newrelic_notifications_destination.go
@@ -19,14 +19,16 @@ func dataSourceNewRelicNotificationDestination() *schema.Resource {
 		ReadContext: dataSourceNewRelicNotificationDestinationRead,
 		Schema: map[string]*schema.Schema{
 			"id": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "The ID of the destination.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"id", "name"},
+				Description:  "The ID of the destination.",
 			},
 			"name": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "The name of the destination.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"id", "name"},
+				Description:  "The name of the destination.",
 			},
 			"account_id": {
 				Type:        schema.TypeInt,
@@ -71,17 +73,12 @@ func dataSourceNewRelicNotificationDestinationRead(ctx context.Context, d *schem
 	sorter := notifications.AiNotificationsDestinationSorter{}
 
 	nameValue, nameOk := d.Get("name").(string)
-	if nameOk {
+	if nameOk && nameValue != "" {
 		filters = ai.AiNotificationsDestinationFilter{Name: nameValue}
 	}
-
 	idValue, idOk := d.Get("id").(string)
-	if idOk {
-		filters = ai.AiNotificationsDestinationFilter{ID: idValue} // will override name parameter
-	}
-
-	if !nameOk && !idOk {
-		return diag.FromErr(fmt.Errorf("missing 'id' or 'name' parameters"))
+	if idOk && idValue != "" {
+		filters = ai.AiNotificationsDestinationFilter{ID: idValue}
 	}
 
 	destinationResponse, err := client.Notifications.GetDestinationsWithContext(updatedContext, accountID, "", filters, sorter)

--- a/newrelic/data_source_newrelic_notifications_destination_test.go
+++ b/newrelic/data_source_newrelic_notifications_destination_test.go
@@ -56,39 +56,39 @@ func TestAccNewRelicNotificationDestinationDataSource_ByName(t *testing.T) {
 
 func testAccNewRelicNotificationsDestinationDataSourceConfigById(name string) string {
 	return fmt.Sprintf(`
-resource "newrelic_notification_destination" "foo" {
-	name = "%s"
-	type = "WEBHOOK"
-	active = true
-
-	property {
-		key = "url"
+	resource "newrelic_notification_destination" "foo" {
+	  name   = "%s"
+	  type   = "WEBHOOK"
+	  active = true
+	
+	  property {
+		key   = "url"
 		value = "https://webhook.site/"
+	  }
 	}
-}
-
-data "newrelic_notification_destination" "foo" {
-	id = newrelic_notification_destination.foo.id
-}
+	
+	data "newrelic_notification_destination" "foo" {
+	  id = newrelic_notification_destination.foo.id
+	}
 `, name)
 }
 
 func testAccNewRelicNotificationsDestinationDataSourceConfigByName(name string) string {
 	return fmt.Sprintf(`
-resource "newrelic_notification_destination" "foo" {
-	name = "%s"
-	type = "WEBHOOK"
-	active = true
-
-	property {
-		key = "url"
+	resource "newrelic_notification_destination" "foo" {
+	  name   = "%s"
+	  type   = "WEBHOOK"
+	  active = true
+	
+	  property {
+		key   = "url"
 		value = "https://webhook.site/"
+	  }
 	}
-}
-
-data "newrelic_notification_destination" "foo" {
-	name = newrelic_notification_destination.foo.name
-}
+	
+	data "newrelic_notification_destination" "foo" {
+	  name = newrelic_notification_destination.foo.name
+	}
 `, name)
 }
 

--- a/newrelic/data_source_newrelic_notifications_destination_test.go
+++ b/newrelic/data_source_newrelic_notifications_destination_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccNewRelicNotificationDestinationDataSource_Id(t *testing.T) {
+func TestAccNewRelicNotificationDestinationDataSource_ById(t *testing.T) {
 	resourceName := "newrelic_notification_destination.foo"
 	rand := acctest.RandString(5)
 	rName := fmt.Sprintf("tf-notifications-test-%s", rand)
@@ -33,7 +33,7 @@ func TestAccNewRelicNotificationDestinationDataSource_Id(t *testing.T) {
 	})
 }
 
-func TestAccNewRelicNotificationDestinationDataSource_Name(t *testing.T) {
+func TestAccNewRelicNotificationDestinationDataSource_ByName(t *testing.T) {
 	resourceName := "newrelic_notification_destination.foo"
 	rand := acctest.RandString(5)
 	rName := fmt.Sprintf("tf-notifications-test-%s", rand)
@@ -76,7 +76,7 @@ data "newrelic_notification_destination" "foo" {
 func testAccNewRelicNotificationsDestinationDataSourceConfigByName(name string) string {
 	return fmt.Sprintf(`
 resource "newrelic_notification_destination" "foo" {
-	name = "%[1]s"
+	name = "%s"
 	type = "WEBHOOK"
 	active = true
 
@@ -85,8 +85,9 @@ resource "newrelic_notification_destination" "foo" {
 		value = "https://webhook.site/"
 	}
 }
+
 data "newrelic_notification_destination" "foo" {
-	name = "%[1]s"
+	name = newrelic_notification_destination.foo.name
 }
 `, name)
 }

--- a/newrelic/data_source_newrelic_notifications_destination_test.go
+++ b/newrelic/data_source_newrelic_notifications_destination_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccNewRelicNotificationDestinationDataSource_Basic(t *testing.T) {
+func TestAccNewRelicNotificationDestinationDataSource_Id(t *testing.T) {
 	resourceName := "newrelic_notification_destination.foo"
 	rand := acctest.RandString(5)
 	rName := fmt.Sprintf("tf-notifications-test-%s", rand)
@@ -22,7 +22,7 @@ func TestAccNewRelicNotificationDestinationDataSource_Basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNewRelicNotificationsDestinationDataSourceConfig(rName),
+				Config: testAccNewRelicNotificationsDestinationDataSourceConfigById(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccNewRelicNotificationDestination("data.newrelic_notification_destination.foo"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -33,7 +33,28 @@ func TestAccNewRelicNotificationDestinationDataSource_Basic(t *testing.T) {
 	})
 }
 
-func testAccNewRelicNotificationsDestinationDataSourceConfig(name string) string {
+func TestAccNewRelicNotificationDestinationDataSource_Name(t *testing.T) {
+	resourceName := "newrelic_notification_destination.foo"
+	rand := acctest.RandString(5)
+	rName := fmt.Sprintf("tf-notifications-test-%s", rand)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckEnvVars(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNewRelicNotificationsDestinationDataSourceConfigByName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNewRelicNotificationDestination("data.newrelic_notification_destination.foo"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "WEBHOOK"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNewRelicNotificationsDestinationDataSourceConfigById(name string) string {
 	return fmt.Sprintf(`
 resource "newrelic_notification_destination" "foo" {
 	name = "%s"
@@ -48,6 +69,24 @@ resource "newrelic_notification_destination" "foo" {
 
 data "newrelic_notification_destination" "foo" {
 	id = newrelic_notification_destination.foo.id
+}
+`, name)
+}
+
+func testAccNewRelicNotificationsDestinationDataSourceConfigByName(name string) string {
+	return fmt.Sprintf(`
+resource "newrelic_notification_destination" "foo" {
+	name = "%[1]s"
+	type = "WEBHOOK"
+	active = true
+
+	property {
+		key = "url"
+		value = "https://webhook.site/"
+	}
+}
+data "newrelic_notification_destination" "foo" {
+	name = "%[1]s"
 }
 `, name)
 }

--- a/website/docs/d/notification_destination.html.markdown
+++ b/website/docs/d/notification_destination.html.markdown
@@ -71,6 +71,7 @@ Optional:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `name` - The name of the notification destination.
 * `type` - The notification destination type, either: `EMAIL`, `SERVICE_NOW`, `WEBHOOK`, `JIRA`, `MOBILE_PUSH`, `EVENT_BRIDGE`, `PAGERDUTY_ACCOUNT_INTEGRATION` or `PAGERDUTY_SERVICE_INTEGRATION`, `SLACK` and `SLACK_COLLABORATION`.
 * `property` - A nested block that describes a notification destination property.
 * `active` - An indication whether the notification destination is active or not.

--- a/website/docs/d/notification_destination.html.markdown
+++ b/website/docs/d/notification_destination.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Use this data source to get information about a specific notification destination in New Relic that already exists. More information on Terraform's data sources can be found [here](https://www.terraform.io/language/data-sources).
 
-## Example Usage
+## Id Example Usage
 
 ```hcl
 # Data source
@@ -33,18 +33,44 @@ resource "newrelic_notification_channel" "foo-channel" {
 }
 ```
 
+## Name Example Usage
+
+```hcl
+# Data source
+data "newrelic_notification_destination" "foo" {
+  name = "webhook-destination"
+}
+
+# Resource
+resource "newrelic_notification_channel" "foo-channel" {
+  name = "webhook-example"
+  type = "WEBHOOK"
+  destination_id = data.newrelic_notification_destination.foo.id
+  product = "IINT"
+
+  property {
+    key = "payload"
+    value = "{\n\t\"name\": \"foo\"\n}"
+    label = "Payload Template"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
+Required **one of these two** arguments:
 * `id` - (Required) The id of the notification destination in New Relic.
+* `name` - (Required) The name of the notification destination.
+
+Optional:
 * `account_id` - (Optional) The New Relic account ID to operate on.  This allows you to override the `account_id` attribute set on the provider. Defaults to the environment variable `NEW_RELIC_ACCOUNT_ID`.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `name` - The name of the notification destination.
 * `type` - The notification destination type, either: `EMAIL`, `SERVICE_NOW`, `WEBHOOK`, `JIRA`, `MOBILE_PUSH`, `EVENT_BRIDGE`, `PAGERDUTY_ACCOUNT_INTEGRATION` or `PAGERDUTY_SERVICE_INTEGRATION`, `SLACK` and `SLACK_COLLABORATION`.
 * `property` - A nested block that describes a notification destination property.
 * `active` - An indication whether the notification destination is active or not.

--- a/website/docs/d/notification_destination.html.markdown
+++ b/website/docs/d/notification_destination.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Use this data source to get information about a specific notification destination in New Relic that already exists. More information on Terraform's data sources can be found [here](https://www.terraform.io/language/data-sources).
 
-## Id Example Usage
+## ID Example Usage
 
 ```hcl
 # Data source
@@ -20,13 +20,13 @@ data "newrelic_notification_destination" "foo" {
 
 # Resource
 resource "newrelic_notification_channel" "foo-channel" {
-  name = "webhook-example"
-  type = "WEBHOOK"
+  name           = "webhook-example"
+  type           = "WEBHOOK"
   destination_id = data.newrelic_notification_destination.foo.id
-  product = "IINT"
+  product        = "IINT"
 
   property {
-    key = "payload"
+    key   = "payload"
     value = "{\n\t\"name\": \"foo\"\n}"
     label = "Payload Template"
   }
@@ -43,13 +43,13 @@ data "newrelic_notification_destination" "foo" {
 
 # Resource
 resource "newrelic_notification_channel" "foo-channel" {
-  name = "webhook-example"
-  type = "WEBHOOK"
+  name           = "webhook-example"
+  type           = "WEBHOOK"
   destination_id = data.newrelic_notification_destination.foo.id
-  product = "IINT"
+  product        = "IINT"
 
   property {
-    key = "payload"
+    key   = "payload"
     value = "{\n\t\"name\": \"foo\"\n}"
     label = "Payload Template"
   }

--- a/website/docs/d/notification_destination.html.markdown
+++ b/website/docs/d/notification_destination.html.markdown
@@ -60,9 +60,9 @@ resource "newrelic_notification_channel" "foo-channel" {
 
 The following arguments are supported:
 
-Required **one of these two** arguments:
-* `id` - (Required) The id of the notification destination in New Relic.
-* `name` - (Required) The name of the notification destination.
+Either of the following two attributes are required, and not both:
+* `id` - (Optional) The id of the notification destination in New Relic.
+* `name` - (Optional) The name of the notification destination.
 
 Optional:
 * `account_id` - (Optional) The New Relic account ID to operate on.  This allows you to override the `account_id` attribute set on the provider. Defaults to the environment variable `NEW_RELIC_ACCOUNT_ID`.


### PR DESCRIPTION
# Description

Add support for creating destination data sources by name. Jira ticket link [here](https://issues.newrelic.com/browse/NR-88092).

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc
- Create a destination with a specific name via New Relic notifications destination UI - in the Alerts tab
- Add this code to your terraform file with the name of the destination:
```
data "newrelic_notification_destination" "foo" {
  name = <destination_name>
}
```