### PR TITLE
feat(synthetics): Enable device emulation for simple browser synthetics

### DIFF
--- a/newrelic/resource_newrelic_synthetics_monitor.go
+++ b/newrelic/resource_newrelic_synthetics_monitor.go
@@ -164,6 +164,16 @@ func resourceNewRelicSyntheticsMonitor() *schema.Resource {
 					},
 				},
 			},
+			"device_orientation": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The device orientation the user would like to represent. Valid values are LANDSCAPE, PORTRAIT, or NONE.",
+			},
+			"device_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The device type that a user can select. Valid values are MOBILE, TABLET, or NONE.",
+			},
 		},
 	}
 }

--- a/newrelic/resource_newrelic_synthetics_monitor.go
+++ b/newrelic/resource_newrelic_synthetics_monitor.go
@@ -237,6 +237,8 @@ func setAttributesFromCreate(res *synthetics.SyntheticsSimpleBrowserMonitorCreat
 	_ = d.Set("uri", res.Monitor.Uri)
 	_ = d.Set("locations_public", res.Monitor.Locations.Public)
 	_ = d.Set("locations_private", res.Monitor.Locations.Private)
+	_ = d.Set("device_orientation", res.Monitor.AdvancedOptions.DeviceEmulation.DeviceOrientation)
+	_ = d.Set("device_type", res.Monitor.AdvancedOptions.DeviceEmulation.DeviceType)
 
 	if res.Monitor.Runtime.RuntimeType != "" {
 		_ = d.Set("runtime_type", res.Monitor.Runtime.RuntimeType)
@@ -407,6 +409,8 @@ func setSimpleBrowserAttributesFromUpdate(res *synthetics.SyntheticsSimpleBrowse
 	_ = d.Set("enable_screenshot_on_failure_and_script", res.Monitor.AdvancedOptions.EnableScreenshotOnFailureAndScript)
 	_ = d.Set("locations_public", res.Monitor.Locations.Public)
 	_ = d.Set("locations_private", res.Monitor.Locations.Private)
+	_ = d.Set("device_orientation", res.Monitor.AdvancedOptions.DeviceEmulation.DeviceOrientation)
+	_ = d.Set("device_type", res.Monitor.AdvancedOptions.DeviceEmulation.DeviceType)
 
 	if res.Monitor.Runtime.RuntimeType != "" {
 		_ = d.Set("runtime_type", res.Monitor.Runtime.RuntimeType)

--- a/newrelic/resource_newrelic_synthetics_monitor.go
+++ b/newrelic/resource_newrelic_synthetics_monitor.go
@@ -325,6 +325,18 @@ func setCommonSyntheticsMonitorAttributes(v *entities.EntityInterface, d *schema
 					_ = d.Set("verify_ssl", v)
 				}
 			}
+
+			if t.Key == "deviceOrientation" {
+				if len(t.Values) == 1 {
+					_ = d.Set("device_orientation", t.Values[0])
+				}
+			}
+
+			if t.Key == "deviceType" {
+				if len(t.Values) == 1 {
+					_ = d.Set("device_type", t.Values[0])
+				}
+			}
 		}
 	}
 }

--- a/newrelic/resource_newrelic_synthetics_monitor_test.go
+++ b/newrelic/resource_newrelic_synthetics_monitor_test.go
@@ -58,6 +58,8 @@ func TestAccNewRelicSyntheticsSimpleMonitor(t *testing.T) {
 					"tag",
 					"enable_screenshot_on_failure_and_script",
 					"custom_header",
+					"device_orientation",
+					"device_type",
 				},
 			},
 		},
@@ -85,6 +87,8 @@ resource "newrelic_synthetics_monitor" "foo" {
 		values = ["pizza"]
 	}
 	uri = "https://www.one.newrelic.com"
+	device_orientation = "PORTRAIT"
+	device_type = "MOBILE"
 }`, name, monitorType)
 }
 
@@ -109,6 +113,8 @@ resource "newrelic_synthetics_monitor" "foo" {
 		values = ["pizza", "cake"]
 	}
 	uri = "https://www.one.newrelic.com"
+	device_orientation = "LANDSCAPE"
+	device_type = "TABLET"
 }`, name, monitorType)
 }
 
@@ -152,6 +158,8 @@ func TestAccNewRelicSyntheticsSimpleBrowserMonitor(t *testing.T) {
 					"runtime_type_version",
 					"runtime_type",
 					"script_language",
+					"device_orientation",
+					"device_type",
 				},
 			},
 		},
@@ -181,6 +189,8 @@ func testAccNewRelicSyntheticsSimpleBrowserMonitorConfig(name string, monitorTyp
 		status	=	"ENABLED"
 		type	=	"%s"
 		uri	=	"https://www.one.newrelic.com"
+		device_orientation = "PORTRAIT"
+		device_type = "MOBILE"
 	}`, name, monitorType)
 }
 
@@ -203,6 +213,8 @@ func testAccNewRelicSyntheticsSimpleBrowserMonitorConfigUpdated(name string, mon
 			status	=	"DISABLED"
 			type	=	"%s"
 			uri	=	"https://www.one.newrelic.com"
+			device_orientation = "PORTRAIT"
+			device_type = "MOBILE"
 		}`, name, monitorType)
 }
 

--- a/newrelic/resource_newrelic_synthetics_monitor_test.go
+++ b/newrelic/resource_newrelic_synthetics_monitor_test.go
@@ -183,6 +183,8 @@ func testAccNewRelicSyntheticsSimpleBrowserMonitorConfig(name string, monitorTyp
 		status	=	"ENABLED"
 		type	=	"%s"
 		uri	=	"https://www.one.newrelic.com"
+		device_orientation = "PORTRAIT"
+		device_type = "MOBILE"
 	}`, name, monitorType)
 }
 
@@ -205,6 +207,8 @@ func testAccNewRelicSyntheticsSimpleBrowserMonitorConfigUpdated(name string, mon
 			status	=	"DISABLED"
 			type	=	"%s"
 			uri	=	"https://www.one.newrelic.com"
+			device_orientation = "LANDSCAPE"
+			device_type = "TABLET"
 		}`, name, monitorType)
 }
 

--- a/newrelic/resource_newrelic_synthetics_monitor_test.go
+++ b/newrelic/resource_newrelic_synthetics_monitor_test.go
@@ -213,8 +213,8 @@ func testAccNewRelicSyntheticsSimpleBrowserMonitorConfigUpdated(name string, mon
 			status	=	"DISABLED"
 			type	=	"%s"
 			uri	=	"https://www.one.newrelic.com"
-			device_orientation = "PORTRAIT"
-			device_type = "MOBILE"
+			device_orientation = "LANDSCAPE"
+			device_type = "TABLET"
 		}`, name, monitorType)
 }
 

--- a/newrelic/resource_newrelic_synthetics_monitor_test.go
+++ b/newrelic/resource_newrelic_synthetics_monitor_test.go
@@ -116,7 +116,7 @@ func TestAccNewRelicSyntheticsSimpleBrowserMonitor(t *testing.T) {
 	resourceName := "newrelic_synthetics_monitor.bar"
 	rName := generateNameForIntegrationTestResource()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicSyntheticsMonitorDestroy,

--- a/newrelic/resource_newrelic_synthetics_monitor_test.go
+++ b/newrelic/resource_newrelic_synthetics_monitor_test.go
@@ -183,8 +183,6 @@ func testAccNewRelicSyntheticsSimpleBrowserMonitorConfig(name string, monitorTyp
 		status	=	"ENABLED"
 		type	=	"%s"
 		uri	=	"https://www.one.newrelic.com"
-		device_orientation = "PORTRAIT"
-		device_type = "MOBILE"
 	}`, name, monitorType)
 }
 
@@ -207,8 +205,6 @@ func testAccNewRelicSyntheticsSimpleBrowserMonitorConfigUpdated(name string, mon
 			status	=	"DISABLED"
 			type	=	"%s"
 			uri	=	"https://www.one.newrelic.com"
-			device_orientation = "LANDSCAPE"
-			device_type = "TABLET"
 		}`, name, monitorType)
 }
 

--- a/newrelic/resource_newrelic_synthetics_monitor_test.go
+++ b/newrelic/resource_newrelic_synthetics_monitor_test.go
@@ -116,7 +116,7 @@ func TestAccNewRelicSyntheticsSimpleBrowserMonitor(t *testing.T) {
 	resourceName := "newrelic_synthetics_monitor.bar"
 	rName := generateNameForIntegrationTestResource()
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckEnvVars(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicSyntheticsMonitorDestroy,

--- a/newrelic/resource_newrelic_synthetics_monitor_test.go
+++ b/newrelic/resource_newrelic_synthetics_monitor_test.go
@@ -58,8 +58,6 @@ func TestAccNewRelicSyntheticsSimpleMonitor(t *testing.T) {
 					"tag",
 					"enable_screenshot_on_failure_and_script",
 					"custom_header",
-					"device_orientation",
-					"device_type",
 				},
 			},
 		},
@@ -87,8 +85,6 @@ resource "newrelic_synthetics_monitor" "foo" {
 		values = ["pizza"]
 	}
 	uri = "https://www.one.newrelic.com"
-	device_orientation = "PORTRAIT"
-	device_type = "MOBILE"
 }`, name, monitorType)
 }
 
@@ -113,8 +109,6 @@ resource "newrelic_synthetics_monitor" "foo" {
 		values = ["pizza", "cake"]
 	}
 	uri = "https://www.one.newrelic.com"
-	device_orientation = "LANDSCAPE"
-	device_type = "TABLET"
 }`, name, monitorType)
 }
 

--- a/newrelic/structures_newrelic_synthetics_simple_browser_monitor.go
+++ b/newrelic/structures_newrelic_synthetics_simple_browser_monitor.go
@@ -13,6 +13,9 @@ func buildSyntheticsSimpleBrowserMonitor(d *schema.ResourceData) synthetics.Synt
 		Period: inputBase.Period,
 		Status: inputBase.Status,
 		Tags:   inputBase.Tags,
+		AdvancedOptions: synthetics.SyntheticsSimpleBrowserMonitorAdvancedOptionsInput{
+			DeviceEmulation: &synthetics.SyntheticsDeviceEmulationInput{},
+		},
 	}
 
 	if v, ok := d.GetOk("custom_header"); ok {
@@ -65,6 +68,14 @@ func buildSyntheticsSimpleBrowserMonitor(d *schema.ResourceData) synthetics.Synt
 		}
 	}
 
+	if v, ok := d.GetOk("device_orientation"); ok {
+		simpleBrowserMonitorInput.AdvancedOptions.DeviceEmulation.DeviceOrientation = synthetics.SyntheticsDeviceOrientation(v.(string))
+	}
+
+	if v, ok := d.GetOk("device_type"); ok {
+		simpleBrowserMonitorInput.AdvancedOptions.DeviceEmulation.DeviceType = synthetics.SyntheticsDeviceType(v.(string))
+	}
+
 	return simpleBrowserMonitorInput
 }
 
@@ -76,6 +87,9 @@ func buildSyntheticsSimpleBrowserMonitorUpdateStruct(d *schema.ResourceData) syn
 		Period: inputBase.Period,
 		Status: inputBase.Status,
 		Tags:   inputBase.Tags,
+		AdvancedOptions: synthetics.SyntheticsSimpleBrowserMonitorAdvancedOptionsInput{
+			DeviceEmulation: &synthetics.SyntheticsDeviceEmulationInput{},
+		},
 	}
 
 	if v, ok := d.GetOk("custom_header"); ok {
@@ -126,6 +140,14 @@ func buildSyntheticsSimpleBrowserMonitorUpdateStruct(d *schema.ResourceData) syn
 		if runtimeTypeVersionOk {
 			simpleBrowserMonitorUpdateInput.Runtime.RuntimeTypeVersion = synthetics.SemVer(runtimeTypeVersion.(string))
 		}
+	}
+
+	if v, ok := d.GetOk("device_orientation"); ok {
+		simpleBrowserMonitorUpdateInput.AdvancedOptions.DeviceEmulation.DeviceOrientation = synthetics.SyntheticsDeviceOrientation(v.(string))
+	}
+
+	if v, ok := d.GetOk("device_type"); ok {
+		simpleBrowserMonitorUpdateInput.AdvancedOptions.DeviceEmulation.DeviceType = synthetics.SyntheticsDeviceType(v.(string))
 	}
 
 	return simpleBrowserMonitorUpdateInput


### PR DESCRIPTION
# Description

Update the simple monitor resource, `newrelic_synthetics_monitor`, with the `device emulation` options. 
Ref: [NR-90076](https://issues.newrelic.com/browse/NR-90076)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Use the `device orientation` and `device type` options as in this test configuration below. Verify in NR1 that your monitor was created and the device emulation options are set according to your specified configuration:

```tf
# main.tf

terraform {
  required_providers {
    newrelic = {
      source = "newrelic/newrelic"
    }
  }
}

provider "newrelic" {
  account_id = ...
  api_key    = "NRAK-..."
  region     = "US"
}

resource "newrelic_synthetics_monitor" "test_monitor" {
  status           = "DISABLED"
  name             = "test_monitor"
  period           = "EVERY_MINUTE"
  uri              = "https://www.one.newrelic.com"
  type             = "BROWSER"
  locations_public = ["US_EAST_2"]

  custom_header {
    name  = "header_name"
    value = "header_value"
  }

  enable_screenshot_on_failure_and_script = true
  validation_string                       = "success"
  verify_ssl                              = true

  device_orientation = "PORTRAIT"
  device_type        = "TABLET"

  tag {
    key    = "tag_key"
    values = ["tag_value"]
  }

  runtime_type_version = "100"
  runtime_type         = "CHROME_BROWSER"
  script_language      = "JAVASCRIPT"
}

```