### PR TITLE
fix: Remove setting default empty values for device emulation

### DIFF
--- a/newrelic/structures_newrelic_synthetics_simple_browser_monitor.go
+++ b/newrelic/structures_newrelic_synthetics_simple_browser_monitor.go
@@ -9,13 +9,11 @@ func buildSyntheticsSimpleBrowserMonitor(d *schema.ResourceData) synthetics.Synt
 	inputBase := expandSyntheticsMonitorBase(d)
 
 	simpleBrowserMonitorInput := synthetics.SyntheticsCreateSimpleBrowserMonitorInput{
-		Name:   inputBase.Name,
-		Period: inputBase.Period,
-		Status: inputBase.Status,
-		Tags:   inputBase.Tags,
-		AdvancedOptions: synthetics.SyntheticsSimpleBrowserMonitorAdvancedOptionsInput{
-			DeviceEmulation: &synthetics.SyntheticsDeviceEmulationInput{},
-		},
+		Name:            inputBase.Name,
+		Period:          inputBase.Period,
+		Status:          inputBase.Status,
+		Tags:            inputBase.Tags,
+		AdvancedOptions: synthetics.SyntheticsSimpleBrowserMonitorAdvancedOptionsInput{},
 	}
 
 	if v, ok := d.GetOk("custom_header"); ok {
@@ -68,12 +66,19 @@ func buildSyntheticsSimpleBrowserMonitor(d *schema.ResourceData) synthetics.Synt
 		}
 	}
 
-	if v, ok := d.GetOk("device_orientation"); ok {
-		simpleBrowserMonitorInput.AdvancedOptions.DeviceEmulation.DeviceOrientation = synthetics.SyntheticsDeviceOrientation(v.(string))
-	}
+	do, doOk := d.GetOk("device_orientation")
+	dt, dtOk := d.GetOk("device_type")
 
-	if v, ok := d.GetOk("device_type"); ok {
-		simpleBrowserMonitorInput.AdvancedOptions.DeviceEmulation.DeviceType = synthetics.SyntheticsDeviceType(v.(string))
+	if doOk || dtOk {
+		simpleBrowserMonitorInput.AdvancedOptions.DeviceEmulation = &synthetics.SyntheticsDeviceEmulationInput{}
+
+		if doOk {
+			simpleBrowserMonitorInput.AdvancedOptions.DeviceEmulation.DeviceOrientation = synthetics.SyntheticsDeviceOrientation(do.(string))
+		}
+
+		if dtOk {
+			simpleBrowserMonitorInput.AdvancedOptions.DeviceEmulation.DeviceType = synthetics.SyntheticsDeviceType(dt.(string))
+		}
 	}
 
 	return simpleBrowserMonitorInput
@@ -83,13 +88,11 @@ func buildSyntheticsSimpleBrowserMonitorUpdateStruct(d *schema.ResourceData) syn
 	inputBase := expandSyntheticsMonitorBase(d)
 
 	simpleBrowserMonitorUpdateInput := synthetics.SyntheticsUpdateSimpleBrowserMonitorInput{
-		Name:   inputBase.Name,
-		Period: inputBase.Period,
-		Status: inputBase.Status,
-		Tags:   inputBase.Tags,
-		AdvancedOptions: synthetics.SyntheticsSimpleBrowserMonitorAdvancedOptionsInput{
-			DeviceEmulation: &synthetics.SyntheticsDeviceEmulationInput{},
-		},
+		Name:            inputBase.Name,
+		Period:          inputBase.Period,
+		Status:          inputBase.Status,
+		Tags:            inputBase.Tags,
+		AdvancedOptions: synthetics.SyntheticsSimpleBrowserMonitorAdvancedOptionsInput{},
 	}
 
 	if v, ok := d.GetOk("custom_header"); ok {
@@ -142,12 +145,19 @@ func buildSyntheticsSimpleBrowserMonitorUpdateStruct(d *schema.ResourceData) syn
 		}
 	}
 
-	if v, ok := d.GetOk("device_orientation"); ok {
-		simpleBrowserMonitorUpdateInput.AdvancedOptions.DeviceEmulation.DeviceOrientation = synthetics.SyntheticsDeviceOrientation(v.(string))
-	}
+	do, doOk := d.GetOk("device_orientation")
+	dt, dtOk := d.GetOk("device_type")
 
-	if v, ok := d.GetOk("device_type"); ok {
-		simpleBrowserMonitorUpdateInput.AdvancedOptions.DeviceEmulation.DeviceType = synthetics.SyntheticsDeviceType(v.(string))
+	if doOk || dtOk {
+		simpleBrowserMonitorUpdateInput.AdvancedOptions.DeviceEmulation = &synthetics.SyntheticsDeviceEmulationInput{}
+
+		if doOk {
+			simpleBrowserMonitorUpdateInput.AdvancedOptions.DeviceEmulation.DeviceOrientation = synthetics.SyntheticsDeviceOrientation(do.(string))
+		}
+
+		if dtOk {
+			simpleBrowserMonitorUpdateInput.AdvancedOptions.DeviceEmulation.DeviceType = synthetics.SyntheticsDeviceType(dt.(string))
+		}
 	}
 
 	return simpleBrowserMonitorUpdateInput


### PR DESCRIPTION
# Description

This PR removes setting default values for deviceEmulation fields on Browser monitors

Fixes #2464

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Create a Browser type monitor without setting any values for deviceEmulation fields. 
The monitor should be created successfully.