### PR TITLE
fix(service_level_alert_helper): Add bad events support

### DIFF
--- a/newrelic/data_source_newrelic_service_level_alert_helper.go
+++ b/newrelic/data_source_newrelic_service_level_alert_helper.go
@@ -139,16 +139,16 @@ func dataSourceNewRelicServiceLevelAlertHelperRead(ctx context.Context, d *schem
 
 	}
 
-    var nrql = "FROM Metric SELECT 100 - clamp_max(sum(newrelic.sli.good) / sum(newrelic.sli.valid) * 100, 100) as 'SLO compliance'  WHERE sli.guid = '"+sliGUID+"'"
+	var nrql = "FROM Metric SELECT 100 - clamp_max(sum(newrelic.sli.good) / sum(newrelic.sli.valid) * 100, 100) as 'SLO compliance'  WHERE sli.guid = '" + sliGUID + "'"
 
 	if isBadEvents {
-		nrql = "FROM Metric SELECT 100 - clamp_max((sum(newrelic.sli.valid) - sum(newrelic.sli.bad)) / sum(newrelic.sli.valid) * 100, 100) as 'SLO compliance' WHERE sli.guid = '"+sliGUID+"'"
-	} 
+		nrql = "FROM Metric SELECT 100 - clamp_max((sum(newrelic.sli.valid) - sum(newrelic.sli.bad)) / sum(newrelic.sli.valid) * 100, 100) as 'SLO compliance' WHERE sli.guid = '" + sliGUID + "'"
+	}
 
-    err := d.Set("nrql", nrql)
-    if err != nil {
-        return diag.FromErr(err)
-    }
+	err := d.Set("nrql", nrql)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	return nil
 }

--- a/newrelic/data_source_newrelic_service_level_alert_helper.go
+++ b/newrelic/data_source_newrelic_service_level_alert_helper.go
@@ -69,6 +69,11 @@ func dataSourceNewRelicServiceLevelAlertHelper() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"is_bad_events": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
@@ -82,6 +87,7 @@ func dataSourceNewRelicServiceLevelAlertHelperRead(ctx context.Context, d *schem
 	var sloPeriod = d.Get("slo_period").(int)
 	var sloTarget = d.Get("slo_target").(float64)
 	var alertType = d.Get("alert_type").(string)
+	var isBadEvents = d.Get("is_bad_events").(bool)
 
 	_, tOk := d.GetOk("custom_tolerated_budget_consumption")
 	_, eOk := d.GetOk("custom_evaluation_period")
@@ -133,9 +139,16 @@ func dataSourceNewRelicServiceLevelAlertHelperRead(ctx context.Context, d *schem
 
 	}
 
-	err := d.Set("nrql", "FROM Metric SELECT 100 - clamp_max(sum(newrelic.sli.good) / sum(newrelic.sli.valid) * 100, 100) as 'SLO compliance'  WHERE sli.guid = '"+sliGUID+"'")
-	if err != nil {
-		return diag.FromErr(err)
+	if isBadEvents {
+		err := d.Set("nrql", "FROM Metric SELECT 100 - clamp_max((sum(newrelic.sli.valid) - sum(newrelic.sli.bad)) / sum(newrelic.sli.valid) * 100, 100) as 'SLO compliance' WHERE sli.guid = '"+sliGUID+"'")
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	} else {
+		err := d.Set("nrql", "FROM Metric SELECT 100 - clamp_max(sum(newrelic.sli.good) / sum(newrelic.sli.valid) * 100, 100) as 'SLO compliance'  WHERE sli.guid = '"+sliGUID+"'")
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	return nil

--- a/newrelic/data_source_newrelic_service_level_alert_helper.go
+++ b/newrelic/data_source_newrelic_service_level_alert_helper.go
@@ -139,17 +139,16 @@ func dataSourceNewRelicServiceLevelAlertHelperRead(ctx context.Context, d *schem
 
 	}
 
+    var nrql = "FROM Metric SELECT 100 - clamp_max(sum(newrelic.sli.good) / sum(newrelic.sli.valid) * 100, 100) as 'SLO compliance'  WHERE sli.guid = '"+sliGUID+"'"
+
 	if isBadEvents {
-		err := d.Set("nrql", "FROM Metric SELECT 100 - clamp_max((sum(newrelic.sli.valid) - sum(newrelic.sli.bad)) / sum(newrelic.sli.valid) * 100, 100) as 'SLO compliance' WHERE sli.guid = '"+sliGUID+"'")
-		if err != nil {
-			return diag.FromErr(err)
-		}
-	} else {
-		err := d.Set("nrql", "FROM Metric SELECT 100 - clamp_max(sum(newrelic.sli.good) / sum(newrelic.sli.valid) * 100, 100) as 'SLO compliance'  WHERE sli.guid = '"+sliGUID+"'")
-		if err != nil {
-			return diag.FromErr(err)
-		}
-	}
+		nrql = "FROM Metric SELECT 100 - clamp_max((sum(newrelic.sli.valid) - sum(newrelic.sli.bad)) / sum(newrelic.sli.valid) * 100, 100) as 'SLO compliance' WHERE sli.guid = '"+sliGUID+"'"
+	} 
+
+    err := d.Set("nrql", nrql)
+    if err != nil {
+        return diag.FromErr(err)
+    }
 
 	return nil
 }

--- a/website/docs/d/service_level_alert_helper.html.markdown
+++ b/website/docs/d/service_level_alert_helper.html.markdown
@@ -12,7 +12,7 @@ Use this data source to obtain the necessary fields to set up alerts on your ser
 
 ## Example Usage
 
-Firstly set up your service level objective, we recommend to use local variables for the `target` and `time_window.rolling.count`, as they are also necessary for the helper.
+Firstly set up your service level objective, we recommend using local variables for the `target` and `time_window.rolling.count`, as they are also necessary for the helper.
 
 ```hcl
 locals {
@@ -49,6 +49,8 @@ resource "newrelic_service_level" "foo" {
 }
 ```
 Then use the helper to obtain the necessary fields to set up an alert on that Service Level.
+Note that the Service Level was set up using bad events, that's why `is_bad_events` is set to `true`.
+If the Service Level was configured with good events that would be unnecessary as the field defaults to `false`.
 
 ```hcl
 

--- a/website/docs/d/service_level_alert_helper.html.markdown
+++ b/website/docs/d/service_level_alert_helper.html.markdown
@@ -31,9 +31,9 @@ resource "newrelic_service_level" "foo" {
             from = "Transaction"
             where = "appName = 'Example application' AND (transactionType='Web')"
         }
-        good_events {
+        bad_events {
             from = "Transaction"
-            where = "appName = 'Example application' AND (transactionType= 'Web') AND duration < 0.1"
+            where = "appName = 'Example application' AND (transactionType= 'Web') AND duration > 0.1"
         }
     }
 
@@ -59,6 +59,7 @@ data "newrelic_service_level_alert_helper" "foo_custom" {
     slo_period = local.foo_period
     custom_tolerated_budget_consumption = 5
     custom_evaluation_period = 90
+    is_bad_events = true
 }
 
 resource "newrelic_nrql_alert_condition" "your_condition" {
@@ -100,6 +101,7 @@ The following arguments are supported:
   * `slo_period` - (Required) The time window of the Service Level Objective in days. Valid values are `1`, `7` and `28`.
   * `custom_tolerated_budget_consumption` - (Optional) How much budget you tolerate to consume during the custom evaluation period, valid values between `0` and `100`. Mandatory if `alert_type` is `custom`.
   * `custom_evaluation_period` - (Optional) Aggregation window taken into consideration in minutes. Mandatory if `alert_type` is `custom`.
+  * `is_bad_events` - (Optional) If the SLI is defined using bad events. Defaults to `false`
 
 ## Attributes Reference
 


### PR DESCRIPTION
# Description

Service Levels can be set up using good or bad events. Until now the newrelic_service_level_alert_helper only considered good events. We added the boolean field `is_bad_events` as a optional field that defaults to false, as the most common case is good events.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist:
- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?
Use the helper with bad events, for example using the updated example in the documentation
