### PR TITLE
Update validation on violation_time_limit_seconds

### DIFF
--- a/newrelic/resource_newrelic_synthetics_multilocation_alert_condition.go
+++ b/newrelic/resource_newrelic_synthetics_multilocation_alert_condition.go
@@ -83,7 +83,7 @@ func resourceNewRelicSyntheticsMultiLocationAlertCondition() *schema.Resource {
 				Type:         schema.TypeInt,
 				Required:     true,
 				ValidateFunc: validation.IntBetween(0, 2592000)
-				Description:  "The maximum number of seconds an incident can remain open before being closed by the system.  Must be between 0 and 2,592,000",
+				Description:  "The maximum number of seconds an incident can remain open before being closed by the system.  Must be between 0 and 2592000",
 			},
 			"entity_guid": {
 				Type:        schema.TypeString,

--- a/newrelic/resource_newrelic_synthetics_multilocation_alert_condition.go
+++ b/newrelic/resource_newrelic_synthetics_multilocation_alert_condition.go
@@ -82,8 +82,8 @@ func resourceNewRelicSyntheticsMultiLocationAlertCondition() *schema.Resource {
 			"violation_time_limit_seconds": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ValidateFunc: validation.IntInSlice([]int{0, 3600, 7200, 14400, 28800, 43200, 86400}),
-				Description:  "The maximum number of seconds an incident can remain open before being closed by the system.  Must be one of: 0, 3600, 7200, 14400, 28800, 43200, 86400",
+				ValidateFunc: validation.IntBetween(0, 2592000)
+				Description:  "The maximum number of seconds an incident can remain open before being closed by the system.  Must be between 0 and 2,592,000",
 			},
 			"entity_guid": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
# Description

As per the docs, this field accepts up to 30 days: https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names/

Fixes #2475 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Run `terraform plan` using the configuration documented in the issue: https://github.com/newrelic/terraform-provider-newrelic/issues/2475