### PR TITLE
chore: add cleanup function to delete redundant synthetic entities

### DIFF
--- a/newrelic/data_source_newrelic_synthetics_secure_credential_test.go
+++ b/newrelic/data_source_newrelic_synthetics_secure_credential_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccNewRelicSyntheticsSecureCredentialDataSource_Basic(t *testing.T) {
-	rName := "TF_ACC_TEST"
+	rName := "INTEGRATION_TEST_SECURE_CREDENTIAL"
 	resourceName := "data.newrelic_synthetics_secure_credential.foo"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/newrelic/resource_newrelic_synthetics_monitor_test.go
+++ b/newrelic/resource_newrelic_synthetics_monitor_test.go
@@ -274,7 +274,7 @@ func TestSyntheticsSimpleBrowserMonitor_PeriodInMinutes(t *testing.T) {
 
 	a := createIntegrationTestClient(t)
 
-	monitorName := mock.RandSeq(5)
+	monitorName := generateNameForIntegrationTestResource()
 
 	simpleBrowserMonitorInput := synthetics.SyntheticsCreateSimpleBrowserMonitorInput{
 		Locations: synthetics.SyntheticsLocationsInput{


### PR DESCRIPTION
It was recently noticed in an account internal to New Relic that Synthetic Monitors were failing to be created, which was traced to a breach of the limit of Synthetic Checks in the account. 

This took place owing to a large number of Synthetics entities (Private Locations, Monitors and Secure Credentials) which failed to be deleted owing to API errors/flakey API behaviour/interruptions caused to running integration tests. Such entities were accumulated over a large time frame and led to an enormous number of Synthetic Checks being triggered, eventually leading to the limit breach.

All of these redundant monitors/private locations/secure credentials have been deleted via the cleanup function written in this PR - the objective of these code changes, however, is to prevent such situations in future, by triggering the run of a cleanup with each run of integration tests, which would delete Synthetics entities created by the Terraform Provider or the Go Client in the aforementioned account.

In addition, a function has been added to streamline the naming convention of Synthetics entities created across test cases, so these can be referenced in all integration tests.

#### Testing

Please watch the video [here](https://new-relic.atlassian.net/browse/NR-180684?focusedCommentId=267916). It may be seen that Synthetics entities starting in `tf-test` or `client-go-test` are cleared once integration tests begin running.

Eventually, the following was the outcome seen (after all of such redundant Synthetics entities were cleared). This mounted to 8M checks, prior to the cleanup.

<img width="456" alt="image" src="https://github.com/newrelic/terraform-provider-newrelic/assets/127438038/6f233966-0c8b-4311-84cd-0745b14e21b2">


