### PR TITLE
fix(dashboards): update to 'text' field schema in widget_markdown

### DIFF
--- a/newrelic/resource_newrelic_one_dashboard.go
+++ b/newrelic/resource_newrelic_one_dashboard.go
@@ -557,9 +557,9 @@ func dashboardWidgetMarkdownSchemaElem() *schema.Resource {
 	delete(s, "nrql_query") // No queries for Markdown
 
 	s["text"] = &schema.Schema{
-		Type:     schema.TypeString,
-		Optional: true,
-		Default:  "",
+		Type:         schema.TypeString,
+		Required:     true,
+		ValidateFunc: validation.StringIsNotEmpty,
 	}
 
 	return &schema.Resource{


### PR DESCRIPTION
Update to the `text` field in `widget_markdown` in `one_dashboard` to avoid the following error seen when the field `text` is not specified in the configuration, or is specified as an empty string.

```
╷
│ Error: query error; Text field in markdown configuration can't be null
│ 
│   with newrelic_one_dashboard.foo,
│   on newrelic.tf line 13, in resource "newrelic_one_dashboard" "foo":
│   13: resource "newrelic_one_dashboard" "foo" {
│ 
╵
```