### PR TITLE
fix(alert_condition): reverting default violation_close_timer 72 to prevent failures

### DIFF
--- a/newrelic/resource_newrelic_alert_condition.go
+++ b/newrelic/resource_newrelic_alert_condition.go
@@ -137,8 +137,7 @@ func resourceNewRelicAlertCondition() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ValidateFunc: validation.IntBetween(1, 720),
-				Default:      72,
-				Description:  "Automatically close instance-based incidents, including JVM health metric incidents, after the number of hours specified. Must be between 1 and 720 hours. Defaults to 72.",
+				Description:  "Automatically close instance-based incidents, including JVM health metric incidents, after the number of hours specified. Must be between 1 and 720 hours.",
 			},
 			"gc_metric": {
 				Type:        schema.TypeString,

--- a/website/docs/r/alert_condition.html.markdown
+++ b/website/docs/r/alert_condition.html.markdown
@@ -99,7 +99,9 @@ The following arguments are supported:
   * `condition_scope` - (Required for some types) `application` or `instance`.  Choose `application` for most scenarios.  If you are using the JVM plugin in New Relic, the `instance` setting allows your condition to trigger [for specific app instances](https://docs.newrelic.com/docs/alerts/new-relic-alerts/defining-conditions/scope-alert-thresholds-specific-instances).
   * `enabled` - (Optional) Whether the condition is enabled or not. Defaults to true.
   * `gc_metric` - (Optional) A valid Garbage Collection metric e.g. `GC/G1 Young Generation`.
-  * `violation_close_timer` - (Optional) Automatically close instance-based incidents, including JVM health metric incidents, after the number of hours specified. Must be between 1 and 720 hours. Defaults to 72.
+  * `violation_close_timer` - (Optional) Automatically close instance-based incidents, including JVM health metric incidents, after the number of hours specified. Must be between 1 and 720 hours. Must be specified in the following two cases, to prevent drift:
+    * when `type` = `apm_app_metric` and `condition_scope` = `instance`
+    * when `type` = `apm_jvm_metric`
   * `runbook_url` - (Optional) Runbook URL to display in notifications.
   * `term` - (Required) A list of terms for this condition. See [Terms](#terms) below for details.
   * `user_defined_metric` - (Optional) A custom metric to be evaluated.


### PR DESCRIPTION
# Description

This PR fixes the following linked issue that was caused by a PR merged earlier (https://github.com/newrelic/terraform-provider-newrelic/pull/2402/files), which is now leading to an issue in which the attribute `violation_close_timer` is defaulting to 72 for all types of conditions, which is not expected, and is hence, leading to an API validation issue.

Since the approach towards conditionally varying this default value only in two cases (when `type` is `apm_jvm_metric` (OR) when `type` is `apm_app_metric` and `condition_scope` is `instance`) is not straightforward yet (this might need modifications directly in the create/update functions to set defaults only when these conditions are true, and proper state management upon read, to infer that 72 is the default value and is expected to cause no drift), this PR fixes the issue in the interim by reverting the default value set.

Fixes #2418 

