### PR TITLE
chore: Mark resources for deprecation

### DIFF
--- a/newrelic/resource_newrelic_alert_condition.go
+++ b/newrelic/resource_newrelic_alert_condition.go
@@ -78,10 +78,11 @@ func resourceNewRelicAlertCondition() *schema.Resource {
 	}
 
 	return &schema.Resource{
-		CreateContext: resourceNewRelicAlertConditionCreate,
-		ReadContext:   resourceNewRelicAlertConditionRead,
-		UpdateContext: resourceNewRelicAlertConditionUpdate,
-		DeleteContext: resourceNewRelicAlertConditionDelete,
+		DeprecationMessage: "The `newrelic_alert_condition` resource is deprecated and will be removed in the next major release.",
+		CreateContext:      resourceNewRelicAlertConditionCreate,
+		ReadContext:        resourceNewRelicAlertConditionRead,
+		UpdateContext:      resourceNewRelicAlertConditionUpdate,
+		DeleteContext:      resourceNewRelicAlertConditionDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/newrelic/resource_newrelic_infra_alert_condition.go
+++ b/newrelic/resource_newrelic_infra_alert_condition.go
@@ -58,10 +58,11 @@ func resourceNewRelicInfraAlertCondition() *schema.Resource {
 	}
 
 	return &schema.Resource{
-		CreateContext: resourceNewRelicInfraAlertConditionCreate,
-		ReadContext:   resourceNewRelicInfraAlertConditionRead,
-		UpdateContext: resourceNewRelicInfraAlertConditionUpdate,
-		DeleteContext: resourceNewRelicInfraAlertConditionDelete,
+		DeprecationMessage: "The `newrelic_infra_alert_condition` resource is deprecated and will be removed in the next major release.",
+		CreateContext:      resourceNewRelicInfraAlertConditionCreate,
+		ReadContext:        resourceNewRelicInfraAlertConditionRead,
+		UpdateContext:      resourceNewRelicInfraAlertConditionUpdate,
+		DeleteContext:      resourceNewRelicInfraAlertConditionDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/newrelic/resource_newrelic_synthetics_alert_condition.go
+++ b/newrelic/resource_newrelic_synthetics_alert_condition.go
@@ -14,10 +14,11 @@ import (
 
 func resourceNewRelicSyntheticsAlertCondition() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceNewRelicSyntheticsAlertConditionCreate,
-		ReadContext:   resourceNewRelicSyntheticsAlertConditionRead,
-		UpdateContext: resourceNewRelicSyntheticsAlertConditionUpdate,
-		DeleteContext: resourceNewRelicSyntheticsAlertConditionDelete,
+		DeprecationMessage: "The `newrelic_synthetics_alert_condition` resource is deprecated and will be removed in the next major release.",
+		CreateContext:      resourceNewRelicSyntheticsAlertConditionCreate,
+		ReadContext:        resourceNewRelicSyntheticsAlertConditionRead,
+		UpdateContext:      resourceNewRelicSyntheticsAlertConditionUpdate,
+		DeleteContext:      resourceNewRelicSyntheticsAlertConditionDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},


### PR DESCRIPTION
# Description

Marks the following resources as deprecated:
- newrelic_alert_condition
- newrelic_infra_alert_condition
- newrelic_synthetics_alert_condition

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.
