### PR TITLE
fix: newrelic_notification_channel property to be optional

### DIFF
--- a/newrelic/resource_newrelic_notifications_channel.go
+++ b/newrelic/resource_newrelic_notifications_channel.go
@@ -59,7 +59,7 @@ func resourceNewRelicNotificationChannel() *schema.Resource {
 			},
 			"property": {
 				Type:        schema.TypeSet,
-				Required:    true,
+				Required:    false,
 				Description: "Notification channel property type.",
 				Elem:        notificationsPropertySchema(),
 			},


### PR DESCRIPTION
# Description

Some of newrelic_notification_channel types (e.g. `EMAIL`) does not require property and it shouldn't be a required value. 

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [ x ] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ x ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Step 1
- Step 2
- etc
