### PR TITLE
fix(workflows): ignore notification trigger order when comparing state

### DIFF
--- a/newrelic/resource_newrelic_workflow_test.go
+++ b/newrelic/resource_newrelic_workflow_test.go
@@ -365,6 +365,33 @@ func TestNewRelicWorkflow_BooleanFlags_DisableOnCreation(t *testing.T) {
 	})
 }
 
+func TestNewRelicWorkflow_NotificationTriggerShouldIgnoreOrder(t *testing.T) {
+	resourceName := "newrelic_workflow.foo"
+	rName := generateNameForIntegrationTestResource()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccNewRelicWorkflowDestroy,
+		Steps: []resource.TestStep{
+			// Test: Create workflow with non-standard trigger order
+			{
+				Config: testAccNewRelicWorkflowConfigurationWithNotificationTriggers(testAccountID, rName, `["CLOSED", "ACTIVATED"]`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicWorkflowExists(resourceName),
+				),
+			},
+			// Test: Update trigger order
+			{
+				Config: testAccNewRelicWorkflowConfigurationWithNotificationTriggers(testAccountID, rName, `["ACKNOWLEDGED", "ACTIVATED", "CLOSED"]`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicWorkflowExists(resourceName),
+				),
+			},
+		},
+	})
+}
+
 func testAccNewRelicWorkflowConfigurationMinimal(accountID int, name string) string {
 	return fmt.Sprintf(`
 resource "newrelic_notification_destination" "foo" {


### PR DESCRIPTION
# Description

Workflow notification triggers is an ordered set that is currently represented in Terraform as an ordered list.
Our backend does not preserve the order of the given notification triggers.

As a result, if a workflow resource notification trigger does not match the order returned by NR API, Terraform reports a state drift when there isn't any.

This PR makes sure to keep the notification trigger order the same as in the existing state.

I could not use `DiffSuppressFunc` because notification triggers are a part of another property that itself is a set. Because Terraform uses a hash of the set item as its key, if notification triggers changes, TF thinks that the entire parent set item was removed and then the new one was added. So diff suppressing would only work for the entire parent set property, which is just not really feasible and would be extremely ugly.

Fixes #2433

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

There is an integration test that reproduces the problem.

In order to reproduce the problem manually, you need to create workflow with notification triggers in a "wrong" order.
For example, `[CLOSED, ACTIVATED]`. Without the fix, the workflow would be successfully applied, but TF would report state drift on `plan`

