### PR TITLE
feat(newrelic_entity): fetch entity in different account

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ Client][client_go] and the only changes you need to make are in the provider
 code.  In that case, simply building the provider binary with the correct name
 and running the plan will get you there. The following assumes working on MacOS.
 
-To compile a new version of the compiler, run the following command in the root
+To compile a new version of the provider, run the following command in the root
 directory of the repository. You will need to run this command every time you
 make a code change.
 
@@ -161,7 +161,7 @@ make compile
 
 To test your locally compiled plugin you can add your hcl files in the `testing`
 directory. The `testing/dev.tfrc` file contains the local development configuration.
-Before running any Terraform commands don't forgot to change the authentication
+Before running any Terraform commands don't forget to change the authentication
 credentials in `testing/newrelic.tf` or use environment variables as mentioned above.
 Additionally run the following command, or add it to your shell profile: `export TF_CLI_CONFIG_FILE=dev.tfrc`
 

--- a/newrelic/data_source_newrelic_entity.go
+++ b/newrelic/data_source_newrelic_entity.go
@@ -68,7 +68,7 @@ func dataSourceNewRelicEntity() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Computed:     true,
-				Description:  "The New Relic account ID associated with this entity. Overrides the account ID configured in the provider, if specified.",
+				Description:  "The New Relic account ID; constrains the data source to return an entity belonging to the account with this ID, of all matching entities retrieved.",
 				ValidateFunc: validation.IntAtLeast(1),
 			},
 			"application_id": {

--- a/newrelic/data_source_newrelic_entity.go
+++ b/newrelic/data_source_newrelic_entity.go
@@ -68,7 +68,7 @@ func dataSourceNewRelicEntity() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Computed:     true,
-				Description:  "The New Relic account ID; constrains the data source to return an entity belonging to the account with this ID, of all matching entities retrieved.",
+				Description:  "The New Relic account ID; if specified, constrains the data source to return an entity belonging to the account with this ID, of all matching entities retrieved.",
 				ValidateFunc: validation.IntAtLeast(1),
 			},
 			"application_id": {

--- a/newrelic/data_source_newrelic_entity_integration_test.go
+++ b/newrelic/data_source_newrelic_entity_integration_test.go
@@ -151,10 +151,10 @@ data "newrelic_entity" "entity" {
 	}
 	tag {
 		key = "account"
-		value = "New Relic Terraform Provider Acceptance Testing"
+		value = "%s"
 	}
 }
-`, name, accountId)
+`, name, accountId, testAccountName)
 }
 
 // The test entity for this data source is created in provider_test.go
@@ -186,10 +186,10 @@ data "newrelic_entity" "entity" {
 	}
 	tag {
 		key = "account"
-		value = "New Relic Terraform Provider Acceptance Testing"
+		value = "%s"
 	}
 }
-`, name, accountId)
+`, name, accountId, testAccountName)
 }
 
 // The test entity for this data source is created in provider_test.go
@@ -205,10 +205,10 @@ data "newrelic_entity" "entity" {
 	}
 	tag {
 		key = "account"
-		value = "New Relic Terraform Provider Acceptance Testing"
+		value = "%s"
 	}
 }
-`, name, accountId)
+`, name, accountId, testAccountName)
 }
 
 // testAccNewRelicEntityDataConfig_EntityInSubAccount checks if the entity retrieved by applying

--- a/newrelic/data_source_newrelic_entity_integration_test.go
+++ b/newrelic/data_source_newrelic_entity_integration_test.go
@@ -82,6 +82,7 @@ func TestAccNewRelicEntityData_IgnoreCase(t *testing.T) {
 	})
 }
 
+// TODO: @pranav-new-relic promissed to fix this and make it more maintainable ^_^
 func TestAccNewRelicEntityData_EntityInSubAccount(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -142,15 +143,17 @@ func testAccCheckNewRelicEntityDataExists(t *testing.T, n string, appName string
 func testAccNewRelicEntityDataConfig(name string, accountId int) string {
 	return fmt.Sprintf(`
 data "newrelic_entity" "entity" {
-	name = "%s"
-	type = "application"
+	name   = "%s"
+	type   = "application"
 	domain = "apm"
+
 	tag {
-		key = "accountId"
+		key   = "accountId"
 		value = "%d"
 	}
+
 	tag {
-		key = "account"
+		key   = "account"
 		value = "%s"
 	}
 }
@@ -161,10 +164,11 @@ data "newrelic_entity" "entity" {
 func testAccNewRelicEntityDataConfig_IgnoreCase(name string, accountId int) string {
 	return fmt.Sprintf(`
 data "newrelic_entity" "entity" {
-	name = "%s"
+	name        = "%s"
 	ignore_case = true
-	type = "application"
-	domain = "apm"
+	type        = "application"
+	domain      = "apm"
+
 	tag {
 		key = "accountId"
 		value = "%d"
@@ -177,15 +181,17 @@ data "newrelic_entity" "entity" {
 func testAccNewRelicEntityDataConfig_InvalidType(name string, accountId int) string {
 	return fmt.Sprintf(`
 data "newrelic_entity" "entity" {
-	name = "%s"
-	type = "app"
+	name   = "%s"
+	type   = "app"
 	domain = "apm"
+
 	tag {
-		key = "accountId"
+		key   = "accountId"
 		value = "%d"
 	}
+
 	tag {
-		key = "account"
+		key   = "account"
 		value = "%s"
 	}
 }
@@ -196,15 +202,17 @@ data "newrelic_entity" "entity" {
 func testAccNewRelicEntityDataConfig_InvalidDomain(name string, accountId int) string {
 	return fmt.Sprintf(`
 data "newrelic_entity" "entity" {
-	name = "%s"
-	type = "application"
+	name   = "%s"
+	type   = "application"
 	domain = "VIZ"
+
 	tag {
-		key = "accountId"
+		key   = "accountId"
 		value = "%d"
 	}
+
 	tag {
-		key = "account"
+		key   = "account"
 		value = "%s"
 	}
 }
@@ -216,16 +224,16 @@ data "newrelic_entity" "entity" {
 // with an identical name in the main account (NEW_RELIC_ACCOUNT_ID).
 func testAccNewRelicEntityDataConfig_EntityInSubAccount(name string, subAccountID int) string {
 	return fmt.Sprintf(`
-			provider "newrelic" {
-  				account_id = %d
-  				alias      = "entity-data-source-test-provider"
-			}
+provider "newrelic" {
+	account_id = %d
+	alias      = "entity-data-source-test-provider"
+}
 
-			data "newrelic_entity" "entity" {
-				provider = newrelic.entity-data-source-test-provider
-				name = "%s"
-				type = "APPLICATION"
-				domain = "APM"
-			}
+data "newrelic_entity" "entity" {
+	provider = newrelic.entity-data-source-test-provider
+	name     = "%s"
+	type     = "APPLICATION"
+	domain   = "APM"
+}
 `, subAccountID, name)
 }

--- a/website/docs/d/entity.html.markdown
+++ b/website/docs/d/entity.html.markdown
@@ -105,8 +105,8 @@ data "newrelic_entity" "app" { # sub-account
 
 The following arguments are supported:
 
-* `account_id` - The New Relic account ID associated with this entity. This attribute overrides a `provider` block account ID.
 * `name` - (Required) The name of the entity in New Relic One.  The first entity matching this name for the given search parameters will be returned.
+* `account_id` - (Optional) The New Relic account ID associated with this entity. This attribute overrides a `provider` block account ID.
 * `ignore_case` - (Optional) Ignore case of the `name` when searching for the entity. Defaults to false.
 * `type` - (Optional) The entity's type. Valid values are APPLICATION, DASHBOARD, HOST, MONITOR, WORKLOAD, AWSLAMBDAFUNCTION, SERVICE_LEVEL, and KEY_TRANSACTION. Note: Other entity types may also be queryable as the list of entity types may fluctuate over time.
 * `domain` - (Optional) The entity's domain. Valid values are APM, BROWSER, INFRA, MOBILE, SYNTH, and EXT. If not specified, all domains are searched.

--- a/website/docs/d/entity.html.markdown
+++ b/website/docs/d/entity.html.markdown
@@ -61,7 +61,65 @@ data "newrelic_entity" "app" {
 }
 ```
 
-### Filter by account ID
+### Example: Filter By Account ID
+
+The default behaviour of this data source is to retrieve entities matching the specified parameters (`name`, `domain`, `type`) from NerdGraph with the credentials specified in the configuration of the provider (account ID and API Key), filter them by the account ID specified in the configuration of the provider, and return the first match. 
+
+This would mean, if no entity with the specified search parameters is found associated with the account ID in the configuration of the provider, i.e. `NEW_RELIC_ACCOUNT_ID`, an error is thrown, stating that no matching entity has been found.
+
+```hcl
+# The entity returned by this configuration would have to 
+# belong to the account_id specified in the provider 
+# configuration, i.e. NEW_RELIC_ACCOUNT_ID.
+data "newrelic_entity" "app" {
+  name   = "my-app"
+  domain = "APM"
+  type   = "APPLICATION"
+}
+```
+However, in order to cater to scenarios in which it could be necessary to retrieve an entity belonging to a subaccount using the account ID and API Key of the parent account (for instance, when entities with identical names are present in both the parent account and subaccounts, since matching entities from subaccounts too are returned by NerdGraph), the `account_id` attribute of this data source may be availed. This ensures that the account ID in the configuration of the provider, used to filter entities returned by the API is now overridden by the `account_id` specified in the configuration; i.e., in the below example, the data source would now return an entity matching the specified `name`, belonging to the account with `account_id`.
+```hcl
+# The entity returned by this configuration, unlike in 
+# the above example, would have to belong to the account_id 
+# specified in the configuration below, i.e. 654321.
+data "newrelic_entity" "app" {
+  name       = "my-app"
+  account_id = 654321
+  domain     = "APM"
+  type       = "APPLICATION"
+}
+```
+The following example explains a use case along the lines of the aforementioned; using the `account_id` argument in the data source to allow the filtering criteria to be the `account_id` specified (of the subaccount), and not the account ID in the provider configuration. 
+
+In simpler terms, when entities are queried from the parent account, entities with matching names are returned from subaccounts too, hence, specifying the `account_id` of the subaccount in the configuration allows the entity returned to belong to the subaccount with `account_id`.
+```hcl
+# The `account_id` specified in the configuration of the
+# provider is that of the parent account.
+provider "newrelic" {
+  account_id = "12345"
+  ..
+}
+
+# A subaccount is created using the `newrelic_account_management` 
+# resource.
+resource "newrelic_account_management" "default" { 
+  name   = "Sample Subaccount"
+  region = "us01"
+}
+
+# The ID of the subaccount is specified in the configuration
+# to allow the entity returned to belong to the subaccount.
+data "newrelic_entity" "app" {
+  account_id = newrelic_account_management.default.id 
+  name       = "my-app"
+  domain     = "APM"
+  type       = "APPLICATION"
+}
+```
+
+The `accountId` tag may also be added to the configuration of this data source as specified below. 
+
+-> **NOTE:** Not to be confused with the `account_id` argument of this data source that helps filter entities retrieved from the API by the specified `account_id` and return a matching entity, adding the `accountId` tag adds the specified account to the NRQL Query that is sent to NerdGraph, i.e. it causes entities not matching `accountId` to be filtered out of the API response that is received by this data source. The entity that is finally returned by this data source, however, is the one that has an account ID matching the account ID specified in the provider configuration, or the `account_id` attribute, as specified in the examples above.
 
 ```hcl
 # The `accountId` tag is automatically added to all entities by the platform.
@@ -71,42 +129,20 @@ data "newrelic_entity" "app" {
   type = "APPLICATION"
   tag {
     key = "accountID"
-    value = "12345"
+    value = "345211"
   }
 }
 ```
 
-By default data source returns entity from the same account as provider's one. This behaviour can be overridden by setting `account_id` attribute, which allows to fetch entity from the different account. For example, if provider has been configured with parent account to deploy a new sub-account it still can fetch sub-account entity in the same configuration:
 
-```hcl
-provider "newrelic" {
-  account_id = "12345" # parent account
-}
 
-resource "newrelic_account_management" "default" { # sub-account
-  name   = "Acme Inc"
-  region = "us01"
-}
-
-data "newrelic_entity" "app" { # sub-account
-  account_id = newrelic_account_management.default.id # without explicit attribute setting this entity won't be found
-  name       = "my-app"
-  domain     = "APM"
-  type       = "APPLICATION"
-
-  tag {
-    key   = "accountID"
-    value = newrelic_account_management.default.id
-  }
-}
-```
 
 ## Argument Reference
 
 The following arguments are supported:
 
 * `name` - (Required) The name of the entity in New Relic One.  The first entity matching this name for the given search parameters will be returned.
-* `account_id` - (Optional) The New Relic account ID associated with this entity. This attribute overrides a `provider` block account ID.
+* `account_id` - (Optional) The New Relic account ID the entity to be returned would be associated with, i.e. if specified, the data source would filter matching entities received by `account_id` and return the first match. If not, matching entities are filtered by the account ID specified in the configuration of the provider. See the **Example: Filter By Account ID** section above for more details.
 * `ignore_case` - (Optional) Ignore case of the `name` when searching for the entity. Defaults to false.
 * `type` - (Optional) The entity's type. Valid values are APPLICATION, DASHBOARD, HOST, MONITOR, WORKLOAD, AWSLAMBDAFUNCTION, SERVICE_LEVEL, and KEY_TRANSACTION. Note: Other entity types may also be queryable as the list of entity types may fluctuate over time.
 * `domain` - (Optional) The entity's domain. Valid values are APM, BROWSER, INFRA, MOBILE, SYNTH, and EXT. If not specified, all domains are searched.


### PR DESCRIPTION
# Description

By default `newrelic_entity` data source returns an entity from the same account as provider's one. This change provides an option to override this behaviour by setting `account_id` attribute, which allows to fetch entity from the different account. For example, if provider has been configured with a parent account to deploy a new sub-account it still can fetch sub-account entity in the same configuration:

```hcl
provider "newrelic" {
  account_id = "12345" # parent account
}

resource "newrelic_account_management" "default" { # sub-account
  name   = "Acme Inc"
  region = "us01"
}

data "newrelic_entity" "app" { # sub-account
  account_id = newrelic_account_management.default.id # without explicit attribute setting this entity won't be found
  name       = "my-app"
  domain     = "APM"
  type       = "APPLICATION"

  tag {
    key   = "accountID"
    value = newrelic_account_management.default.id
  }
}
```

Closes #2425

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [x] This change requires acctest update

## Checklist

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic#testing) for instructions on running tests locally.

## Testing

### Unit

```
$ make test-unit
...
DONE 73 tests in 4.416s
```

### Acceptance

```
$ TF_ACC=1 gotestsum -f testname -- -v --tags=integration -timeout 10m ./newrelic --run TestAccNewRelicEntityData
PASS newrelic.TestAccNewRelicEntityData_Missing (8.14s)
PASS newrelic.TestAccNewRelicEntityData_EntityAbsentInSubAccount (8.36s)
PASS newrelic.TestAccNewRelicEntityData_IgnoreCase (9.68s)
=== RUN   TestAccNewRelicEntityData_EntityInSubAccount
=== PAUSE TestAccNewRelicEntityData_EntityInSubAccount
=== CONT  TestAccNewRelicEntityData_EntityInSubAccount
=== CONT  TestAccNewRelicEntityData_EntityInSubAccount
    provider_test.go:237: testacc cleanup of 0 applications complete
=== CONT  TestAccNewRelicEntityData_EntityInSubAccount
    data_source_newrelic_entity_integration_test.go:86: Step 1/1 error: Error running pre-apply refresh: exit status 1

        Error: no entities found for the provided search parameters, please ensure your schema attributes are valid

          with data.newrelic_entity.entity,
          on terraform_plugin_test.tf line 8, in data "newrelic_entity" "entity":
           8: 			data "newrelic_entity" "entity" {

--- FAIL: TestAccNewRelicEntityData_EntityInSubAccount (9.86s)
FAIL newrelic.TestAccNewRelicEntityData_EntityInSubAccount (9.86s)
PASS newrelic.TestAccNewRelicEntityData_Basic (11.85s)
FAIL newrelic

=== Failed
=== FAIL: newrelic TestAccNewRelicEntityData_EntityInSubAccount (9.86s)
    provider_test.go:237: testacc cleanup of 0 applications complete
    data_source_newrelic_entity_integration_test.go:86: Step 1/1 error: Error running pre-apply refresh: exit status 1

        Error: no entities found for the provided search parameters, please ensure your schema attributes are valid

          with data.newrelic_entity.entity,
          on terraform_plugin_test.tf line 8, in data "newrelic_entity" "entity":
           8: 			data "newrelic_entity" "entity" {


DONE 5 tests, 1 failure in 14.744s
```

The target acceptance test fails because the account IDs are hardcoded. As I understand the main problem with the current provider test setup is **unconditional** APM application creation – it always appears in the main/parent account (the one `NEW_RELIC_ACCOUNT_ID` references) and there is no way to parametrise it from the acctest atm. That's why different APM application name (`"Dummy App Two"`) and hardcoded account (`3814156`) and subaccount (`3957524`) IDs are present in the code.

## How to test this change?

1. Switch to local provider:
```
$ export TF_CLI_CONFIG_FILE=dev.tfrc
```
2. Compile local provider:
```
$ make compile
```
3. Note the parent/primary/default account ID as `accountId`.
4. Create a sub-account and note it's ID as `subAccountId`.
5. Set `NEW_RELIC_API_KEY` env var with your personal user API key with admin permissions.
6. Set `NEW_RELIC_REGION` env var to `US` value.
7.  Set `NEW_RELIC_ACCOUNT_ID` env var  to `<accountId>` value from the step 3
8.  Create APM entity in sub-account.
9. Add `main.tf` file to `testing` folder with the next content:
```
data "newrelic_entity" "app" {
  account_id = <subAccountId> # value from step 4
  name       = "my-app"
  domain     = "APM"
  type       = "APPLICATION"

  tag {
    key   = "accountID"
    value = <subAccountId>
  }
}

output "account_id" {
  value = data.newrelic_entity.app.account_id
}
```
10. Run Terraform:
```
$ terraform apply -auto-approve
...
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

account_id = <subAccountId>
```
11. The entity has to be found.