### PR TITLE
docs: added note on duration and time function of nrql alert conditio…

### DIFF
--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -124,9 +124,9 @@ The `term` block supports the following arguments:
 - `duration` - (Optional) **DEPRECATED:** Use `threshold_duration` instead. The duration of time, in _minutes_, that the threshold must violate for in order to create an incident. Must be within 1-120 (inclusive).
 - `time_function` - (Optional) **DEPRECATED:** Use `threshold_occurrences` instead. The criteria for how many data points must be in violation for the specified threshold duration. Valid values are: `all` or `any`.
 
-~> **NOTE:** When specifying a `critical` or `warning` block, using either `duration` or `threshold_duration` (one of the two) is mandatory. Both of these should not be specified.
+~> **NOTE:** When a `critical` or `warning` block is added to this resource, using either `duration` or `threshold_duration` (one of the two) is mandatory. Both of these should not be specified.
 
-~> **NOTE:** When specifying a `critical` or `warning` block, using either `time_function` or `threshold_occurrences` (one of the two) is mandatory. Both of these should not be specified.
+~> **NOTE:** When a `critical` or `warning` block is added to this resource, using either `time_function` or `threshold_occurrences` (one of the two) is mandatory. Both of these should not be specified.
 
 ## Attributes Reference
 

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -124,6 +124,10 @@ The `term` block supports the following arguments:
 - `duration` - (Optional) **DEPRECATED:** Use `threshold_duration` instead. The duration of time, in _minutes_, that the threshold must violate for in order to create an incident. Must be within 1-120 (inclusive).
 - `time_function` - (Optional) **DEPRECATED:** Use `threshold_occurrences` instead. The criteria for how many data points must be in violation for the specified threshold duration. Valid values are: `all` or `any`.
 
+~> **NOTE:** Since the use of `duration` has been deprecated, users should use either `duration` or `threshold_duration` as either of these attributes is mandatory.
+
+~> **NOTE:** Since the use of `time_function` has been deprecated, users should use either `time_function` or `threshold_occurrences` as either of these attributes is mandatory.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -124,9 +124,9 @@ The `term` block supports the following arguments:
 - `duration` - (Optional) **DEPRECATED:** Use `threshold_duration` instead. The duration of time, in _minutes_, that the threshold must violate for in order to create an incident. Must be within 1-120 (inclusive).
 - `time_function` - (Optional) **DEPRECATED:** Use `threshold_occurrences` instead. The criteria for how many data points must be in violation for the specified threshold duration. Valid values are: `all` or `any`.
 
-~> **NOTE:** Since the use of `duration` has been deprecated, users should use either `duration` or `threshold_duration` as either of these attributes is mandatory.
+~> **NOTE:** When specifying a `critical` or `warning` block, using either `duration` or `threshold_duration` (one of the two) is mandatory. Both of these should not be specified.
 
-~> **NOTE:** Since the use of `time_function` has been deprecated, users should use either `time_function` or `threshold_occurrences` as either of these attributes is mandatory.
+~> **NOTE:** When specifying a `critical` or `warning` block, using either `time_function` or `threshold_occurrences` (one of the two) is mandatory. Both of these should not be specified.
 
 ## Attributes Reference
 


### PR DESCRIPTION
# Description

Added note on duration and time function of nrql alert condition resource docs

Please delete options that are not relevant.

- [ ] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [ ] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I have made corresponding changes to the documentation

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Step 1
In the nrql alert condition resource docs, note added for duration and time function should be visible
