### PR TITLE
fix(docs): Correct upper limit time for aggregation_window

### DIFF
--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -86,7 +86,7 @@ The following arguments are supported:
 
 - `fill_option` - (Optional) Which strategy to use when filling gaps in the signal. Possible values are `none`, `last_value` or `static`. If `static`, the `fill_value` field will be used for filling gaps in the signal.
 - `fill_value` - (Optional, required when `fill_option` is `static`) This value will be used for filling gaps in the signal.
-- `aggregation_window` - (Optional) The duration of the time window used to evaluate the NRQL query, in seconds. The value must be at least 30 seconds, and no more than 900 seconds (15 minutes). Default is 60 seconds.
+- `aggregation_window` - (Optional) The duration of the time window used to evaluate the NRQL query, in seconds. The value must be at least 30 seconds, and no more than 7200 seconds (2 hours). Default is 60 seconds.
 - `expiration_duration` - (Optional) The amount of time (in seconds) to wait before considering the signal expired. The value must be at least 30 seconds, and no more than 172800 seconds (48 hours).
 - `open_violation_on_expiration` - (Optional) Whether to create a new incident to capture that the signal expired.
 - `close_violations_on_expiration` - (Optional) Whether to close all open incidents when the signal expires.


### PR DESCRIPTION
# Description

This PR corrects a documentation discrepancy in the Terraform provider regarding the maximum value for aggregation_window in the nrql_alert_condition resource.

 The current Terraform documentation states a maximum value of 900 seconds (15 minutes), but the [official New Relic documentation](https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names/#signal_aggregation_window) indicates a maximum value of 7200 seconds (2 hours). 

This PR aligns the Terraform documentation with the official New Relic documentation.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Since this is a documentation change, it can be verified by reviewing the updated documentation section for aggregation_window in the nrql_alert_condition resource and comparing it with the [official New Relic documentation](https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names/#signal_aggregation_window).