### PR TITLE
docs: standardize account_id format in a few docs

### DIFF
--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -23,7 +23,7 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_nrql_alert_condition" "foo" {
-  account_id                     = <Your Account ID>
+  account_id                     = 12345678
   policy_id                      = newrelic_alert_policy.foo.id
   type                           = "static"
   name                           = "foo"
@@ -150,7 +150,7 @@ resource "newrelic_alert_policy" "foo" {
 
 resource "newrelic_nrql_alert_condition" "foo" {
   type                         = "baseline"
-  account_id                   = <Your Account ID>
+  account_id                   = 12345678
   name                         = "foo"
   policy_id                    = newrelic_alert_policy.foo.id
   description                  = "Alert when transactions are taking too long"
@@ -213,7 +213,7 @@ resource "newrelic_alert_policy" "foo" {
 }
 
 resource "newrelic_nrql_alert_condition" "foo" {
-  account_id                     = <Your Account ID>
+  account_id                     = 12345678
   policy_id                      = newrelic_alert_policy.foo.id
   type                           = "static"
   name                           = "foo"

--- a/website/docs/r/one_dashboard.html.markdown
+++ b/website/docs/r/one_dashboard.html.markdown
@@ -309,7 +309,7 @@ widget_line {
   height = 3
 
   nrql_query {
-    account_id  = <Another Account ID>
+    account_id  = Another_Account_ID
     query       = "FROM Transaction SELECT average(duration) FACET appName"
   }
 
@@ -409,11 +409,11 @@ resource "newrelic_one_dashboard" "multi_page_dashboard" {
       column = 1
       width  = 12
       nrql_query {
-        account_id = <First Account ID>
+        account_id = First_Account_ID
         query      = "FROM Metric SELECT rate(count(apm.service.transaction.duration), 1 minute) as 'First Account Throughput' TIMESERIES"
       }
       nrql_query {
-        account_id = <Second Account ID>
+        account_id = Second_Account_ID
         query      = "FROM Metric SELECT rate(count(apm.service.transaction.duration), 1 minute) as 'Second Account Throughput' TIMESERIES"
       }
       y_axis_left_zero = false


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

# Description
standardize account_id format in a few docs - the <> are non-standard

* `newrelic_nrql_alert_condition` - use 12345678 format similar to other documentation
* `one_dashboard` - use a friendlier format for the account IDs

in both cases the updated format is more clear.  this is a documentation only change

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [ ] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Step 1
- Step 2
- etc
