### PR TITLE
docs(cloud_guides): beautification of cloud provider docs

### DIFF
--- a/website/docs/guides/cloud_integrations_guide.html.markdown
+++ b/website/docs/guides/cloud_integrations_guide.html.markdown
@@ -20,11 +20,38 @@ If you encounter issues or bugs, please [report those on Github repository](http
 
 ### AWS
 
-The New Relic AWS integration relies on two mechanisms to get data in New Relic: [AWS Metric stream](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/connect/aws-metric-stream/) and [AWS Polling integrations](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/connect/connect-aws-new-relic-infrastructure-monitoring). For the majority of AWS services the AWS Metric stream is used as it [has many advantages compared to polling](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/connect/aws-metric-stream#why-it-matters). The AWS Polling integrations are also enabled because AWS does not yet [support all metrics through AWS Metric Stream](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/connect/aws-metric-stream#integrations-not-replaced-streams). We enable `AWS Billing`, `AWS CloudTrail`, `AWS Health`, `AWS Trusted Advisor`, `AWS X-Ray`, `AWS S3`, `AWS Doc DB`, `AWS SQS`, `AWS EBS`, `AWS ALB`, `AWS Elasticache`, `AWS ApiGateway`, `AWS AutoScaling`, `AWS AppSync`, `AWS Athena`, `AWS Cognito`, `AWS Connect`, `AWS DirectConnect`, `AWS Fsx`, `AWS Glue`, `AWS Kinesis Analytics`, `AWS MediaConvert`, `AWS Media Package vod`, `AWS Mq`, `AWS Msk`, `AWS Neptune`, `AWS Qldb`, `AWS Route53resolver`, `AWS States`, `AWS TransitGateway`, `AWS Waf`, `AWS Wafv2`, `Cloudfront`, `DynamoDB`, `Ec2`, `Ecs`, `Efs`, `Elasticbeanstalk`, `Elasticsearch`, `Elb`, `Emr`, `Iam`, `Iot`, `Kinesis`, `Kinesis Firehose`, `Lambda`, `Rds`, `Redshift`, `Route53`, `Ses` and `Sns`.
+The New Relic AWS integration relies on two mechanisms to get data in New Relic: [AWS Metric stream](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/connect/aws-metric-stream/) and [AWS Polling integrations](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/connect/connect-aws-new-relic-infrastructure-monitoring). For the majority of AWS services the AWS Metric stream is used as it [has many advantages compared to polling](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/connect/aws-metric-stream#why-it-matters). AWS Polling integrations are also enabled because AWS does not yet [support all metrics through AWS Metric Stream](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/connect/aws-metric-stream#integrations-not-replaced-streams). 
+
+The following AWS services may be integrated via API Polling, using the New Relic Terraform Provider. A combination of these services may be added to the Terraform Configuration, to set up an AWS Integration comprising these services via API Polling. More [examples](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/cloud_aws_integrations#example-usage) and [details](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/cloud_aws_integrations#argument-reference) on the arguments needed to set up each service can be found in the documentation of the [`newrelic_cloud_aws_integrations`](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/cloud_aws_integrations) resource.
+
+|                     |                     |                    |
+|---------------------|---------------------|--------------------|
+| `ALB`               | `API Gateway`       | `AppSync`          |
+| `Athena`            | `Auto Scaling`      | `Billing`          |
+| `CloudFront`        | `CloudTrail`        | `Cognito`          |
+| `Connect`           | `Direct Connect`    | `DocumentDB`       |
+| `DynamoDB`          | `EBS`               | `EC2`              |
+| `ECS`               | `EFS`               | `ElastiCache`      |
+| `Elastic Beanstalk` | `Elasticsearch`     | `ELB`              |
+| `EMR`               | `FSx`               | `Glue`             |
+| `Health`            | `IAM`               | `IoT`              |
+| `Kinesis`           | `Kinesis Analytics` | `Kinesis Firehose` |
+| `Lambda`            | `Media Package VOD` | `MediaConvert`     |
+| `MQ`                | `MSK`               | `Neptune`          |
+| `QLDB`              | `RDS`               | `Redshift`         |
+| `Route53`           | `Route53 Resolver`  | `S3`               |
+| `SES`               | `SNS`               | `SQS`              |
+| `States`            | `Transit Gateway`   | `Trusted Advisor`  |
+| `VPC`               | `WAF`               | `WAFv2`            |
+| `X-Ray`             | 
+
+
 
 Check out our [introduction to AWS integrations](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/get-started/introduction-aws-integrations) and the [requirements](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/get-started/integrations-managed-policies/) documentation before continuing with the steps below.
 
-Add the following module to your Terraform code, and set the variables to your desired values. This module assumes you've already set up the New Relic and AWS provider with the correct credentials. If you haven't done so, you can find the instructions here: [New Relic instructions](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/getting_started), [AWS instructions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication-and-configuration).
+The GitHub repository of the Terraform Provider also has an AWS Cloud Integrations 'module', that can be used to simplify setting up an AWS integration; both, via metric streams, and with API polling (inclusive of a few of the aforementioned services). To use this module, add the following to your Terraform code, and set the variables to your desired values.
+
+-> **NOTE:** This module assumes you've already set up the New Relic and AWS provider with the correct credentials. If you haven't done so, you can find the instructions here: [New Relic instructions](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/getting_started), [AWS instructions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication-and-configuration).
 
 ```
 module "newrelic-aws-cloud-integrations" {
@@ -35,6 +62,7 @@ module "newrelic-aws-cloud-integrations" {
   name                    = "production"
 }
 ```
+
 [*You can find the sourcecode for the module on Github.*](https://github.com/newrelic/terraform-provider-newrelic/tree/main/examples/modules/cloud-integrations/aws)
 
 
@@ -49,11 +77,27 @@ Variables:
 
 The Microsoft Azure integrations reports data from various Azure platform services to your New Relic account.
 
-This module will integrate the following resources: `API Management`, `App Gateway`, `App Service`, `Containers`, `Cosmos DB`, `Cost Management`, `Data Factory`, `Eventhub`, `Express Route`, `Firewalls`, `FrontDoor`, `Functions`, `KeyVault`, `Load Balancer`, `Logic apps`, `Machine learning`, `MariaDB`, `Mysql`, `Postgresql`, `PowerBI Dedicated`, `Redis cache`, `Service Bus`, `Sql`, `Sql Managed`, `Storage`, `Virtual Machine`, `Virtual Networks`, `Vms`, and `VPN gateway`.
+The following Azure services may be integrated using the New Relic Terraform Provider. A combination of these services may be added to the Terraform Configuration, to set up an Azure Integration comprising the selected services. More [examples](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/cloud_azure_integrations#example-usage) and [details](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/cloud_azure_integrations#argument-reference) on the arguments needed to set up each service can be found in the documentation of the [`newrelic_cloud_azure_integrations`](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/cloud_azure_integrations) resource.
+
+|                    |                       |                      |
+|--------------------|-----------------------|----------------------|
+| `API Management`   | `Application Gateway` | `App Service`        |
+| `Containers`       | `Cosmos DB`           | `Cost Management`    |
+| `Data Factory`     | `Event Hub`           | `Express Route`      |
+| `Firewalls`        | `Front Door`          | `Functions`          |
+| `Key Vault`        | `Load Balancer`       | `Logic Apps`         |
+| `Machine Learning` | `MariaDB`             | `Monitor`            |
+| `MySQL`            | `PostgreSQL`          | `Power BI Dedicated` |
+| `Redis Cache`      | `Service Bus`         | `SQL`                |
+| `SQL Managed`      | `Storage`             | `Virtual Machine`    |
+| `Virtual Network`  | `VMs`                 | `VPN Gateway`        |
 
 Check out our [introduction to Azure integrations](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations/) and the [requirements](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/get-started/activate-azure-integrations/#reqs) documentation before continuing with the steps below.
 
-Add the following module to your Terraform code, and set the variables to your desired values. This module assumes you've already set up the New Relic and Azure provider with the correct credentials. If you haven't done so, you can find the instructions here: [New Relic instructions](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/getting_started), [Azure instructions](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs).
+The GitHub repository of the Terraform Provider also has an Azure Cloud Integrations 'module', comprising all the aforementioned Azure services, that can be used to simplify setting up an Azure Integration. To use this module, add the following to your Terraform code, and set the variables to your desired values. 
+
+-> **NOTE:** This module assumes you've already set up the New Relic and Azure provider with the correct credentials. If you haven't done so, you can find the instructions here: [New Relic instructions](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/getting_started), [Azure instructions](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs).
+
 
 ```
 module "newrelic-azure-cloud-integrations" {
@@ -75,11 +119,25 @@ Variables:
 
 The Google Cloud Platform integrations reports data from various GCP services to your New Relic account.
 
-This module will integrate the following resources: `App Engine`, `BigQuery`, `Cloud Functions`, `Cloud Load Balancing`, `Cloud Pub/Sub`, `Cloud Spanner`, `Cloud SQL`, `Cloud Storage`, `Compute Engine`, and `Kubernetes Engine`.
+The following GCP services may be integrated using the New Relic Terraform Provider. A combination of these services may be added to the Terraform Configuration, to set up an GCP Integration comprising the selected services. More [examples](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/cloud_gcp_integrations#example-usage) and [details](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/cloud_gcp_integrations#argument-reference) on the arguments needed to set up each service can be found in the documentation of the [`newrelic_cloud_gcp_integrations`](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/cloud_gcp_integrations) resource.
+
+|                      |                           |                       |
+|----------------------|---------------------------|-----------------------|
+| `Alloy DB`           | `App Engine`              | `BigQuery`            |
+| `Cloud Bigtable`     | `Cloud Composer`          | `Cloud Functions`     |
+| `Cloud Interconnect` | `Cloud Load Balancing`    | `Cloud Pub/Sub`       |
+| `Cloud Router`       | `Cloud Run`               | `Cloud SQL`           |
+| `Cloud Spanner`      | `Cloud Storage`           | `Dataflow`            |
+| `Dataproc`           | `Datastore`               | `Firebase Database`   |
+| `Firebase Hosting`   | `Firebase Storage`        | `Firestore`           |
+| `Kubernetes Engine`  | `Memorystore (Memcached)` | `Memorystore (Redis)` |
+| `VPC Access`         | `Virtual Machines`        |
 
 Check out our [introduction to GCP integrations](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/get-started/introduction-google-cloud-platform-integrations/) and the [requirements](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/get-started/connect-google-cloud-platform-services-new-relic/#reqs) documentation before continuing with the steps below.
 
-Add the following module to your Terraform code, and set the variables to your desired values. This module assumes you've already set up the New Relic and GCP provider with the correct credentials. If you haven't done so, you can find the instructions here: [New Relic instructions](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/getting_started), [GCP instructions](https://registry.terraform.io/providers/hashicorp/google/latest/docs).
+The GitHub repository of the Terraform Provider also has an GCP Cloud Integrations 'module', comprising a few of the aforementioned GCP services as a sample, that can be used to simplify setting up an GCP Integration. To use this module, add the following to your Terraform code, and set the variables to your desired values.
+
+-> **NOTE:** This module assumes you've already set up the New Relic and GCP provider with the correct credentials. If you haven't done so, you can find the instructions here: [New Relic instructions](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/getting_started), [GCP instructions](https://registry.terraform.io/providers/hashicorp/google/latest/docs).
 
 ```
 module "newrelic-gcp-cloud-integrations" {

--- a/website/docs/r/cloud_aws_integrations.html.markdown
+++ b/website/docs/r/cloud_aws_integrations.html.markdown
@@ -305,60 +305,65 @@ resource "newrelic_cloud_aws_integrations" "bar" {
 * `account_id` - (Optional) The New Relic account ID to operate on.  This allows the user to override the `account_id` attribute set on the provider. Defaults to the environment variable `NEW_RELIC_ACCOUNT_ID`.
 * `linked_account_id` - (Required) The ID of the linked AWS account in New Relic.
 
+All other arguments are dependent on the services to be integrated, which have been listed in the collapsible section below. All of these are **optional** blocks that can be added in any required combination. **For details on arguments that can be used with each service, check out the [`Integration` blocks](#integration-blocks) section below.**
 <details>
-  <summary> All other arguments are dependent on the services to be integrated. To view a comprehensive list of valid arguments, expand this section. </summary>
-* `billing` - (Optional) Billing integration. See [Integration blocks](#integration-blocks) below for details.
-* `cloudtrail` - (Optional) Cloudtrail integration. See [Integration blocks](#integration-blocks) below for details.
-* `health` - (Optional) Health integration. See [Integration blocks](#integration-blocks) below for details.
-* `trusted_advisor` - (Optional) Trusted Advisor integration. See [Integration blocks](#integration-blocks) below for details.
-* `vpc` - (Optional) VPC integration. See [Integration blocks](#integration-blocks) below for details.
-* `x_ray` - (Optional) X-Ray integration. See [Integration blocks](#integration-blocks) below for details.
-* `s3` - (Optional) S3 integration. See [Integration blocks](#integration-blocks) below for details.
-* `doc_db` - (Optional) Doc_DB integration. See [Integration blocks](#integration-blocks) below for details.
-* `sqs` - (Optional) SQS integration. See [Integration blocks](#integration-blocks) below for details.
-* `ebs` - (Optional) EBS integration. See [Integration blocks](#integration-blocks) below for details.
-* `alb` - (Optional) ALB integration. See [Integration blocks](#integration-blocks) below for details.
-* `elasticache` - (Optional) Elasticache integration. See [Integration blocks](#integration-blocks) below for details.
-* `api_gateway` - (Optional) ApiGateway integration. See [Integration blocks](#integration-blocks) below for details.
-* `auto_scaling` - (Optional) AutoScaling integration. See [Integration blocks](#integration-blocks) below for details.
-* `aws_app_sync` - (Optional) AppSync integration. See [Integration blocks](#integration-blocks) below for details.
-* `aws_athena` - (Optional) Athena integration. See [Integration blocks](#integration-blocks) below for details.
-* `aws_cognito` - (Optional) Cognito integration. See [Integration blocks](#integration-blocks) below for details.
-* `aws_connect` - (Optional) Connect integration. See [Integration blocks](#integration-blocks) below for details.
-* `aws_direct_connect` - (Optional) DirectConnect integration. See [Integration blocks](#integration-blocks) below for details.
-* `aws_fsx` - (Optional) Fsx integration. See [Integration blocks](#integration-blocks) below for details.
-* `aws_glue` - (Optional) Glue integration. See [Integration blocks](#integration-blocks) below for details.
-* `aws_kinesis_analytics` - (Optional) Kinesis Analytics integration. See [Integration blocks](#integration-blocks) below for details.
-* `aws_media_convert` - (Optional) Media Convert integration. See [Integration blocks](#integration-blocks) below for details.
-* `aws_media_package_vod` - (Optional) Media Package vod integration. See [Integration blocks](#integration-blocks) below for details.
-* `aws_mq` - (Optional) Mq integration. See [Integration blocks](#integration-blocks) below for details.
-* `aws_msk` - (Optional) Msk integration. See [Integration blocks](#integration-blocks) below for details.
-* `aws_neptune` - (Optional) Neptune integration. See [Integration blocks](#integration-blocks) below for details.
-* `aws_qldb` - (Optional) Qldb integration. See [Integration blocks](#integration-blocks) below for details.
-* `aws_route53resolver` - (Optional) Route53resolver integration. See [Integration blocks](#integration-blocks) below for details.
-* `aws_states` - (Optional) States integration. See [Integration blocks](#integration-blocks) below for details.
-* `aws_transit_gateway` - (Optional) TransitGateway integration. See [Integration blocks](#integration-blocks) below for details.
-* `aws_waf` - (Optional) Waf integration. See [Integration blocks](#integration-blocks) below for details.
-* `aws_wafv2` - (Optional) Wafv2 integration. See [Integration blocks](#integration-blocks) below for details.
-* `cloudfront` - (Optional) Cloudfront integration. See [Integration blocks](#integration-blocks) below for details.
-* `dynamodb` - (Optional) DynamoDB integration. See [Integration blocks](#integration-blocks) below for details.
-* `ec2` - (Optional) Ec2 integration. See [Integration blocks](#integration-blocks) below for details.
-* `ecs` - (Optional) Ecs integration. See [Integration blocks](#integration-blocks) below for details.
-* `efs` - (Optional) Efs integration. See [Integration blocks](#integration-blocks) below for details.
-* `elasticbeanstalk` - (Optional) Elasticbeanstalk integration. See [Integration blocks](#integration-blocks) below for details.
-* `elasticsearch` - (Optional) Elasticsearch integration. See [Integration blocks](#integration-blocks) below for details.
-* `elb` - (Optional) Elb integration. See [Integration blocks](#integration-blocks) below for details.
-* `emr` - (Optional) Emr integration. See [Integration blocks](#integration-blocks) below for details.
-* `iam` - (Optional) Iam integration. See [Integration blocks](#integration-blocks) below for details.
-* `iot` - (Optional) Iot integration. See [Integration blocks](#integration-blocks) below for details.
-* `kinesis` - (Optional) Kinesis integration. See [Integration blocks](#integration-blocks) below for details.
-* `kinesis_firehose` - (Optional) Kinesis firehose integration. See [Integration blocks](#integration-blocks) below for details.
-* `lambda` - (Optional) Lambda integration. See [Integration blocks](#integration-blocks) below for details.
-* `rds` - (Optional) Rds integration. See [Integration blocks](#integration-blocks) below for details.
-* `redshift` - (Optional) Redshift integration. See [Integration blocks](#integration-blocks) below for details.
-* `route53` - (Optional) Route53 integration. See [Integration blocks](#integration-blocks) below for details.
-* `ses` - (Optional) Ses integration. See [Integration blocks](#integration-blocks) below for details.
-* `sns` - (Optional) Sns integration. See [Integration blocks](#integration-blocks) below for details.
+  <summary>Expand this section to view all supported AWS services supported, that may be integrated via this resource.</summary>
+
+| Block                   | Description                   |
+|-------------------------|-------------------------------|
+| `alb`                   | ALB Integration               |
+| `api_gateway`           | API Gateway Integration       |
+| `auto_scaling`          | Auto Scaling Integration      |
+| `aws_app_sync`          | AppSync Integration           |
+| `aws_athena`            | Athena Integration            |
+| `aws_cognito`           | Cognito Integration           |
+| `aws_connect`           | Connect Integration           |
+| `aws_direct_connect`    | Direct Connect Integration    |
+| `aws_fsx`               | FSx Integration               |
+| `aws_glue`              | Glue Integration              |
+| `aws_kinesis_analytics` | Kinesis Analytics Integration |
+| `aws_media_convert`     | MediaConvert Integration      |
+| `aws_media_package_vod` | Media Package VOD Integration |
+| `aws_mq`                | MQ Integration                |
+| `aws_msk`               | MSK Integration               |
+| `aws_neptune`           | Neptune Integration           |
+| `aws_qldb`              | QLDB Integration              |
+| `aws_route53resolver`   | Route53 Resolver Integration  |
+| `aws_states`            | States Integration            |
+| `aws_transit_gateway`   | Transit Gateway Integration   |
+| `aws_waf`               | WAF Integration               |
+| `aws_wafv2`             | WAFv2 Integration             |
+| `billing`               | Billing Integration           |
+| `cloudfront`            | CloudFront Integration        |
+| `cloudtrail`            | CloudTrail Integration        |
+| `doc_db`                | DocumentDB Integration        |
+| `dynamodb`              | DynamoDB Integration          |
+| `ebs`                   | EBS Integration               |
+| `ec2`                   | EC2 Integration               |
+| `ecs`                   | ECS Integration               |
+| `efs`                   | EFS Integration               |
+| `elasticache`           | ElastiCache Integration       |
+| `elasticbeanstalk`      | Elastic Beanstalk Integration |
+| `elasticsearch`         | Elasticsearch Integration     |
+| `elb`                   | ELB Integration               |
+| `emr`                   | EMR Integration               |
+| `health`                | Health Integration            |
+| `iam`                   | IAM Integration               |
+| `iot`                   | IoT Integration               |
+| `kinesis`               | Kinesis Integration           |
+| `kinesis_firehose`      | Kinesis Firehose Integration  |
+| `lambda`                | Lambda Integration            |
+| `rds`                   | RDS Integration               |
+| `redshift`              | Redshift Integration          |
+| `route53`               | Route53 Integration           |
+| `s3`                    | S3 Integration                |
+| `ses`                   | SES Integration               |
+| `sns`                   | SNS Integration               |
+| `sqs`                   | SQS Integration               |
+| `trusted_advisor`       | Trusted Advisor Integration   |
+| `vpc`                   | VPC Integration               |
+| `x_ray`                 | X-Ray Integration             |
+
 </details>
 
 ### `Integration` blocks
@@ -368,7 +373,7 @@ All `integration` blocks support the following common arguments:
 * `metrics_polling_interval` - (Optional) The data polling interval in seconds.
 
 <details>
-  <summary> Some integration types support an additional set of arguments. To delve deeper into the list of arguments, click here. </summary>
+  <summary> Some integration types support an additional set of arguments. Expand this section to take a look at these supported arguments. </summary>
 * `cloudtrail`
   * `aws_regions` - (Optional) Specify each AWS region that includes the resources that you want to monitor.
 * `vpc`

--- a/website/docs/r/cloud_aws_integrations.html.markdown
+++ b/website/docs/r/cloud_aws_integrations.html.markdown
@@ -302,10 +302,11 @@ resource "newrelic_cloud_aws_integrations" "bar" {
 ```
 ## Argument Reference
 
-<details>
-  <summary> To view the comprehensive list of valid arguments, click here. </summary>
 * `account_id` - (Optional) The New Relic account ID to operate on.  This allows the user to override the `account_id` attribute set on the provider. Defaults to the environment variable `NEW_RELIC_ACCOUNT_ID`.
 * `linked_account_id` - (Required) The ID of the linked AWS account in New Relic.
+
+<details>
+  <summary> All other arguments are dependent on the services to be integrated. To view a comprehensive list of valid arguments, expand this section. </summary>
 * `billing` - (Optional) Billing integration. See [Integration blocks](#integration-blocks) below for details.
 * `cloudtrail` - (Optional) Cloudtrail integration. See [Integration blocks](#integration-blocks) below for details.
 * `health` - (Optional) Health integration. See [Integration blocks](#integration-blocks) below for details.

--- a/website/docs/r/cloud_gcp_integrations.html.markdown
+++ b/website/docs/r/cloud_gcp_integrations.html.markdown
@@ -130,6 +130,7 @@ The following arguments are supported:
 * `functions` - (Optional) Functions integration. See [Integration blocks](#integration-blocks) below for details.
 * `interconnect` - (Optional) Interconnect integration. See [Integration blocks](#integration-blocks) below for details.
 * `kubernetes` - (Optional) Kubernetes integration. See [Integration blocks](#integration-blocks) below for details.
+* `load_balancing` - (Optional) Load Balancing integration. See [Integration blocks](#integration-blocks) below for details.
 * `mem_cache` - (Optional) Mem cache integration. See [Integration blocks](#integration-blocks) below for details.
 * `pub_sub` - (Optional) Pub/Sub integration. See [Integration blocks](#integration-blocks) below for details.
 * `redis` - (Optional) Redis integration. See [Integration blocks](#integration-blocks) below for details.


### PR DESCRIPTION
# Description

This PR addresses (the following changes made to the Cloud Providers Guide in the Terraform Provider's docs)
- recent feedback received on changing the supported services by an integration (AWS/Azure/GCP) from a **list** to a **table**, to make it slightly more readable
- few corrections made to the services supported (typos corrected and missing services added)
- rephrasing of a few sentences to support the changes listed above

