### PR TITLE
fix(tests): change to expected error message in provider region integration test

### DIFF
--- a/newrelic/provider_integration_test.go
+++ b/newrelic/provider_integration_test.go
@@ -29,6 +29,8 @@ func TestAccNewRelicProvider_Region(t *testing.T) {
 	// This error message will occur when configuring
 	// US region with EU API URLs when using the TF test account.
 	expectedErrorMsg := "403 response returned"
+	expectedErrorMsgTwo := "Access denied."
+	expectedErrorMsgRegex := fmt.Sprintf("%s|%s", expectedErrorMsg, expectedErrorMsgTwo)
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -43,12 +45,12 @@ func TestAccNewRelicProvider_Region(t *testing.T) {
 			// Test: Region "EU"
 			{
 				Config:      testAccNewRelicProviderConfig("EU", "", rName),
-				ExpectError: regexp.MustCompile(expectedErrorMsg),
+				ExpectError: regexp.MustCompile(expectedErrorMsgRegex),
 			},
 			// Test: Override US region URLs with EU region URLs (will result in an auth error)
 			{
 				Config:      testAccNewRelicProviderConfig("US", `nerdgraph_api_url = "https://api.eu.newrelic.com/graphql"`, rName),
-				ExpectError: regexp.MustCompile(expectedErrorMsg),
+				ExpectError: regexp.MustCompile(expectedErrorMsgRegex),
 			},
 			// Test: Override EU region URLs with US region URLs (should work since the TF acct is US-based)
 			{


### PR DESCRIPTION
Update to the `TestAccNewRelicProvider_Region` integration test as there is a difference in the error message being returned currently ("Access denied.") as opposed to what it previously was ("403 response returned"), which is causing this test to fail.