### PR TITLE
chore(synthetics): revert change to export private location key

### DIFF
--- a/newrelic/data_source_newrelic_synthetics_private_location.go
+++ b/newrelic/data_source_newrelic_synthetics_private_location.go
@@ -25,13 +25,6 @@ func dataSourceNewRelicSyntheticsPrivateLocation() *schema.Resource {
 				Required:    true,
 				Description: "The name of the Synthetics monitor private location.",
 			},
-			"key": {
-				Type:        schema.TypeList,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Computed:    true,
-				Optional:    true,
-				Description: "The key of the queried private location.",
-			},
 		},
 	}
 }
@@ -84,28 +77,5 @@ func dataSourceNewRelicSyntheticsPrivateLocationRead(ctx context.Context, d *sch
 		return diag.FromErr(err)
 	}
 
-	key := fetchPrivateLocationKey(location.Tags)
-	if len(key) == 0 {
-		//logs the absence of a key but does not throw an error to prevent halting execution
-		log.Printf("[INFO] No keys found corresponding to the queried private location.")
-	}
-	err = d.Set("key", key)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
 	return nil
-}
-
-// fetchPrivateLocationKey extracts the 'key' of the private location by iterating through all tags
-// and finding the tag by the name 'key', the 'values' of which would contain the key of the private location
-func fetchPrivateLocationKey(tagList []entities.EntityTag) []string {
-	var key []string
-	for _, tag := range tagList {
-		if tag.Key == "key" {
-			// tag.Values is a list of strings returned by the API, though it is expected to contain only one string
-			key = tag.Values
-		}
-	}
-	return key
 }

--- a/website/docs/d/synthetics_private_location.html.markdown
+++ b/website/docs/d/synthetics_private_location.html.markdown
@@ -43,9 +43,3 @@ The following arguments are supported:
 
 * `account_id` - (Optional) The New Relic account ID of the associated private location. If left empty will default to account ID specified in provider level configuration.
 * `name` - (Required) The name of the Synthetics monitor private location.
-
-## Attributes Reference
-
-In addition to all arguments above, the following attributes are exported:
-
-* `key` - The key of the private location.


### PR DESCRIPTION
Reversal of change made via #2446, as this was merged after approval, but is being reverted as the PR depends on the next release of **newrelic-client-go** and this feature depends on that change to be out with the next release. 

Please see the linked PR for the newrelic-client-go changes mentioned.