### PR TITLE
docs(cloud_integrations_guide): Fix missing a quote at cloud_integrations_guide.html.markdown

### DIFF
--- a/website/docs/guides/cloud_integrations_guide.html.markdown
+++ b/website/docs/guides/cloud_integrations_guide.html.markdown
@@ -31,7 +31,7 @@ module "newrelic-aws-cloud-integrations" {
   source = "github.com/newrelic/terraform-provider-newrelic/examples/modules/cloud-integrations/aws"
 
   newrelic_account_id     = 1234567
-  newrelic_account_region = "US
+  newrelic_account_region = "US"
   name                    = "production"
 }
 ```


### PR DESCRIPTION
# Description

Added missing `"` that causes syntax error.

## Type of change

N/A
## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation

## How to test this change?

N/A
