### PR TITLE
chore(synthetics): refactor validate method to throw a deprecation warning with MUTED status

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/newrelic/go-insights v1.0.3
 	github.com/newrelic/newrelic-client-go/v2 v2.21.2
 	github.com/stretchr/testify v1.8.4
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 )
 
 require (
@@ -61,7 +62,7 @@ require (
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
 	github.com/zclconf/go-cty v1.13.1 // indirect
 	golang.org/x/crypto v0.14.0 // indirect
-	golang.org/x/mod v0.8.0 // indirect
+	golang.org/x/mod v0.13.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -393,6 +393,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.5.0/go.mod h1:NK/OQwhpMQP3MwtdjgLlYHnH9ebylxKWv3e0fK+mkQU=
 golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=
 golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
@@ -400,8 +402,8 @@ golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKG
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
-golang.org/x/mod v0.8.0 h1:LUYupSeNrTNCGzR/hVBk2NHZO4hXcVaW1k4Qx7rjPx8=
-golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/mod v0.13.0 h1:I/DsJXRlw/8l/0c24sM9yb0T4z9liZTduXvdAWYiysY=
+golang.org/x/mod v0.13.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180811021610-c39426892332/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/newrelic/resource_helpers_synthetics.go
+++ b/newrelic/resource_helpers_synthetics.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/entities"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/synthetics"
+	"golang.org/x/exp/slices"
 )
 
 // Returns the common schema attributes shared by all Synthetics monitor types.
@@ -34,8 +35,8 @@ func syntheticsMonitorCommonSchema() map[string]*schema.Schema {
 		"status": {
 			Type:         schema.TypeString,
 			Required:     true,
-			Description:  "The monitor status (i.e. ENABLED, MUTED, DISABLED). Note: The 'MUTED' status will be deprecated in a future release and it is recommended to refrain from using it.",
-			ValidateFunc: validation.StringInSlice(listValidSyntheticsMonitorStatuses(), false),
+			Description:  "The monitor status (i.e. ENABLED, MUTED, DISABLED). Note: The 'MUTED' status is now deprecated, and support for this value will soon be removed from the Terraform Provider in an upcoming release. It is highly recommended for users to refrain from using this value and shift to alternatives.",
+			ValidateFunc: validateSyntheticMonitorStatus,
 		},
 		"tag": {
 			Type:        schema.TypeSet,
@@ -260,13 +261,37 @@ func listValidSyntheticsMonitorPeriods() []string {
 	}
 }
 
-// validate func to validate monitor status
+// function to list out valid Synthetic Monitor status values
 func listValidSyntheticsMonitorStatuses() []string {
 	return []string{
 		string(synthetics.SyntheticsMonitorStatusTypes.DISABLED),
 		string(synthetics.SyntheticsMonitorStatusTypes.ENABLED),
+
+		// "MUTED" to be removed from the provider as this is soon going to reach its EOL, on February 29, 2024
 		string(synthetics.SyntheticsMonitorStatusTypes.MUTED),
 	}
+}
+
+// validate function that validates the status of Synthetic Monitors
+// recent addition: return a warning if 'MUTED' status is used, as this has been deprecated
+func validateSyntheticMonitorStatus(val interface{}, key string) (warns []string, errs []error) {
+	monitorStatusInput := val.(string)
+	listOfValidSyntheticMonitorStatuses := listValidSyntheticsMonitorStatuses()
+	containsValidSyntheticMonitorStatus := slices.Contains(listOfValidSyntheticMonitorStatuses, monitorStatusInput)
+	if containsValidSyntheticMonitorStatus == false {
+		errs = append(errs, fmt.Errorf("expected status to be one of %v, got %s", listOfValidSyntheticMonitorStatuses, monitorStatusInput))
+	}
+
+	// hard-coding "MUTED" instead of using synthetics.SyntheticsMonitorStatusTypes.MUTED as it could be removed from newrelic-client-go post the EOL
+	if monitorStatusInput == "MUTED" {
+		warns = append(warns, fmt.Sprintf(`
+The 'MUTED' status of Synthetic Monitors has been deprecated, and shall reach its end of life in February 2024.
+In accordance with this, the New Relic Terraform Provider would also discontinue support for the status 'MUTED' soon, in an upcoming release.
+To mute Synthetic Monitors, please shift to alternatives such as muting rules. 
+A detailed guide on this can be found here: https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/upcoming_synthetics_muted_status_eol_guide
+`))
+	}
+	return warns, errs
 }
 
 type SyntheticsMonitorType string

--- a/newrelic/resource_helpers_synthetics.go
+++ b/newrelic/resource_helpers_synthetics.go
@@ -278,18 +278,18 @@ func validateSyntheticMonitorStatus(val interface{}, key string) (warns []string
 	monitorStatusInput := val.(string)
 	listOfValidSyntheticMonitorStatuses := listValidSyntheticsMonitorStatuses()
 	containsValidSyntheticMonitorStatus := slices.Contains(listOfValidSyntheticMonitorStatuses, monitorStatusInput)
-	if containsValidSyntheticMonitorStatus == false {
+	if !containsValidSyntheticMonitorStatus {
 		errs = append(errs, fmt.Errorf("expected status to be one of %v, got %s", listOfValidSyntheticMonitorStatuses, monitorStatusInput))
 	}
 
 	// hard-coding "MUTED" instead of using synthetics.SyntheticsMonitorStatusTypes.MUTED as it could be removed from newrelic-client-go post the EOL
 	if monitorStatusInput == "MUTED" {
-		warns = append(warns, fmt.Sprintf(`
+		warns = append(warns, `
 The 'MUTED' status of Synthetic Monitors has been deprecated, and shall reach its end of life in February 2024.
 In accordance with this, the New Relic Terraform Provider would also discontinue support for the status 'MUTED' soon, in an upcoming release.
 To mute Synthetic Monitors, please shift to alternatives such as muting rules. 
 A detailed guide on this can be found here: https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/upcoming_synthetics_muted_status_eol_guide
-`))
+`)
 	}
 	return warns, errs
 }

--- a/newrelic/resource_newrelic_synthetics_cert_check_monitor.go
+++ b/newrelic/resource_newrelic_synthetics_cert_check_monitor.go
@@ -62,9 +62,9 @@ func resourceNewRelicSyntheticsCertCheckMonitor() *schema.Resource {
 			},
 			"status": {
 				Type:         schema.TypeString,
-				Description:  "The monitor status (i.e. ENABLED, MUTED, DISABLED). Note: The 'MUTED' status will be deprecated in a future release and it is recommended to refrain from using it.",
+				Description:  "The monitor status (i.e. ENABLED, MUTED, DISABLED). Note: The 'MUTED' status is now deprecated, and support for this value will soon be removed from the Terraform Provider in an upcoming release. It is highly recommended for users to refrain from using this value and shift to alternatives.",
 				Required:     true,
-				ValidateFunc: validation.StringInSlice(listValidSyntheticsMonitorStatuses(), false),
+				ValidateFunc: validateSyntheticMonitorStatus,
 			},
 			"tag": {
 				Type:        schema.TypeSet,

--- a/newrelic/resource_newrelic_synthetics_monitor.go
+++ b/newrelic/resource_newrelic_synthetics_monitor.go
@@ -80,8 +80,8 @@ func resourceNewRelicSyntheticsMonitor() *schema.Resource {
 			"status": {
 				Type:         schema.TypeString,
 				Required:     true,
-				Description:  "The monitor status (i.e. ENABLED, MUTED, DISABLED). Note: The 'MUTED' status will be deprecated in a future release and it is recommended to refrain from using it.",
-				ValidateFunc: validation.StringInSlice(listValidSyntheticsMonitorStatuses(), false),
+				Description:  "The monitor status (i.e. ENABLED, MUTED, DISABLED). Note: The 'MUTED' status is now deprecated, and support for this value will soon be removed from the Terraform Provider in an upcoming release. It is highly recommended for users to refrain from using this value and shift to alternatives.",
+				ValidateFunc: validateSyntheticMonitorStatus,
 			},
 			"validation_string": {
 				Type:        schema.TypeString,

--- a/website/docs/r/synthetics_broken_links_monitor.html.markdown
+++ b/website/docs/r/synthetics_broken_links_monitor.html.markdown
@@ -3,7 +3,7 @@ layout: "newrelic"
 page_title: "New Relic: newrelic_synthetics_broken_links_monitor"
 sidebar_current: "docs-newrelic-resource-synthetics-broken-links-monitor"
 description: |-
-Create and manage a Synthetics Broken Links monitor in New Relic.
+    Create and manage a Synthetics Broken Links monitor in New Relic.
 ---
 
 # Resource: newrelic\_synthetics\_broken\_links\_monitor
@@ -39,7 +39,7 @@ The following are the common arguments supported for `BROKEN LINKS` monitor:
 * `period` - (Required) The interval at which this monitor should run. Valid values are EVERY_MINUTE, EVERY_5_MINUTES, EVERY_10_MINUTES, EVERY_15_MINUTES, EVERY_30_MINUTES, EVERY_HOUR, EVERY_6_HOURS, EVERY_12_HOURS, or EVERY_DAY.
 * `status` - (Required) The run state of the monitor. (i.e. `ENABLED`, `DISABLED`, `MUTED`). 
 
--> **NOTE:** The `MUTED` status is now **deprecated**, and support for this value will soon be removed from the Terraform Provider with the next major release (v4). It is highly recommended for users to refrain from using the status `MUTED` and shift to alternatives at the earliest. Please check out [this guide](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/upcoming_synthetics_muted_status_eol_guide) for more details about the EOL of `MUTED` status and alternatives to move to.
+-> **NOTE:** The `MUTED` status is now **deprecated**, and support for this value will soon be removed from the Terraform Provider in an upcoming release. It is highly recommended for users to refrain from using the status `MUTED` and shift to alternatives at the earliest. Please check out [this guide](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/upcoming_synthetics_muted_status_eol_guide) for more details about the EOL of `MUTED` status and alternatives to move to.
 * `tag` - (Optional) The tags that will be associated with the monitor. See [Nested tag blocks](#nested-tag-blocks) below for details
 
 ### Nested `tag` blocks

--- a/website/docs/r/synthetics_cert_check_monitor.html.markdown
+++ b/website/docs/r/synthetics_cert_check_monitor.html.markdown
@@ -3,7 +3,7 @@ layout: "newrelic"
 page_title: "New Relic: newrelic_synthetics_cert_check_monitor"
 sidebar_current: "docs-newrelic-resource-synthetics-cert-check-monitor"
 description: |-
-Create and manage a Synthetics Cert Check monitor in New Relic.
+    Create and manage a Synthetics Cert Check monitor in New Relic.
 ---
 
 # Resource: newrelic\_synthetics\_cert\_check\_monitor
@@ -41,7 +41,7 @@ The following are the common arguments supported for `CERTIFICATE CHECK` monitor
 * `period` - (Required) The interval at which this monitor should run. Valid values are EVERY_MINUTE, EVERY_5_MINUTES, EVERY_10_MINUTES, EVERY_15_MINUTES, EVERY_30_MINUTES, EVERY_HOUR, EVERY_6_HOURS, EVERY_12_HOURS, or EVERY_DAY.
 * `status` - (Required) The run state of the monitor. (i.e. `ENABLED`, `DISABLED`, `MUTED`). 
 
--> **NOTE:** The `MUTED` status is now **deprecated**, and support for this value will soon be removed from the Terraform Provider with the next major release (v4). It is highly recommended for users to refrain from using the status `MUTED` and shift to alternatives at the earliest. Please check out [this guide](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/upcoming_synthetics_muted_status_eol_guide) for more details about the EOL of `MUTED` status and alternatives to move to.
+-> **NOTE:** The `MUTED` status is now **deprecated**, and support for this value will soon be removed from the Terraform Provider in an upcoming release. It is highly recommended for users to refrain from using the status `MUTED` and shift to alternatives at the earliest. Please check out [this guide](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/upcoming_synthetics_muted_status_eol_guide) for more details about the EOL of `MUTED` status and alternatives to move to.
 * `tag` - (Optional) The tags that will be associated with the monitor. See [Nested tag blocks](#nested-tag-blocks) below for details
 
 ### Nested `tag` blocks

--- a/website/docs/r/synthetics_monitor.html.markdown
+++ b/website/docs/r/synthetics_monitor.html.markdown
@@ -3,7 +3,7 @@ layout: "newrelic"
 page_title: "New Relic: newrelic_synthetics_monitor"
 sidebar_current: "docs-newrelic-resource-synthetics-monitor"
 description: |-
-Create and manage a Synthetics monitor in New Relic.
+    Create and manage a Synthetics monitor in New Relic.
 ---
 
 # Resource: newrelic\_synthetics\_monitor
@@ -71,7 +71,7 @@ The following are the common arguments supported for `SIMPLE` and `BROWSER` moni
 * `account_id`- (Optional) The account in which the Synthetics monitor will be created.
 * `status` - (Required) The run state of the monitor. (i.e. `ENABLED`, `DISABLED`, `MUTED`).
 
--> **NOTE:** The `MUTED` status is now **deprecated**, and support for this value will soon be removed from the Terraform Provider with the next major release (v4). It is highly recommended for users to refrain from using the status `MUTED` and shift to alternatives at the earliest. Please check out [this guide](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/upcoming_synthetics_muted_status_eol_guide) for more details about the EOL of `MUTED` status and alternatives to move to.
+-> **NOTE:** The `MUTED` status is now **deprecated**, and support for this value will soon be removed from the Terraform Provider in an upcoming release. It is highly recommended for users to refrain from using the status `MUTED` and shift to alternatives at the earliest. Please check out [this guide](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/upcoming_synthetics_muted_status_eol_guide) for more details about the EOL of `MUTED` status and alternatives to move to.
 * `name` - (Required) The human-readable identifier for the monitor.
 * `period` - (Required) The interval at which this monitor should run. Valid values are EVERY_MINUTE, EVERY_5_MINUTES, EVERY_10_MINUTES, EVERY_15_MINUTES, EVERY_30_MINUTES, EVERY_HOUR, EVERY_6_HOURS, EVERY_12_HOURS, or EVERY_DAY.
 * `uri` - (Required) The URI the monitor runs against.

--- a/website/docs/r/synthetics_script_monitor.html.markdown
+++ b/website/docs/r/synthetics_script_monitor.html.markdown
@@ -3,7 +3,7 @@ layout: "newrelic"
 page_title: "New Relic: newrelic_synthetics_script_monitor"
 sidebar_current: "docs-newrelic-resource-synthetics-script-monitor"
 description: |-
-Create and manage a Synthetics script monitor in New Relic.
+    Create and manage a Synthetics script monitor in New Relic.
 ---
 
 # Resource: newrelic\_synthetics\_script\_monitor
@@ -67,7 +67,7 @@ The following are the common arguments supported for `SCRIPT_API` and `SCRIPT_BR
 * `account_id`- (Optional) The account in which the Synthetics monitor will be created.
 * `status` - (Required) The run state of the monitor. (i.e. `ENABLED`, `DISABLED`, `MUTED`).
 
--> **NOTE:** The `MUTED` status is now **deprecated**, and support for this value will soon be removed from the Terraform Provider with the next major release (v4). It is highly recommended for users to refrain from using the status `MUTED` and shift to alternatives at the earliest. Please check out [this guide](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/upcoming_synthetics_muted_status_eol_guide) for more details about the EOL of `MUTED` status and alternatives to move to.
+-> **NOTE:** The `MUTED` status is now **deprecated**, and support for this value will soon be removed from the Terraform Provider in an upcoming release. It is highly recommended for users to refrain from using the status `MUTED` and shift to alternatives at the earliest. Please check out [this guide](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/upcoming_synthetics_muted_status_eol_guide) for more details about the EOL of `MUTED` status and alternatives to move to.
 * `name` - (Required) The name for the monitor.
 * `type` - (Required) The plaintext representing the monitor script. Valid values are SCRIPT_BROWSER or SCRIPT_API
 * `locations_public` - (Optional) The location the monitor will run from. Check out [this page](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips/) for a list of valid public locations. The `AWS_` prefix is not needed, as the provider uses NerdGraph. **At least one of either** `locations_public` **or** `location_private` **is required**.

--- a/website/docs/r/synthetics_step_monitor.html.markdown
+++ b/website/docs/r/synthetics_step_monitor.html.markdown
@@ -3,7 +3,7 @@ layout: "newrelic"
 page_title: "New Relic: newrelic_synthetics_step_monitor"
 sidebar_current: "docs-newrelic-resource-synthetics-step-monitor"
 description: |-
-Create and manage a Synthetics Step monitor in New Relic.
+    Create and manage a Synthetics Step monitor in New Relic.
 ---
 
 # Resource: newrelic\_synthetics\_step\_monitor
@@ -44,7 +44,7 @@ The following are the common arguments supported for `STEP` monitor:
 * `period` - (Required) The interval at which this monitor should run. Valid values are EVERY_MINUTE, EVERY_5_MINUTES, EVERY_10_MINUTES, EVERY_15_MINUTES, EVERY_30_MINUTES, EVERY_HOUR, EVERY_6_HOURS, EVERY_12_HOURS, or EVERY_DAY.
 * `status` - (Required) The run state of the monitor. (i.e. `ENABLED`, `DISABLED`, `MUTED`).
 
--> **NOTE:** The `MUTED` status is now **deprecated**, and support for this value will soon be removed from the Terraform Provider with the next major release (v4). It is highly recommended for users to refrain from using the status `MUTED` and shift to alternatives at the earliest. Please check out [this guide](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/upcoming_synthetics_muted_status_eol_guide) for more details about the EOL of `MUTED` status and alternatives to move to.
+-> **NOTE:** The `MUTED` status is now **deprecated**, and support for this value will soon be removed from the Terraform Provider in an upcoming release. It is highly recommended for users to refrain from using the status `MUTED` and shift to alternatives at the earliest. Please check out [this guide](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/upcoming_synthetics_muted_status_eol_guide) for more details about the EOL of `MUTED` status and alternatives to move to.
 * `steps` - (Required) The steps that make up the script the monitor will run. See [Nested steps blocks](#nested-steps-blocks) below for details.
 * `tag` - (Optional) The tags that will be associated with the monitor. See [Nested tag blocks](#nested-tag-blocks) below for details.
 


### PR DESCRIPTION
### Summary of Changes
This PR addresses the following - 
- modifying the validate function of the status attribute of all Synthetic Monitor resources to a new function, `validateSyntheticMonitorStatus`. This function checks if the status is valid (similar to current behaviour) but also helps throw a warning if the status is `MUTED`. Examples below.
- making consistent the statement talking about the deprecation across docs, the warning message and the description of the `status` attribute in the code

### Examples

Case 1: If one tries creating a monitor with status `MUTED` with these new changes

<img width="1400" alt="image" src="https://github.com/newrelic/terraform-provider-newrelic/assets/127438038/4d2926f7-b203-4e01-b53d-3efc1db9abcb">

<img width="1472" alt="image" src="https://github.com/newrelic/terraform-provider-newrelic/assets/127438038/36c9b064-e6b0-4855-8bbf-1692c365c57f">


Case 2: If one tries modifying a monitor with status `MUTED` (with `MUTED` in the configuration)

<img width="972" alt="image" src="https://github.com/newrelic/terraform-provider-newrelic/assets/127438038/9f07fc27-e28c-4cb5-86a4-b58293b97b79">


However, this is shown only if the current status in the configuration is `MUTED` and not if we try changing it to `ENABLED` or `DISABLED`.

<img width="968" alt="image" src="https://github.com/newrelic/terraform-provider-newrelic/assets/127438038/528e710b-6970-4d4b-9dc3-f758f4291848">


