### PR TITLE
fix(log_parsing): fix to the update method to discard checking for existing rules with the name

### DIFF
--- a/newrelic/resource_newrelic_log_parsing_rule.go
+++ b/newrelic/resource_newrelic_log_parsing_rule.go
@@ -172,15 +172,17 @@ func resourceNewRelicLogParsingRuleUpdate(ctx context.Context, d *schema.Resourc
 	client := meta.(*ProviderConfig).NewClient
 	accountID := selectAccountID(meta.(*ProviderConfig), d)
 	if e, ok := d.GetOk("name"); ok {
-		rule, err := getLogParsingRuleByName(ctx, client, accountID, e.(string))
-		if (rule != nil && err != nil) || (rule == nil && err != nil) {
-			return diag.FromErr(err)
+		if o, n := d.GetChange("name"); o != n {
+			rule, err := getLogParsingRuleByName(ctx, client, accountID, e.(string))
+			if (rule != nil && err != nil) || (rule == nil && err != nil) {
+				return diag.FromErr(err)
+			}
 		}
 	}
 
 	updateInput := expandLogParsingRuleUpdateInput(d)
 
-	log.Printf("[INFO] Updating New Relic logging parsing rule %s", d.Id())
+	log.Printf("[INFO] Updating New Relic log parsing rule %s", d.Id())
 
 	ruleID := d.Id()
 
@@ -231,12 +233,12 @@ func expandLogParsingRuleUpdateInput(d *schema.ResourceData) logconfigurations.L
 	return updateInp
 }
 
-// Delete the logging parsing rule
+// Delete the log parsing rule
 func resourceNewRelicLogParsingRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
 	client := providerConfig.NewClient
 
-	log.Printf("[INFO] Deleting New Relic logging parsing rule id %s", d.Id())
+	log.Printf("[INFO] Deleting New Relic log parsing rule id %s", d.Id())
 
 	accountID := selectAccountID(meta.(*ProviderConfig), d)
 	ruleID := d.Id()


### PR DESCRIPTION
### Summary

It was identified via a recent support case that if a log parsing rule (that has already been applied) has its arguments updated other than name and a re-apply is performed, it fails with the following error.
```
│ Error: name is already in use by another rule
│
│   with newrelic_log_parsing_rule.foo,
│   on log-parsing-rule.tf line 1, in resource "newrelic_log_parsing_rule" "foo":
│    1: resource "newrelic_log_parsing_rule" "foo"{
```

The cause of this was traced to the following code snippet in the **Update** function of the resource.

https://github.com/newrelic/terraform-provider-newrelic/blob/95cba5c2f360dfec53392542708668a9e1684758/newrelic/resource_newrelic_log_parsing_rule.go#L174-L179

The method called in the above snippet is intended to find if log parsing rules already exist with the name specified by the user, which would be useful in the **Update** function, only in the case when the value of the argument **name** is changed in the Terraform Configuration, and we would like to validate if no log parsing rule already exists with the new name.

However, this is also being called when **name** is not updated, and since a log parsing rule already exists with the old name (as was applied from Terraform), the aforementioned error is thrown.

Hence, the resource needs to be updated to call the above function only if there is a difference observed in the value of the argument **name** and not, if the name is not changed.

### Changes Made in This PR
- make the aforementioned changes to the `Update` function
- add a test case to validate this scenario
- a few other minor verbiage changes in code comments

This has also been tested with both of the scenarios listed above; updating Terraform configuration by changing the name of the resource, and also by changing other arguments; and seems to work as expected.