### PR TITLE
docs: updates and typo fixes to resource docs

### DIFF
--- a/website/docs/r/account_management.html.markdown
+++ b/website/docs/r/account_management.html.markdown
@@ -30,6 +30,11 @@ The following arguments are supported:
   * `region` - (Required) The region code of the account.  One of: `us01`, `eu01`.
 
 
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- `id` - The ID of the account created.
 
 ## Import
 

--- a/website/docs/r/notification_channel.html.markdown
+++ b/website/docs/r/notification_channel.html.markdown
@@ -64,15 +64,15 @@ Each notification channel type supports a specific set of arguments for the `pro
   * `project` - (Required) Identifier that specifies jira project id.
   * `issuetype` - (Required) Identifier that specifies the issue type id.
   * `description` - (Required) Free text that represents a description.
-  * `summary` - (Required) Free text that represents the summery.
+  * `summary` - (Required) Free text that represents the summary.
 * `EMAIL`
   * `subject` - (Optional) Free text that represents the email subject title.
   * `customDetailsEmail` - (Optional) Free text that represents the email custom details.
 * `PAGERDUTY_SERVICE_INTEGRATION`
-  * `summary` - (Required) Free text that represents the summery.
+  * `summary` - (Required) Free text that represents the summary.
   * `customDetails` - (Optional) Free text that *replaces* the content of the alert.
 * `PAGERDUTY_ACCOUNT_INTEGRATION`
-  * `summary` - (Required) Free text that represents the summery.
+  * `summary` - (Required) Free text that represents the summary.
   * `service` - (Required) Identifier that specifies the service id to alert to.
   * `email` - (Required) Specifies the user email for integrating with Pagerduty.
   * `customDetails` - (Optional) Free text that *replaces* the content of the alert.


### PR DESCRIPTION
# Description

- Fix typo in `notification_channel` docs.
- Add `id` as an exported attribute in the `account_management` resource. This fixes #2405 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have performed a self-review of my own code
