### PR TITLE
fix(synthetics): added error handling for monitor id when it is empty

### DIFF
--- a/newrelic/resource_newrelic_synthetics_alert_condition.go
+++ b/newrelic/resource_newrelic_synthetics_alert_condition.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/alerts"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/errors"
 )
@@ -33,10 +34,11 @@ func resourceNewRelicSyntheticsAlertCondition() *schema.Resource {
 				Description: "The title of this condition.",
 			},
 			"monitor_id": {
-				Type:        schema.TypeString,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Required:    true,
-				Description: "The ID of the Synthetics monitor to be referenced in the alert condition.",
+				Type:         schema.TypeString,
+				Elem:         &schema.Schema{Type: schema.TypeString},
+				Required:     true,
+				Description:  "The ID of the Synthetics monitor to be referenced in the alert condition.",
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 			"runbook_url": {
 				Type:        schema.TypeString,

--- a/newrelic/resource_newrelic_synthetics_alert_condition_test.go
+++ b/newrelic/resource_newrelic_synthetics_alert_condition_test.go
@@ -5,6 +5,7 @@ package newrelic
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -174,6 +175,37 @@ resource "newrelic_synthetics_alert_condition" "foo" {
 	monitor_id  = newrelic_synthetics_monitor.bar.id
 	runbook_url = "www.example-updated.com"
 	enabled     = "false"
+}
+`, name)
+}
+
+func TestAccNewRelicSyntheticsAlertConditionCheckMonitorIdEmpty(t *testing.T) {
+	rName := generateNameForIntegrationTestResource()
+	expectedMsg, _ := regexp.Compile("expected \"monitor_id\" to not be an empty string, got")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckEnvVars(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccNewRelicSyntheticsAlertConditionConfigCheckMonitorIdEmpty(rName),
+				ExpectError: expectedMsg,
+			},
+		},
+	})
+}
+
+func testAccNewRelicSyntheticsAlertConditionConfigCheckMonitorIdEmpty(name string) string {
+	return fmt.Sprintf(`
+resource "newrelic_alert_policy" "foo" {
+	name = "tf-test-%[1]s"
+}
+
+resource "newrelic_synthetics_alert_condition" "foo" {
+	policy_id   = newrelic_alert_policy.foo.id
+	name        = "tf-test-%[1]s"
+	monitor_id  = ""
+	runbook_url = "www.example.com"
+	enabled     = "true"
 }
 `, name)
 }


### PR DESCRIPTION
 added error handling for monitor id when it is empty

Fixes # (issue)
https://issues.newrelic.com/browse/NR-140492

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Step 1
- Step 2
- etc
