### PR TITLE
chore: bump-up client-go version to v2.20.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.20.3
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.19.6
+	github.com/newrelic/newrelic-client-go/v2 v2.20.0
 	github.com/stretchr/testify v1.8.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -273,8 +273,8 @@ github.com/newrelic/go-agent/v3 v3.20.3 h1:hUBAMq/Y2Y9as5/yxQbf0zNde/X7w58cWZkm2
 github.com/newrelic/go-agent/v3 v3.20.3/go.mod h1:rT6ZUxJc5rQbWLyCtjqQCOcfb01lKRFbc1yMQkcboWM=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.19.6 h1:nKMVor/8ujdF37dipVzk+Tq13Mv3bEfGDDSW63C8PY0=
-github.com/newrelic/newrelic-client-go/v2 v2.19.6/go.mod h1:VPWTvEfKvnTZLunAC7fiW33y4e0srznNfN5HJH2cOp8=
+github.com/newrelic/newrelic-client-go/v2 v2.20.0 h1:87aHvOCnv8MeZL6pm4VptjZKFxatmQq//35onHGBVic=
+github.com/newrelic/newrelic-client-go/v2 v2.20.0/go.mod h1:VPWTvEfKvnTZLunAC7fiW33y4e0srznNfN5HJH2cOp8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=


### PR DESCRIPTION
Upgrade newrelic-client-go to the latest version, [v2.20.0](https://github.com/newrelic/newrelic-client-go/releases/tag/v2.20.0).