### PR TITLE
fix(private_location): addition of key to attributes exported by the data source

### DIFF
--- a/website/docs/d/synthetics_private_location.html.markdown
+++ b/website/docs/d/synthetics_private_location.html.markdown
@@ -43,3 +43,9 @@ The following arguments are supported:
 
 * `account_id` - (Optional) The New Relic account ID of the associated private location. If left empty will default to account ID specified in provider level configuration.
 * `name` - (Required) The name of the Synthetics monitor private location.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `key` - The key of the private location.


### PR DESCRIPTION
# Description

This PR addresses the addition of the **key** of the private location to the list of attributes exported by the data source **newrelic_synthetics_private_location**.

depends on changes in **newrelic-client-go** https://github.com/newrelic/newrelic-client-go/pull/1051

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.