### PR TITLE
feat(synthetics): addition of a resource for monitor downtimes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.27.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.21.2
+	github.com/newrelic/newrelic-client-go/v2 v2.22.3-0.20231204042520-c8d66ca4d6c9
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.27.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.22.3-0.20231204042520-c8d66ca4d6c9
+	github.com/newrelic/newrelic-client-go/v2 v2.23.0
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 )

--- a/go.sum
+++ b/go.sum
@@ -267,8 +267,8 @@ github.com/newrelic/go-agent/v3 v3.27.0 h1:Z3XB49d8FKjRcGzCyViCO9itBxiLPSpwjY1Hl
 github.com/newrelic/go-agent/v3 v3.27.0/go.mod h1:TUzePinDc0BMH4Sui66rl4SBe6yOKJ5X/bRJekwuAtM=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.21.2 h1:38WTxIcfds96XrF/ouBbWspobh5+XX+Vmbu/RlLDGhU=
-github.com/newrelic/newrelic-client-go/v2 v2.21.2/go.mod h1:VPWTvEfKvnTZLunAC7fiW33y4e0srznNfN5HJH2cOp8=
+github.com/newrelic/newrelic-client-go/v2 v2.22.3-0.20231204042520-c8d66ca4d6c9 h1:4WTAG4Aj4i7dmXhHlKsvJDOIvS7mByhz2nB1r9XcEsE=
+github.com/newrelic/newrelic-client-go/v2 v2.22.3-0.20231204042520-c8d66ca4d6c9/go.mod h1:VPWTvEfKvnTZLunAC7fiW33y4e0srznNfN5HJH2cOp8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/go.sum
+++ b/go.sum
@@ -267,8 +267,8 @@ github.com/newrelic/go-agent/v3 v3.27.0 h1:Z3XB49d8FKjRcGzCyViCO9itBxiLPSpwjY1Hl
 github.com/newrelic/go-agent/v3 v3.27.0/go.mod h1:TUzePinDc0BMH4Sui66rl4SBe6yOKJ5X/bRJekwuAtM=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.22.3-0.20231204042520-c8d66ca4d6c9 h1:4WTAG4Aj4i7dmXhHlKsvJDOIvS7mByhz2nB1r9XcEsE=
-github.com/newrelic/newrelic-client-go/v2 v2.22.3-0.20231204042520-c8d66ca4d6c9/go.mod h1:VPWTvEfKvnTZLunAC7fiW33y4e0srznNfN5HJH2cOp8=
+github.com/newrelic/newrelic-client-go/v2 v2.23.0 h1:ULqiPv4Z0QVLjMjX6uP13wSxPDL3uiKTt5U8vFsvpCQ=
+github.com/newrelic/newrelic-client-go/v2 v2.23.0/go.mod h1:VPWTvEfKvnTZLunAC7fiW33y4e0srznNfN5HJH2cOp8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/newrelic/provider.go
+++ b/newrelic/provider.go
@@ -158,6 +158,7 @@ func Provider() *schema.Provider {
 			"newrelic_infra_alert_condition":                    resourceNewRelicInfraAlertCondition(),
 			"newrelic_insights_event":                           resourceNewRelicInsightsEvent(),
 			"newrelic_log_parsing_rule":                         resourceNewRelicLogParsingRule(),
+			"newrelic_monitor_downtime":                         resourceNewRelicMonitorDowntime(),
 			"newrelic_notification_channel":                     resourceNewRelicNotificationChannel(),
 			"newrelic_notification_destination":                 resourceNewRelicNotificationDestination(),
 			"newrelic_nrql_alert_condition":                     resourceNewRelicNrqlAlertCondition(),

--- a/newrelic/resource_newrelic_monitor_downtime.go
+++ b/newrelic/resource_newrelic_monitor_downtime.go
@@ -1,0 +1,361 @@
+package newrelic
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/entities"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/synthetics"
+)
+
+func resourceNewRelicMonitorDowntime() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNewRelicMonitorDowntimeCreate,
+		ReadContext:   resourceNewRelicMonitorDowntimeRead,
+		UpdateContext: resourceNewRelicMonitorDowntimeUpdate,
+		DeleteContext: resourceNewRelicMonitorDowntimeDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Description: "A name to identify the Monitor Downtime to be created.",
+				Required:    true,
+			},
+			"monitor_guids": {
+				Type:        schema.TypeSet,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				Description: "A list of GUIDs of monitors, to which the created Monitor Downtime shall be applied.",
+				// ValidateFunc: validation included in validateMonitorDowntimeMonitorGUIDs as this is a set and is unsupported by the "validation" package
+			},
+			"account_id": {
+				Type:        schema.TypeString,
+				Description: "The ID of the New Relic account in which the Monitor Downtime shall be created. Defaults to NEW_RELIC_ACCOUNT_ID if not specified.",
+				Optional:    true,
+				Default:     os.Getenv("NEW_RELIC_ACCOUNT_ID"),
+			},
+			"start_time": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "A datetime stamp signifying the start of the Monitor Downtime.",
+				ValidateFunc: validateNaiveDateTime,
+			},
+			"end_time": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "A datetime stamp signifying the end of the Monitor Downtime.",
+				ValidateFunc: validateNaiveDateTime,
+			},
+			"time_zone": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "The timezone that applies to the Monitor Downtime schedule.",
+				ValidateFunc: validateMonitorDowntimeTimeZone,
+			},
+			// used with daily, weekly and monthly monitor downtime
+			"end_repeat": {
+				Type:        schema.TypeList,
+				MinItems:    1,
+				MaxItems:    1,
+				Optional:    true,
+				Description: "A specification of when the Monitor Downtime should end its repeat cycle, by number of occurrences or date.",
+				// ValidateFunc: validation included in validateMonitorDowntimeEndRepeatStructure as this is a set; lists and sets are not supported by the "validation" package
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"on_date": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ExactlyOneOf: []string{"end_repeat.0.on_date", "end_repeat.0.on_repeat"},
+							Description:  "A date, on which the Monitor Downtime's repeat cycle is expected to end.",
+							ValidateFunc: validateMonitorDowntimeOnDate,
+						},
+						"on_repeat": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ExactlyOneOf: []string{"end_repeat.0.on_date", "end_repeat.0.on_repeat"},
+							Description:  "Number of repetitions after which the Monitor Downtime's repeat cycle is expected to end.",
+						},
+					},
+				},
+			},
+			// used with weekly monitor downtime
+			"maintenance_days": {
+				Type:        schema.TypeSet,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				Description: "A list of maintenance days to be included with the created weekly Monitor Downtime.",
+				// ValidateFunc: validation included in validateMonitorDowntimeMaintenanceDaysStructure as this is a set; lists and sets are not supported by the "validation" package
+			},
+			// used with monthly monitor downtime
+			"frequency": {
+				Type:        schema.TypeList,
+				MinItems:    1,
+				MaxItems:    1,
+				Optional:    true,
+				Description: "Configuration options for which days of the month a monitor downtime will occur",
+				// ValidateFunc: validation included in validateMonitorDowntimeFrequencyStructure to use this argument only with "MONTHLY" mode
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"days_of_month": {
+							Type:         schema.TypeSet,
+							Elem:         &schema.Schema{Type: schema.TypeInt},
+							Optional:     true,
+							ExactlyOneOf: []string{"frequency.0.days_of_month", "frequency.0.days_of_week"},
+							Description:  "A numerical list of days of a month on which the Monitor Downtime is scheduled to run.",
+							// ValidateFunc: validation included in validateMonitorDowntimeFrequencyStructure as this is a set; lists and sets are not supported by the "validation" package
+						},
+						"days_of_week": {
+							Type:         schema.TypeList,
+							MinItems:     1,
+							MaxItems:     1,
+							Optional:     true,
+							ExactlyOneOf: []string{"frequency.0.days_of_month", "frequency.0.days_of_week"},
+							Description:  "A list of days of the week on which the Monitor Downtime is scheduled to run.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"ordinal_day_of_month": {
+										Type:         schema.TypeString,
+										Required:     true,
+										Description:  "An occurrence of the day selected within the month.",
+										ValidateFunc: validation.StringInSlice(listValidOrdinalDayOfMonthValues(), false),
+									},
+									"week_day": {
+										Type:         schema.TypeString,
+										Required:     true,
+										Description:  "The day of the week on which the Monitor Downtime would run.",
+										ValidateFunc: validation.StringInSlice(listValidWeekDayValues(), false),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"mode": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "An identifier of the type of Monitor Downtime to be created.",
+				ValidateFunc: validation.StringInSlice([]string{
+					SyntheticsMonitorDowntimeModes.OneTime,
+					SyntheticsMonitorDowntimeModes.DAILY,
+					SyntheticsMonitorDowntimeModes.MONTHLY,
+					SyntheticsMonitorDowntimeModes.WEEKLY,
+				}, false),
+				ForceNew: true,
+			},
+		},
+		CustomizeDiff: validateMonitorDowntimeAttributes,
+	}
+}
+
+func resourceNewRelicMonitorDowntimeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+	commonArgumentsObject, err := getMonitorDowntimeValuesOfCommonArguments(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	switch commonArgumentsObject.Mode {
+	case SyntheticsMonitorDowntimeModes.OneTime:
+		oneTimeCreateObject, err := getMonitorDowntimeOneTimeValues(d, commonArgumentsObject)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		guid, err := oneTimeCreateObject.createMonitorDowntimeOneTime(ctx, client)
+		if err != nil {
+			d.SetId("")
+			diag.FromErr(err)
+		}
+
+		d.SetId(guid)
+	case SyntheticsMonitorDowntimeModes.DAILY:
+		dailyCreateObject, err := getMonitorDowntimeDailyValues(d, commonArgumentsObject)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		guid, err := dailyCreateObject.createMonitorDowntimeDaily(ctx, client)
+		if err != nil {
+			d.SetId("")
+			diag.FromErr(err)
+		}
+
+		d.SetId(guid)
+	case SyntheticsMonitorDowntimeModes.WEEKLY:
+		weeklyCreateObject, err := getMonitorDowntimeWeeklyValues(d, commonArgumentsObject)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		guid, err := weeklyCreateObject.createMonitorDowntimeWeekly(ctx, client)
+		if err != nil {
+			d.SetId("")
+			diag.FromErr(err)
+		}
+
+		d.SetId(guid)
+	case SyntheticsMonitorDowntimeModes.MONTHLY:
+		monthlyCreateObject, err := getMonitorDowntimeMonthlyValues(d, commonArgumentsObject)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		guid, err := monthlyCreateObject.createMonitorDowntimeMonthly(ctx, client)
+		if err != nil {
+			d.SetId("")
+			diag.FromErr(err)
+		}
+
+		d.SetId(guid)
+	default:
+		return diag.FromErr(errors.New("invalid mode of operation: 'mode' can be 'ONE_TIME', 'DAILY', 'WEEKLY' or 'MONTHLY'"))
+	}
+
+	return resourceNewRelicMonitorDowntimeRead(ctx, d, meta)
+}
+
+func resourceNewRelicMonitorDowntimeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+
+	log.Printf("[INFO] Reading New Relic Synthetics Monitor Downtime %s", d.Id())
+
+	var tags []entities.EntityTag
+	var entity *entities.GenericEntity
+
+	// retry mechanism since the entity query "immediately" does NOT return all tags, and returns only three
+	retryErr := resource.RetryContext(context.Background(), 30*time.Second, func() *resource.RetryError {
+		resp, err := client.Entities.GetEntityWithContext(ctx, common.EntityGUID(d.Id()))
+		if err != nil {
+			return resource.RetryableError(err)
+		}
+		entity = (*resp).(*entities.GenericEntity)
+		tags = entity.GetTags()
+		if len(tags) < 4 {
+			return resource.RetryableError(fmt.Errorf("enough tags not found. retrying"))
+		}
+		return nil
+	})
+
+	if retryErr != nil {
+		log.Fatalf("Unable to find application entity: %s", retryErr)
+	}
+
+	mode := setMonitorDowntimeMode(tags)
+	timezone := setMonitorDowntimeTimezone(tags)
+	_ = d.Set("name", entity.GetName())
+	_ = d.Set("account_id", setMonitorDowntimeAccountID(tags))
+	_ = d.Set("mode", mode)
+	_ = d.Set("start_time", setMonitorDowntimeStartTime(tags))
+	_ = d.Set("end_time", setMonitorDowntimeEndTime(tags))
+	_ = d.Set("time_zone", timezone)
+
+	if mode != SyntheticsMonitorDowntimeModes.OneTime {
+		setMonitorDowntimeEndRepeat(d, tags, timezone)
+	}
+
+	if mode == SyntheticsMonitorDowntimeModes.WEEKLY {
+		setMonitorDowntimeMaintenanceDays(d, tags)
+	}
+
+	if mode == SyntheticsMonitorDowntimeModes.MONTHLY {
+		setMonitorDowntimeFrequency(d, tags)
+	}
+	return nil
+
+}
+
+func resourceNewRelicMonitorDowntimeUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+	commonArgumentsObject, err := getMonitorDowntimeValuesOfCommonArguments(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	switch commonArgumentsObject.Mode {
+	case SyntheticsMonitorDowntimeModes.OneTime:
+		oneTimeUpdateObject, err := getMonitorDowntimeOneTimeValues(d, commonArgumentsObject)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		guid, err := oneTimeUpdateObject.updateMonitorDowntimeOneTime(ctx, client, synthetics.EntityGUID(d.Id()))
+		if err != nil {
+			// d.SetId("")
+			diag.FromErr(err)
+		}
+
+		d.SetId(guid)
+	case SyntheticsMonitorDowntimeModes.DAILY:
+		dailyUpdateObject, err := getMonitorDowntimeDailyValues(d, commonArgumentsObject)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		guid, err := dailyUpdateObject.updateMonitorDowntimeDaily(ctx, client, synthetics.EntityGUID(d.Id()))
+		if err != nil {
+			// d.SetId("")
+			diag.FromErr(err)
+		}
+
+		d.SetId(guid)
+	case SyntheticsMonitorDowntimeModes.WEEKLY:
+		weeklyUpdateObject, err := getMonitorDowntimeWeeklyValues(d, commonArgumentsObject)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		guid, err := weeklyUpdateObject.updateMonitorDowntimeWeekly(ctx, client, synthetics.EntityGUID(d.Id()))
+		if err != nil {
+			// d.SetId("")
+			diag.FromErr(err)
+		}
+
+		d.SetId(guid)
+	case SyntheticsMonitorDowntimeModes.MONTHLY:
+		monthlyUpdateObject, err := getMonitorDowntimeMonthlyValues(d, commonArgumentsObject)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		guid, err := monthlyUpdateObject.updateMonitorDowntimeMonthly(ctx, client, synthetics.EntityGUID(d.Id()))
+		if err != nil {
+			// d.SetId("")
+			diag.FromErr(err)
+		}
+
+		d.SetId(guid)
+	default:
+		return diag.FromErr(errors.New("invalid mode of operation: 'mode' can be 'ONE_TIME', 'DAILY', 'WEEKLY' or 'MONTHLY'"))
+	}
+
+	return resourceNewRelicMonitorDowntimeRead(ctx, d, meta)
+}
+
+func resourceNewRelicMonitorDowntimeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+
+	resp, err := client.Synthetics.SyntheticsDeleteMonitorDowntimeWithContext(ctx, synthetics.EntityGUID(d.Id()))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if resp == nil {
+		return diag.FromErr(errors.New("encountered an API error while trying to delete the monitor downtime: nil response returned"))
+	}
+	return nil
+}

--- a/newrelic/resource_newrelic_monitor_downtime_test.go
+++ b/newrelic/resource_newrelic_monitor_downtime_test.go
@@ -1,0 +1,424 @@
+//go:build integration
+// +build integration
+
+package newrelic
+
+import (
+	"fmt"
+	"math/rand"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/entities"
+)
+
+var resourceName = fmt.Sprintf("tf-test-%s", acctest.RandString(5))
+
+// TestAccNewRelicMonitorDowntime_Once tests create, update operations of a one time monitor downtime
+func TestAccNewRelicMonitorDowntime_Once(t *testing.T) {
+	rName := fmt.Sprintf("%s-once", resourceName)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// Create
+			{
+				Config: testAccCheckNewRelicMonitorDowntime_OnceConfiguration(rName, SyntheticsMonitorDowntimeModes.OneTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicMonitorDowntimeExists("newrelic_monitor_downtime.foo"),
+				),
+			},
+			// Update
+			{
+				Config: testAccCheckNewRelicMonitorDowntime_OnceConfigurationUpdated(rName, SyntheticsMonitorDowntimeModes.OneTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicMonitorDowntimeExists("newrelic_monitor_downtime.foo"),
+				),
+			},
+			// Import
+			{
+				ResourceName: "newrelic_monitor_downtime.foo",
+				ImportState:  true,
+			},
+		},
+	})
+}
+
+// TestAccNewRelicMonitorDowntime_Daily tests create, update operations of a daily monitor downtime
+func TestAccNewRelicMonitorDowntime_Daily(t *testing.T) {
+	rName := fmt.Sprintf("%s-daily", resourceName)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// Create
+			{
+				Config: testAccCheckNewRelicMonitorDowntime_DailyConfiguration(rName, SyntheticsMonitorDowntimeModes.DAILY),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicMonitorDowntimeExists("newrelic_monitor_downtime.foo"),
+				),
+			},
+			// Update
+			{
+				Config: testAccCheckNewRelicMonitorDowntime_DailyConfigurationUpdated(rName, SyntheticsMonitorDowntimeModes.DAILY),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicMonitorDowntimeExists("newrelic_monitor_downtime.foo"),
+				),
+			},
+			// Import
+			{
+				ResourceName: "newrelic_monitor_downtime.foo",
+				ImportState:  true,
+			},
+		},
+	})
+}
+
+// TestAccNewRelicMonitorDowntime_Weekly tests create, update operations of a weekly monitor downtime
+func TestAccNewRelicMonitorDowntime_Weekly(t *testing.T) {
+	rName := fmt.Sprintf("%s-weekly", resourceName)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// Create
+			{
+				Config: testAccCheckNewRelicMonitorDowntime_WeeklyConfiguration(rName, SyntheticsMonitorDowntimeModes.WEEKLY),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicMonitorDowntimeExists("newrelic_monitor_downtime.foo"),
+				),
+			},
+			// Update
+			{
+				Config: testAccCheckNewRelicMonitorDowntime_WeeklyConfigurationUpdated(rName, SyntheticsMonitorDowntimeModes.WEEKLY),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicMonitorDowntimeExists("newrelic_monitor_downtime.foo"),
+				),
+			},
+			// Import
+			{
+				ResourceName: "newrelic_monitor_downtime.foo",
+				ImportState:  true,
+			},
+		},
+	})
+}
+
+// TestAccNewRelicMonitorDowntime_Monthly tests create, update operations of a monthly monitor downtime
+func TestAccNewRelicMonitorDowntime_Monthly(t *testing.T) {
+	rName := fmt.Sprintf("%s-monthly", resourceName)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// Create
+			{
+				Config: testAccCheckNewRelicMonitorDowntime_MonthlyConfiguration(rName, SyntheticsMonitorDowntimeModes.MONTHLY),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicMonitorDowntimeExists("newrelic_monitor_downtime.foo"),
+				),
+			},
+			// Update
+			{
+				Config: testAccCheckNewRelicMonitorDowntime_MonthlyConfigurationUpdated(rName, SyntheticsMonitorDowntimeModes.MONTHLY),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicMonitorDowntimeExists("newrelic_monitor_downtime.foo"),
+				),
+			},
+			// Import
+			{
+				ResourceName: "newrelic_monitor_downtime.foo",
+				ImportState:  true,
+			},
+		},
+	})
+}
+
+// TestAccNewRelicMonitorDowntime_MultiMode tests creating a monthly downtime and updating it as a daily downtime
+func TestAccNewRelicMonitorDowntime_MultiMode(t *testing.T) {
+	rName := fmt.Sprintf("%s-multimode", resourceName)
+	resource.ParallelTest(t, resource.TestCase{
+		//PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// Create
+			{
+				Config: testAccCheckNewRelicMonitorDowntime_MonthlyConfiguration(rName, SyntheticsMonitorDowntimeModes.MONTHLY),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicMonitorDowntimeExists("newrelic_monitor_downtime.foo"),
+				),
+			},
+			// Update
+			{
+				Config: testAccCheckNewRelicMonitorDowntime_DailyConfigurationUpdated(rName, SyntheticsMonitorDowntimeModes.DAILY),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicMonitorDowntimeExists("newrelic_monitor_downtime.foo"),
+				),
+			},
+			// Import
+			{
+				ResourceName: "newrelic_monitor_downtime.foo",
+				ImportState:  true,
+			},
+		},
+	})
+}
+
+// TestAccNewRelicMonitorDowntime_Once_IncorrectConfig tests the creation of a once time monitor downtime with incorrect configuration
+func TestAccNewRelicMonitorDowntime_Once_IncorrectConfig(t *testing.T) {
+	rName := fmt.Sprintf("%s-once-incorrect", resourceName)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckNewRelicMonitorDowntime_DailyConfiguration(rName, SyntheticsMonitorDowntimeModes.OneTime),
+				ExpectError: regexp.MustCompile(`validation errors`),
+			},
+		},
+	})
+}
+
+// TestAccNewRelicMonitorDowntime_Weekly_IncorrectConfig tests the creation of a weekly monitor downtime with incorrect configuration
+func TestAccNewRelicMonitorDowntime_Weekly_IncorrectConfig(t *testing.T) {
+	rName := fmt.Sprintf("%s-weekly-incorrect", resourceName)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckNewRelicMonitorDowntime_MonthlyConfiguration(rName, SyntheticsMonitorDowntimeModes.WEEKLY),
+				ExpectError: regexp.MustCompile(`validation errors`),
+			},
+		},
+	})
+}
+
+// TestAccNewRelicMonitorDowntime_Monthly_IncorrectConfig tests the creation of a monthly monitor downtime with incorrect configuration
+func TestAccNewRelicMonitorDowntime_Monthly_IncorrectConfig(t *testing.T) {
+	rName := fmt.Sprintf("%s-monthly-incorrect", resourceName)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckNewRelicMonitorDowntime_WeeklyConfiguration(rName, SyntheticsMonitorDowntimeModes.MONTHLY),
+				ExpectError: regexp.MustCompile(`validation errors`),
+			},
+		},
+	})
+}
+
+func testAccCheckNewRelicMonitorDowntimeExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no monitor downtime ID is set")
+		}
+
+		client := testAccProvider.Meta().(*ProviderConfig).NewClient
+
+		found, err := client.Entities.GetEntity(common.EntityGUID(rs.Primary.ID))
+		if err != nil {
+			return fmt.Errorf(err.Error())
+		}
+
+		x := (*found).(*entities.GenericEntity)
+		if x.GUID != common.EntityGUID(rs.Primary.ID) {
+			return fmt.Errorf("monitor downtime not found")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckNewRelicMonitorDowntime_BaseConfiguration(name string, monitorGUIDsConverted string, mode string) string {
+	return `
+	  	name = "` + name + `"
+      	monitor_guids = ` + monitorGUIDsConverted + `
+  		mode       = "` + mode + `"
+  		start_time = "` + generateRandomStartTime() + `"
+  		end_time   = "` + generateRandomEndTime() + `"
+  		time_zone  = "` + generateRandomTimeZone() + `"
+	`
+}
+func testAccCheckNewRelicMonitorDowntime_OnceConfiguration(name string, mode string) string {
+	return `
+		resource "newrelic_monitor_downtime" "foo" {
+  		` + testAccCheckNewRelicMonitorDowntime_BaseConfiguration(name, monitorGUIDsAsString, mode) + `
+		}
+	`
+}
+
+func testAccCheckNewRelicMonitorDowntime_OnceConfigurationUpdated(name string, mode string) string {
+	return `
+		resource "newrelic_monitor_downtime" "foo" {
+  		` + testAccCheckNewRelicMonitorDowntime_BaseConfiguration(fmt.Sprintf("%s-updated", name), monitorGUIDsUpdatedAsString, mode) + `
+		}
+	`
+}
+
+func testAccCheckNewRelicMonitorDowntime_DailyConfiguration(name string, mode string) string {
+	return `
+		resource "newrelic_monitor_downtime" "foo" {
+  		` + testAccCheckNewRelicMonitorDowntime_BaseConfiguration(name, monitorGUIDsAsString, mode) + `
+			end_repeat {
+				on_repeat = 3
+			}
+		}
+	`
+}
+
+func testAccCheckNewRelicMonitorDowntime_DailyConfigurationUpdated(name string, mode string) string {
+	return `
+		resource "newrelic_monitor_downtime" "foo" {
+  		` + testAccCheckNewRelicMonitorDowntime_BaseConfiguration(fmt.Sprintf("%s-updated", name), monitorGUIDsUpdatedAsString, mode) + `
+			end_repeat {
+				on_date = "` + generateRandomEndRepeatDate() + `"
+			}
+		}
+	`
+}
+
+func testAccCheckNewRelicMonitorDowntime_WeeklyConfiguration(name string, mode string) string {
+	return `
+		resource "newrelic_monitor_downtime" "foo" {
+  		` + testAccCheckNewRelicMonitorDowntime_BaseConfiguration(name, monitorGUIDsAsString, mode) + `
+			maintenance_days = ` + generateRandomMaintenanceDays() + `
+		}
+	`
+}
+
+func testAccCheckNewRelicMonitorDowntime_WeeklyConfigurationUpdated(name string, mode string) string {
+	return `
+		resource "newrelic_monitor_downtime" "foo" {
+  		` + testAccCheckNewRelicMonitorDowntime_BaseConfiguration(fmt.Sprintf("%s-updated", name), monitorGUIDsUpdatedAsString, mode) + `
+			maintenance_days = ` + generateRandomMaintenanceDays() + `
+			end_repeat {
+				on_date = "` + generateRandomEndRepeatDate() + `"
+			}
+		}
+	`
+}
+
+func testAccCheckNewRelicMonitorDowntime_MonthlyConfiguration(name string, mode string) string {
+	return `
+		resource "newrelic_monitor_downtime" "foo" {
+  		` + testAccCheckNewRelicMonitorDowntime_BaseConfiguration(name, monitorGUIDsAsString, mode) + `
+			end_repeat {
+				on_date = "` + generateRandomEndRepeatDate() + `"
+			}
+			frequency {
+				days_of_month = [5, 15, 25]
+			}
+		}
+	`
+}
+
+func testAccCheckNewRelicMonitorDowntime_MonthlyConfigurationUpdated(name string, mode string) string {
+	return `
+		resource "newrelic_monitor_downtime" "foo" {
+  		` + testAccCheckNewRelicMonitorDowntime_BaseConfiguration(fmt.Sprintf("%s-updated", name), monitorGUIDsUpdatedAsString, mode) + `
+			frequency {
+				days_of_week {
+					ordinal_day_of_month = "SECOND"
+					week_day = "SATURDAY"
+				}
+			}
+		}
+	`
+}
+
+// helpers for all the tests written above
+var fewValidTimeZones = []string{
+	"Asia/Kolkata",
+	"America/Los_Angeles",
+	"Europe/Madrid",
+	"Asia/Tokyo",
+	"America/Vancouver",
+	"Asia/Tel_Aviv",
+	"Europe/Dublin",
+	"Asia/Tashkent",
+	"Europe/London",
+	"Asia/Riyadh",
+	"America/Chicago",
+	"Australia/Sydney",
+}
+
+// monitors with the below GUIDs belong to the v2 Integration Tests Account
+var monitorGUIDsAsString = convertStringListToString([]string{
+	"MzgwNjUyNnxTWU5USHxNT05JVE9SfGFmZmM0MTRiLTVhNmMtNGI5NS1iMzYwLThhNmQ2ZTkzOTM3Yw",
+})
+var monitorGUIDsUpdatedAsString = convertStringListToString([]string{
+	"MzgwNjUyNnxTWU5USHxNT05JVE9SfDhkYmMyYmIwLTQwZjgtNDA5NC05OTA1LTdhZGE2ZGViMmEwNg",
+	"MzgwNjUyNnxTWU5USHxNT05JVE9SfDViZDNmYTk4LTA2NjgtNGQ1Yy05ODU2LTk3MzlmNWViY2JlNg",
+	"MzgwNjUyNnxTWU5USHxNT05JVE9SfGFmZmM0MTRiLTVhNmMtNGI5NS1iMzYwLThhNmQ2ZTkzOTM3Yw",
+})
+
+func convertStringListToString(list []string) string {
+	return fmt.Sprintf("[\"%s\"]", strings.Join(list, "\", \""))
+}
+func generateRandomTimeZone() string {
+	rand.Seed(time.Now().Unix())
+	return fewValidTimeZones[rand.Intn(len(fewValidTimeZones))]
+}
+
+func generateRandomStartTime() string {
+	rand.Seed(time.Now().Unix())
+
+	now := time.Now()
+	hourLater := now.Add(time.Hour * 2)
+
+	return hourLater.Format("2006-01-02T15:04:05")
+}
+
+func generateRandomEndTime() string {
+	rand.Seed(time.Now().Unix())
+
+	now := time.Now()
+
+	// "5 +" to make sure end_time exceeds start_time by a minimum of 5 days
+	randomDays := 5 + rand.Intn(25)
+	daysLater := now.AddDate(0, 0, randomDays)
+
+	return daysLater.Format("2006-01-02T15:04:05")
+}
+
+func generateRandomEndRepeatDate() string {
+	rand.Seed(time.Now().Unix())
+
+	now := time.Now()
+
+	// "31 +" so that end_repeat > on_date can succeed the date in endTime by 30 days - endRepeat needs to be after endTime
+	randomDays := 31 + rand.Intn(30)
+	daysLater := now.AddDate(0, 0, randomDays)
+
+	return daysLater.Format("2006-01-02")
+}
+
+func generateRandomMaintenanceDays() string {
+	source := rand.NewSource(time.Now().UnixNano())
+	r := rand.New(source)
+
+	originalList := listSyntheticsMonitorDowntimeValidMaintenanceDays()
+
+	// minimum 1, maximum 3
+	randomLength := 1 + r.Intn(3)
+	newList := make([]string, randomLength)
+
+	for i := range newList {
+		randomIndex := r.Intn(len(originalList))
+		newList[i] = originalList[randomIndex]
+	}
+
+	return convertStringListToString(newList)
+}

--- a/newrelic/structures_newrelic_monitor_downtime.go
+++ b/newrelic/structures_newrelic_monitor_downtime.go
@@ -1,0 +1,856 @@
+package newrelic
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/newrelic/newrelic-client-go/v2/newrelic"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/entities"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/synthetics"
+	"golang.org/x/exp/slices"
+)
+
+func listValidOrdinalDayOfMonthValues() []string {
+	return []string{
+		string(synthetics.SyntheticsMonitorDowntimeDayOfMonthOrdinalTypes.FIRST),
+		string(synthetics.SyntheticsMonitorDowntimeDayOfMonthOrdinalTypes.SECOND),
+		string(synthetics.SyntheticsMonitorDowntimeDayOfMonthOrdinalTypes.THIRD),
+		string(synthetics.SyntheticsMonitorDowntimeDayOfMonthOrdinalTypes.FOURTH),
+		string(synthetics.SyntheticsMonitorDowntimeDayOfMonthOrdinalTypes.LAST),
+	}
+}
+
+func listValidWeekDayValues() []string {
+	return []string{
+		string(synthetics.SyntheticsMonitorDowntimeWeekDaysTypes.SUNDAY),
+		string(synthetics.SyntheticsMonitorDowntimeWeekDaysTypes.MONDAY),
+		string(synthetics.SyntheticsMonitorDowntimeWeekDaysTypes.TUESDAY),
+		string(synthetics.SyntheticsMonitorDowntimeWeekDaysTypes.WEDNESDAY),
+		string(synthetics.SyntheticsMonitorDowntimeWeekDaysTypes.THURSDAY),
+		string(synthetics.SyntheticsMonitorDowntimeWeekDaysTypes.FRIDAY),
+		string(synthetics.SyntheticsMonitorDowntimeWeekDaysTypes.SATURDAY),
+	}
+}
+
+var syntheticsMonitorDowntimeMaintenanceDaysMap = map[string]synthetics.SyntheticsMonitorDowntimeWeekDays{
+	"SUNDAY":    synthetics.SyntheticsMonitorDowntimeWeekDaysTypes.SUNDAY,
+	"MONDAY":    synthetics.SyntheticsMonitorDowntimeWeekDaysTypes.MONDAY,
+	"TUESDAY":   synthetics.SyntheticsMonitorDowntimeWeekDaysTypes.TUESDAY,
+	"WEDNESDAY": synthetics.SyntheticsMonitorDowntimeWeekDaysTypes.WEDNESDAY,
+	"THURSDAY":  synthetics.SyntheticsMonitorDowntimeWeekDaysTypes.THURSDAY,
+	"FRIDAY":    synthetics.SyntheticsMonitorDowntimeWeekDaysTypes.FRIDAY,
+	"SATURDAY":  synthetics.SyntheticsMonitorDowntimeWeekDaysTypes.SATURDAY,
+}
+
+func listSyntheticsMonitorDowntimeValidMaintenanceDays() []string {
+	keys := make([]string, 0, len(syntheticsMonitorDowntimeMaintenanceDaysMap))
+
+	for k := range syntheticsMonitorDowntimeMaintenanceDaysMap {
+		keys = append(keys, k)
+	}
+
+	return keys
+}
+
+// validate functions which perform custom validation
+func validateMonitorDowntimeAttributes(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	var errorsList []string
+
+	err := validateMonitorDowntimeEndRepeatStructure(d)
+	if err != nil {
+		errorsList = append(errorsList, err.Error())
+	}
+
+	err = validateMonitorDowntimeMaintenanceDaysStructure(d)
+	if err != nil {
+		errorsList = append(errorsList, err.Error())
+	}
+
+	err = validateMonitorDowntimeFrequencyStructure(d)
+	if err != nil {
+		errorsList = append(errorsList, err.Error())
+	}
+
+	err = validateMonitorDowntimeStartTimeEndTime(d)
+	if err != nil {
+		errorsList = append(errorsList, err.Error())
+	}
+
+	if len(errorsList) == 0 {
+		return nil
+	}
+
+	errorsString := "the following validation errors have been identified: \n"
+
+	for index, val := range errorsList {
+		errorsString += fmt.Sprintf("(%d): %s\n", index+1, val)
+	}
+
+	return errors.New(errorsString)
+}
+
+func validateMonitorDowntimeStartTimeEndTime(d *schema.ResourceDiff) error {
+	_, startTimeObtained := d.GetChange("start_time")
+	_, endTimeObtained := d.GetChange("end_time")
+
+	startTime, _ := time.Parse("2006-01-02T15:04:05", startTimeObtained.(string))
+	endTime, _ := time.Parse("2006-01-02T15:04:05", endTimeObtained.(string))
+
+	if endTime.Before(startTime) {
+		return errors.New("`end_time` cannot be before `start_time`")
+	}
+
+	return nil
+}
+
+func validateMonitorDowntimeFrequencyStructure(d *schema.ResourceDiff) error {
+	_, mode := d.GetChange("mode")
+	_, frequencyObtained := d.GetChange("frequency")
+	frequency := frequencyObtained.([]interface{})
+
+	if mode != SyntheticsMonitorDowntimeModes.MONTHLY && len(frequency) > 0 {
+		return errors.New("the argument `frequency` may only be used with the 'MONTHLY' mode")
+	} else if mode == SyntheticsMonitorDowntimeModes.MONTHLY && len(frequency) == 0 {
+		return errors.New("the argument `frequency` is mandatory to be specified with the 'MONTHLY' mode")
+	}
+
+	frequencyDaysOfMonth, frequencyDaysOfMonthOk := d.GetOkExists("frequency.0.days_of_month")
+	if frequencyDaysOfMonthOk {
+		for _, val := range frequencyDaysOfMonth.(*schema.Set).List() {
+			if val.(int) < 1 || val.(int) > 31 {
+				return errors.New("all `days_of_month` values need to be in the range of 1 and 31")
+			}
+		}
+	}
+
+	return nil
+}
+func validateMonitorDowntimeMaintenanceDaysStructure(d *schema.ResourceDiff) error {
+	_, mode := d.GetChange("mode")
+	_, maintenanceDaysObtained := d.GetChange("maintenance_days")
+	maintenanceDays := maintenanceDaysObtained.(*schema.Set)
+
+	if mode != SyntheticsMonitorDowntimeModes.WEEKLY && maintenanceDays.Len() > 0 {
+		return errors.New("the argument `maintenance_days` may only be used with the 'WEEKLY' mode")
+	} else if mode == SyntheticsMonitorDowntimeModes.WEEKLY && maintenanceDays.Len() == 0 {
+		return errors.New("the argument `maintenance_days` is mandatory to be specified with the 'WEEKLY' mode")
+	}
+
+	listOfValidMaintenanceDays := listSyntheticsMonitorDowntimeValidMaintenanceDays()
+	for _, val := range maintenanceDays.List() {
+		isValidMaintenanceDay := false
+		for _, day := range listOfValidMaintenanceDays {
+			if day == val {
+				isValidMaintenanceDay = true
+			}
+		}
+		if !isValidMaintenanceDay {
+			return fmt.Errorf("%s is not an accepted value for maintenance_days; the acceptable list of values is %v", val, listOfValidMaintenanceDays)
+		}
+	}
+
+	return nil
+}
+
+func validateMonitorDowntimeEndRepeatStructure(d *schema.ResourceDiff) error {
+	_, mode := d.GetChange("mode")
+	_, endRepeatObtained := d.GetChange("end_repeat")
+	endRepeat := endRepeatObtained.([]interface{})
+
+	if len(endRepeat) != 0 && mode == SyntheticsMonitorDowntimeModes.OneTime {
+		return errors.New("the argument `end_repeat` may only be used with the modes `DAILY`, `MONTHLY` and `WEEKLY`")
+	}
+
+	return nil
+}
+
+func validateMonitorDowntimeTimeZone(val interface{}, key string) (warns []string, errs []error) {
+	timezone := val.(string)
+	_, err := time.LoadLocation(timezone)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	return warns, errs
+}
+
+func validateMonitorDowntimeOnDate(val interface{}, key string) (warns []string, errs []error) {
+	valueString := val.(string)
+	_, err := time.Parse("2006-01-02", valueString)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("invalid `on_date` %s: the attribute `on_date` needs to be in the format 'YYYY-MM-DD'", valueString))
+	}
+	return warns, errs
+}
+
+var SyntheticsMonitorDowntimeModes = struct {
+	OneTime string
+	DAILY   string
+	MONTHLY string
+	WEEKLY  string
+}{
+	OneTime: "ONE_TIME",
+	DAILY:   "DAILY",
+	MONTHLY: "MONTHLY",
+	WEEKLY:  "WEEKLY",
+}
+
+// classes whose objects would be used in create/update requests
+type SyntheticsMonitorDowntimeCommonArgumentsInput struct {
+	AccountID    int
+	Name         string
+	Mode         string
+	StartTime    synthetics.NaiveDateTime
+	EndTime      synthetics.NaiveDateTime
+	Timezone     string
+	MonitorGUIDs []synthetics.EntityGUID
+}
+
+type SyntheticsMonitorDowntimeOneTimeInput struct {
+	SyntheticsMonitorDowntimeCommonArgumentsInput
+}
+
+type SyntheticsMonitorDowntimeDailyInput struct {
+	SyntheticsMonitorDowntimeCommonArgumentsInput
+	EndRepeat synthetics.SyntheticsDateWindowEndConfig
+}
+
+type SyntheticsMonitorDowntimeWeeklyInput struct {
+	SyntheticsMonitorDowntimeDailyInput
+	MaintenanceDays []synthetics.SyntheticsMonitorDowntimeWeekDays
+}
+
+type SyntheticsMonitorDowntimeMonthlyInput struct {
+	SyntheticsMonitorDowntimeDailyInput
+	Frequency synthetics.SyntheticsMonitorDowntimeMonthlyFrequency
+}
+
+// GET functions used to fetch values from the configuration
+func getMonitorDowntimeValuesOfCommonArguments(d *schema.ResourceData) (*SyntheticsMonitorDowntimeCommonArgumentsInput, error) {
+	commonArgumentsObject := &SyntheticsMonitorDowntimeCommonArgumentsInput{}
+
+	accountID, err := getMonitorDowntimeAccountIDFromConfiguration(d)
+	if err != nil {
+		return nil, err
+	}
+
+	name, err := getMonitorDowntimeNameFromConfiguration(d)
+	if err != nil {
+		return nil, err
+	}
+
+	mode, err := getMonitorDowntimeModeFromConfiguration(d)
+	if err != nil {
+		return nil, err
+	}
+
+	startTime, err := getMonitorDowntimeStartTimeFromConfiguration(d)
+	if err != nil {
+		return nil, err
+	}
+
+	endTime, err := getMonitorDowntimeEndTimeFromConfiguration(d)
+	if err != nil {
+		return nil, err
+	}
+
+	timezone, err := getMonitorDowntimeTimezoneFromConfiguration(d)
+	if err != nil {
+		return nil, err
+	}
+
+	monitorGUIDs, err := getMonitorDowntimeMonitorGUIDsFromConfiguration(d)
+	if err != nil {
+		return nil, err
+	}
+
+	commonArgumentsObject.AccountID = accountID
+	commonArgumentsObject.Name = name
+	commonArgumentsObject.Mode = mode
+	commonArgumentsObject.StartTime = startTime
+	commonArgumentsObject.EndTime = endTime
+	commonArgumentsObject.Timezone = timezone
+	commonArgumentsObject.MonitorGUIDs = monitorGUIDs
+
+	return commonArgumentsObject, nil
+}
+
+func getMonitorDowntimeAccountIDFromConfiguration(d *schema.ResourceData) (int, error) {
+	val, ok := d.GetOk("account_id")
+	if ok {
+		if val.(string) == "" {
+			return 0, fmt.Errorf("%s has value \"\"", `account_id`)
+		}
+		accountIDAsInteger, err := strconv.Atoi(val.(string))
+		if err != nil {
+			return 0, err
+		}
+		return accountIDAsInteger, nil
+	}
+	accountIDAsInteger, err := strconv.Atoi(os.Getenv("NEW_RELIC_ACCOUNT_ID"))
+	if err != nil {
+		return 0, err
+	}
+	return accountIDAsInteger, nil
+}
+
+func getMonitorDowntimeNameFromConfiguration(d *schema.ResourceData) (string, error) {
+	val, ok := d.GetOk("name")
+	if ok {
+		if val.(string) == "" {
+			return "", fmt.Errorf("%s has value \"\"", `name`)
+		}
+		return val.(string), nil
+	}
+	return "", fmt.Errorf(" value of argument %s not specified", `name`)
+}
+
+func getMonitorDowntimeModeFromConfiguration(d *schema.ResourceData) (string, error) {
+	val, ok := d.GetOk("mode")
+	if ok {
+		if val.(string) == "" {
+			return "", fmt.Errorf("%s has value \"\"", `mode`)
+		}
+		return val.(string), nil
+	}
+	return "", fmt.Errorf(" value of argument %s not specified", `mode`)
+}
+
+func getMonitorDowntimeStartTimeFromConfiguration(d *schema.ResourceData) (synthetics.NaiveDateTime, error) {
+	val, ok := d.GetOk("start_time")
+	if ok {
+		if val.(string) == "" {
+			return "", fmt.Errorf("%s has value \"\"", `start_time`)
+		}
+		return synthetics.NaiveDateTime(val.(string)), nil
+	}
+	return "", fmt.Errorf(" value of argument %s not specified", `start_time`)
+}
+
+func getMonitorDowntimeEndTimeFromConfiguration(d *schema.ResourceData) (synthetics.NaiveDateTime, error) {
+	val, ok := d.GetOk("end_time")
+	if ok {
+		if val.(string) == "" {
+			return "", fmt.Errorf("%s has value \"\"", `end_time`)
+		}
+		return synthetics.NaiveDateTime(val.(string)), nil
+	}
+	return "", fmt.Errorf(" value of argument %s not specified", `end_time`)
+}
+
+func getMonitorDowntimeTimezoneFromConfiguration(d *schema.ResourceData) (string, error) {
+	val, ok := d.GetOk("time_zone")
+	if ok {
+		if val.(string) == "" {
+			return "", fmt.Errorf("%s has value \"\"", `time_zone`)
+		}
+		return val.(string), nil
+	}
+	return "", fmt.Errorf(" value of argument %s not specified", `time_zone`)
+}
+
+func getMonitorDowntimeMonitorGUIDsFromConfiguration(d *schema.ResourceData) ([]synthetics.EntityGUID, error) {
+	val, ok := d.GetOk("monitor_guids")
+	if ok {
+		in := val.(*schema.Set).List()
+		out := make([]synthetics.EntityGUID, len(in))
+		for i := range in {
+			out[i] = synthetics.EntityGUID(in[i].(string))
+		}
+		if len(out) == 0 {
+			return []synthetics.EntityGUID{}, nil
+		}
+		return out, nil
+	}
+	return []synthetics.EntityGUID{}, nil
+}
+
+// GET functions used by create methods
+func getMonitorDowntimeOneTimeValues(d *schema.ResourceData, commonArgumentsObject *SyntheticsMonitorDowntimeCommonArgumentsInput) (*SyntheticsMonitorDowntimeOneTimeInput, error) {
+	return &SyntheticsMonitorDowntimeOneTimeInput{
+		SyntheticsMonitorDowntimeCommonArgumentsInput: *commonArgumentsObject,
+	}, nil
+}
+
+func getMonitorDowntimeDailyValues(d *schema.ResourceData, commonArgumentsObject *SyntheticsMonitorDowntimeCommonArgumentsInput) (*SyntheticsMonitorDowntimeDailyInput, error) {
+	monitorDowntimeDailyInput := &SyntheticsMonitorDowntimeDailyInput{
+		SyntheticsMonitorDowntimeCommonArgumentsInput: *commonArgumentsObject,
+	}
+
+	_, ok := d.GetOk("end_repeat")
+	if ok {
+		// endRepeatStruct := endRepeat.(map[string]interface{})
+		var endRepeatInput synthetics.SyntheticsDateWindowEndConfig
+		onDate, onDateOk := d.GetOk("end_repeat.0.on_date")
+		onRepeat, onRepeatOk := d.GetOk("end_repeat.0.on_repeat")
+
+		if !onDateOk && !onRepeatOk {
+			return nil, errors.New("the block `end_repeat` requires one of `on_date` or `on_repeat` to be specified")
+		} else if onDateOk && onRepeatOk {
+			return nil, errors.New("the block `end_repeat` requires only one of `on_date` or `on_repeat` to be specified, both cannot be specified")
+		}
+
+		endRepeatInput.OnDate = synthetics.Date(onDate.(string))
+		endRepeatInput.OnRepeat = onRepeat.(int)
+		monitorDowntimeDailyInput.EndRepeat = endRepeatInput
+
+	} else {
+		monitorDowntimeDailyInput.EndRepeat = synthetics.SyntheticsDateWindowEndConfig{}
+	}
+
+	return monitorDowntimeDailyInput, nil
+}
+
+func getMonitorDowntimeWeeklyValues(d *schema.ResourceData, commonArgumentsObject *SyntheticsMonitorDowntimeCommonArgumentsInput) (*SyntheticsMonitorDowntimeWeeklyInput, error) {
+	monitorDowntimeDailyInput, err := getMonitorDowntimeDailyValues(d, commonArgumentsObject)
+	if err != nil {
+		return nil, err
+	}
+
+	monitorDowntimeWeeklyInput := &SyntheticsMonitorDowntimeWeeklyInput{
+		SyntheticsMonitorDowntimeDailyInput: *monitorDowntimeDailyInput,
+	}
+
+	// mandatory argument
+	listOfMaintenanceDaysInConfiguration, err := getMaintenanceDaysList(d)
+	if err != nil {
+		return nil, err
+	}
+	maintenanceDays, err := convertSyntheticsMonitorDowntimeMaintenanceDays(listOfMaintenanceDaysInConfiguration)
+	if err != nil {
+		return nil, err
+	}
+	monitorDowntimeWeeklyInput.MaintenanceDays = maintenanceDays
+
+	return monitorDowntimeWeeklyInput, nil
+}
+
+func getMonitorDowntimeMonthlyValues(d *schema.ResourceData, commonArgumentsObject *SyntheticsMonitorDowntimeCommonArgumentsInput) (*SyntheticsMonitorDowntimeMonthlyInput, error) {
+	monitorDowntimeDailyInput, err := getMonitorDowntimeDailyValues(d, commonArgumentsObject)
+	if err != nil {
+		return nil, err
+	}
+
+	monitorDowntimeMonthlyInput := &SyntheticsMonitorDowntimeMonthlyInput{
+		SyntheticsMonitorDowntimeDailyInput: *monitorDowntimeDailyInput,
+	}
+
+	_, ok := d.GetOk("frequency")
+	if !ok {
+		return nil, errors.New("`frequency` is a required argument with monthly monitor downtime")
+	}
+	var frequencyInput synthetics.SyntheticsMonitorDowntimeMonthlyFrequency
+	daysOfMonth, daysOfMonthOk := d.GetOk("frequency.0.days_of_month")
+	_, daysOfWeekOk := d.GetOk("frequency.0.days_of_week")
+	if !daysOfMonthOk && !daysOfWeekOk {
+		return nil, errors.New("the block `frequency` requires one of `days_of_month` or `days_of_week` to be specified")
+	} else if daysOfMonthOk && daysOfWeekOk {
+		return nil, errors.New("the block `frequency` requires one of `days_of_month` or `days_of_week` to be specified but not both")
+	} else if daysOfMonthOk && !daysOfWeekOk {
+		frequencyInput.DaysOfMonth = getFrequencyDaysOfMonthList(daysOfMonth.(*schema.Set).List())
+	} else {
+		var daysOfWeekInput synthetics.SyntheticsDaysOfWeek
+		ordinalDayOfMonth, ordinalDayOfMonthOk := d.GetOk("frequency.0.days_of_week.0.ordinal_day_of_month")
+		weekDay, weekDayOk := d.GetOk("frequency.0.days_of_week.0.week_day")
+		if !ordinalDayOfMonthOk && !weekDayOk {
+			return nil, errors.New("the block `days_of_week` requires specifying both `ordinal_day_of_month` and `week_day`")
+		}
+		daysOfWeekInput.WeekDay = synthetics.SyntheticsMonitorDowntimeWeekDays(weekDay.(string))
+		daysOfWeekInput.OrdinalDayOfMonth = synthetics.SyntheticsMonitorDowntimeDayOfMonthOrdinal(ordinalDayOfMonth.(string))
+		frequencyInput.DaysOfWeek = &daysOfWeekInput
+	}
+	monitorDowntimeMonthlyInput.Frequency = frequencyInput
+
+	return monitorDowntimeMonthlyInput, nil
+}
+
+// Methods which assist create methods
+func (obj *SyntheticsMonitorDowntimeOneTimeInput) createMonitorDowntimeOneTime(ctx context.Context, client *newrelic.NewRelic) (string, error) {
+	resp, err := client.Synthetics.SyntheticsCreateOnceMonitorDowntimeWithContext(
+		ctx,
+		obj.AccountID,
+		obj.EndTime,
+		obj.MonitorGUIDs,
+		obj.Name,
+		obj.StartTime,
+		obj.Timezone,
+	)
+	if err != nil {
+		return "", err
+	}
+	if resp == nil {
+		return "", errors.New("encountered an API error while trying to create a monitor downtime: nil response returned")
+	}
+
+	return string(resp.GUID), nil
+}
+
+func (obj *SyntheticsMonitorDowntimeDailyInput) createMonitorDowntimeDaily(ctx context.Context, client *newrelic.NewRelic) (string, error) {
+	resp, err := client.Synthetics.SyntheticsCreateDailyMonitorDowntimeWithContext(
+		ctx,
+		obj.AccountID,
+		obj.EndRepeat,
+		obj.EndTime,
+		obj.MonitorGUIDs,
+		obj.Name,
+		obj.StartTime,
+		obj.Timezone,
+	)
+	if err != nil {
+		return "", err
+	}
+	if resp == nil {
+		return "", errors.New("encountered an API error while trying to create a monitor downtime: nil response returned")
+	}
+
+	return string(resp.GUID), nil
+}
+
+func (obj *SyntheticsMonitorDowntimeWeeklyInput) createMonitorDowntimeWeekly(ctx context.Context, client *newrelic.NewRelic) (string, error) {
+	resp, err := client.Synthetics.SyntheticsCreateWeeklyMonitorDowntimeWithContext(
+		ctx,
+		obj.AccountID,
+		obj.EndRepeat,
+		obj.EndTime,
+		obj.MaintenanceDays,
+		obj.MonitorGUIDs,
+		obj.Name,
+		obj.StartTime,
+		obj.Timezone,
+	)
+	if err != nil {
+		return "", err
+	}
+	if resp == nil {
+		return "", errors.New("encountered an API error while trying to create a monitor downtime: nil response returned")
+	}
+	return string(resp.GUID), nil
+}
+
+func (obj *SyntheticsMonitorDowntimeMonthlyInput) createMonitorDowntimeMonthly(ctx context.Context, client *newrelic.NewRelic) (string, error) {
+	resp, err := client.Synthetics.SyntheticsCreateMonthlyMonitorDowntimeWithContext(
+		ctx,
+		obj.AccountID,
+		obj.EndRepeat,
+		obj.EndTime,
+		obj.Frequency,
+		obj.MonitorGUIDs,
+		obj.Name,
+		obj.StartTime,
+		obj.Timezone,
+	)
+	if err != nil {
+		return "", err
+	}
+	if resp == nil {
+		return "", errors.New("encountered an API error while trying to create a monitor downtime: nil response returned")
+	}
+
+	return string(resp.GUID), nil
+}
+
+// Methods which assist update methods
+func (obj *SyntheticsMonitorDowntimeOneTimeInput) updateMonitorDowntimeOneTime(ctx context.Context, client *newrelic.NewRelic, guid synthetics.EntityGUID) (string, error) {
+	resp, err := client.Synthetics.SyntheticsEditOneTimeMonitorDowntimeWithContext(
+		ctx,
+		guid,
+		obj.MonitorGUIDs,
+		obj.Name,
+		synthetics.SyntheticsMonitorDowntimeOnceConfig{
+			EndTime:   obj.EndTime,
+			StartTime: obj.StartTime,
+			Timezone:  obj.Timezone,
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+	if resp == nil {
+		return "", errors.New("encountered an API error while trying to create a monitor downtime: nil response returned")
+	}
+
+	return string(resp.GUID), nil
+}
+
+func (obj *SyntheticsMonitorDowntimeDailyInput) updateMonitorDowntimeDaily(ctx context.Context, client *newrelic.NewRelic, guid synthetics.EntityGUID) (string, error) {
+	resp, err := client.Synthetics.SyntheticsEditDailyMonitorDowntimeWithContext(
+		ctx,
+		guid,
+		obj.MonitorGUIDs,
+		obj.Name,
+		synthetics.SyntheticsMonitorDowntimeDailyConfig{
+			EndTime:   obj.EndTime,
+			StartTime: obj.StartTime,
+			Timezone:  obj.Timezone,
+			EndRepeat: obj.EndRepeat,
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+	if resp == nil {
+		return "", errors.New("encountered an API error while trying to create a monitor downtime: nil response returned")
+	}
+
+	return string(resp.GUID), nil
+}
+
+func (obj *SyntheticsMonitorDowntimeWeeklyInput) updateMonitorDowntimeWeekly(ctx context.Context, client *newrelic.NewRelic, guid synthetics.EntityGUID) (string, error) {
+	resp, err := client.Synthetics.SyntheticsEditWeeklyMonitorDowntimeWithContext(
+		ctx,
+		guid,
+		obj.MonitorGUIDs,
+		obj.Name,
+		synthetics.SyntheticsMonitorDowntimeWeeklyConfig{
+			EndTime:         obj.EndTime,
+			StartTime:       obj.StartTime,
+			Timezone:        obj.Timezone,
+			EndRepeat:       obj.EndRepeat,
+			MaintenanceDays: obj.MaintenanceDays,
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+	if resp == nil {
+		return "", errors.New("encountered an API error while trying to create a monitor downtime: nil response returned")
+	}
+	return string(resp.GUID), nil
+}
+
+func (obj *SyntheticsMonitorDowntimeMonthlyInput) updateMonitorDowntimeMonthly(ctx context.Context, client *newrelic.NewRelic, guid synthetics.EntityGUID) (string, error) {
+	resp, err := client.Synthetics.SyntheticsEditMonthlyMonitorDowntimeWithContext(
+		ctx,
+		guid,
+		obj.MonitorGUIDs,
+		obj.Name,
+		synthetics.SyntheticsMonitorDowntimeMonthlyConfig{
+			EndTime:   obj.EndTime,
+			StartTime: obj.StartTime,
+			Timezone:  obj.Timezone,
+			EndRepeat: obj.EndRepeat,
+			Frequency: obj.Frequency,
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+	if resp == nil {
+		return "", errors.New("encountered an API error while trying to create a monitor downtime: nil response returned")
+	}
+
+	return string(resp.GUID), nil
+}
+
+// Other Helper Functions
+func getMaintenanceDaysList(d *schema.ResourceData) ([]string, error) {
+	val, ok := d.GetOk("maintenance_days")
+	if !ok {
+		return nil, errors.New("`maintenance_days` not found in the configuration")
+	}
+	if ok {
+		in := val.(*schema.Set).List()
+		out := make([]string, len(in))
+		for i := range in {
+			out[i] = in[i].(string)
+		}
+		if len(out) == 0 {
+			return nil, errors.New("invalid specification: empty list received in the argument 'maintenance_days'")
+		}
+		return out, nil
+	}
+	return nil, nil
+}
+
+func getFrequencyDaysOfMonthList(daysOfMonth []interface{}) []int {
+	out := make([]int, len(daysOfMonth))
+	for i := range out {
+		out[i] = daysOfMonth[i].(int)
+	}
+	return out
+}
+
+var syntheticsMonitorDowntimeMaintenanceDaysAliasesMap = map[string]synthetics.SyntheticsMonitorDowntimeWeekDays{
+	"SU": synthetics.SyntheticsMonitorDowntimeWeekDaysTypes.SUNDAY,
+	"MO": synthetics.SyntheticsMonitorDowntimeWeekDaysTypes.MONDAY,
+	"TU": synthetics.SyntheticsMonitorDowntimeWeekDaysTypes.TUESDAY,
+	"WE": synthetics.SyntheticsMonitorDowntimeWeekDaysTypes.WEDNESDAY,
+	"TH": synthetics.SyntheticsMonitorDowntimeWeekDaysTypes.THURSDAY,
+	"FR": synthetics.SyntheticsMonitorDowntimeWeekDaysTypes.FRIDAY,
+	"SA": synthetics.SyntheticsMonitorDowntimeWeekDaysTypes.SATURDAY,
+}
+
+func convertSyntheticsMonitorDowntimeMaintenanceDays(maintenanceDays []string) ([]synthetics.SyntheticsMonitorDowntimeWeekDays, error) {
+	maintenanceDaysTypeCasted := make([]synthetics.SyntheticsMonitorDowntimeWeekDays, 0, len(maintenanceDays))
+	listOfValidMaintenanceDays := listSyntheticsMonitorDowntimeValidMaintenanceDays()
+
+	for index, value := range maintenanceDays {
+		isValidDay := slices.Contains(listOfValidMaintenanceDays, value)
+		if !isValidDay {
+			return nil, fmt.Errorf("expected maintenance_days[%d] to be one of %v, got %s", index, listOfValidMaintenanceDays, value)
+		}
+		maintenanceDaysTypeCasted = append(maintenanceDaysTypeCasted, syntheticsMonitorDowntimeMaintenanceDaysMap[value])
+	}
+	return maintenanceDaysTypeCasted, nil
+}
+
+func getStringEntityTag(tags []entities.EntityTag, attributeName string) string {
+	out := []string{}
+	for _, t := range tags {
+		if t.Key == attributeName {
+			out = append(out, t.Values...)
+		}
+	}
+	return out[0]
+}
+
+// Functions which help set values in the state
+func setMonitorDowntimeFrequency(d *schema.ResourceData, tags []entities.EntityTag) {
+	daysOfMonthTag := "monthDay"
+	daysOfWeekTag := "specificWeekDay"
+
+	var daysOfMonthValue []int
+	var daysOfWeekValue = ""
+
+	for _, t := range tags {
+		if t.Key == daysOfMonthTag {
+			for _, v := range t.Values {
+				value, _ := strconv.Atoi(v)
+				daysOfMonthValue = append(daysOfMonthValue, value)
+			}
+		} else if t.Key == daysOfWeekTag {
+			for _, v := range t.Values {
+				daysOfWeekValue = v
+			}
+		}
+	}
+
+	// if neither monthDay or specificWeekDay is found in the tags, it means frequency is absent in the configuration
+	if len(daysOfMonthValue) == 0 && daysOfWeekValue == "" {
+		return
+	}
+
+	if len(daysOfMonthValue) != 0 {
+		_ = d.Set("frequency", []map[string]interface{}{
+			{
+				"days_of_month": daysOfMonthValue,
+			},
+		})
+	}
+
+	if daysOfWeekValue != "" {
+		value := strings.Split(daysOfWeekValue, ":")
+		ordinalDayOfMonth := value[0]
+		weekDay := value[1]
+
+		_ = d.Set("frequency", []map[string]interface{}{
+			{
+				"days_of_week": []map[string]interface{}{
+					{
+						"ordinal_day_of_month": ordinalDayOfMonth,
+						"week_day":             weekDay,
+					},
+				},
+			},
+		})
+	}
+}
+
+func setMonitorDowntimeMaintenanceDays(d *schema.ResourceData, tags []entities.EntityTag) {
+	maintenanceDaysTag := "weekDay"
+	var maintenanceDaysValue []string
+	for _, t := range tags {
+		if t.Key == maintenanceDaysTag {
+			for _, v := range t.Values {
+				val, ok := syntheticsMonitorDowntimeMaintenanceDaysAliasesMap[v]
+				if ok {
+					maintenanceDaysValue = append(maintenanceDaysValue, string(val))
+				}
+			}
+		}
+	}
+	_ = d.Set("maintenance_days", maintenanceDaysValue)
+}
+
+func setMonitorDowntimeEndRepeat(d *schema.ResourceData, tags []entities.EntityTag, timezone string) {
+	onDateTag := "endRepeat"
+	onRepeatTag := "occurrences"
+
+	onDateValue := ""
+
+	// TODO: is there a better way to do this? (not initialise with -1 but something like nil)? Cannot initialise with 0 as it can be a valid end_repeat
+	onRepeatValue := -1
+
+	for _, t := range tags {
+		if t.Key == onDateTag {
+			for _, v := range t.Values {
+				onDateValue = v
+			}
+		} else if t.Key == onRepeatTag {
+			for _, v := range t.Values {
+				onRepeatValue, _ = strconv.Atoi(v)
+			}
+		}
+	}
+
+	// if neither onDate or onRepeat is found in the tags, it means endRepeat is absent in the configuration
+	if onDateValue == "" && onRepeatValue == -1 {
+		return
+	}
+
+	if onDateValue != "" {
+		onDateValueParsed, _ := strconv.ParseInt(onDateValue, 10, 64)
+		dt := time.Unix(onDateValueParsed/1000, 0)
+		loc, _ := time.LoadLocation(timezone)
+		_ = d.Set("end_repeat", []map[string]interface{}{
+			{
+				"on_date": dt.In(loc).Format("2006-01-02"),
+			},
+		})
+	}
+
+	if onRepeatValue != -1 {
+		_ = d.Set("end_repeat", []map[string]interface{}{
+			{
+				"on_repeat": onRepeatValue,
+			},
+		})
+	}
+
+}
+
+func setMonitorDowntimeAccountID(tags []entities.EntityTag) string {
+	return getStringEntityTag(tags, "accountId")
+}
+
+func setMonitorDowntimeMode(tags []entities.EntityTag) string {
+	return getStringEntityTag(tags, "type")
+}
+
+func setMonitorDowntimeTimezone(tags []entities.EntityTag) string {
+	return getStringEntityTag(tags, "timezone")
+}
+
+func setMonitorDowntimeStartTime(tags []entities.EntityTag) string {
+	startTime := getStringEntityTag(tags, "startTime")
+	startTimeIntParsed, _ := strconv.ParseInt(startTime, 10, 64)
+	timezone := getStringEntityTag(tags, "timezone")
+	dt := time.Unix(startTimeIntParsed/1000, 0)
+	loc, _ := time.LoadLocation(timezone)
+	return dt.In(loc).Format("2006-01-02T15:04:05")
+}
+
+func setMonitorDowntimeEndTime(tags []entities.EntityTag) string {
+	endTime := getStringEntityTag(tags, "endTime")
+	endTimeIntParsed, _ := strconv.ParseInt(endTime, 10, 64)
+	timezone := getStringEntityTag(tags, "timezone")
+	dt := time.Unix(endTimeIntParsed/1000, 0)
+	loc, _ := time.LoadLocation(timezone)
+	return dt.In(loc).Format("2006-01-02T15:04:05")
+}

--- a/website/docs/guides/upcoming_synthetics_muted_status_eol_guide.html.markdown
+++ b/website/docs/guides/upcoming_synthetics_muted_status_eol_guide.html.markdown
@@ -12,7 +12,7 @@ Use this guide to find details on the upcoming end-of-life of the `MUTED` status
 ### About Synthetic Monitors' 'MUTED' Status and the EOL
 Synthetic Monitors have a `status` field that defines the activity of the monitor, and can currently be either of `ENABLED`, `DISABLED`, or `MUTED`. When a monitor is MUTED, it still functions as usual (runs tests), but is muted; i.e., it does not send out notifications in cases of failure.
 
-Since it has been announced that New Relic Synthetics will discontinue support for the `MUTED` status of monitors, slated to hit its end-of-life in February 2024 (see [this community post](https://forum.newrelic.com/s/hubtopic/aAX8W0000015BHc/endoflife-product-updates-july-2023-september-2023)), the `MUTED` value of `status` has been marked **deprecated** in the New Relic Terraform Provider, in late October 2023. The provider will also _soon_ **discontinue support** for the value `MUTED` pertaining to the `status` argument of resources operating on Synthetic Monitors, with the next major release of the provider, tentatively scheduled in December 2023.
+Since it has been announced that New Relic Synthetics will discontinue support for the `MUTED` status of monitors, slated to hit its end-of-life in February 2024 (see [this community post](https://forum.newrelic.com/s/hubtopic/aAX8W0000015BHc/endoflife-product-updates-july-2023-september-2023)), the `MUTED` value of `status` has been marked **deprecated** in the New Relic Terraform Provider, in late October 2023. The provider will also _soon_ **discontinue support** for the value `MUTED` pertaining to the `status` argument of resources operating on Synthetic Monitors, with a release of the Terraform Provider in February 2023.
 
 This would affect all resources in the provider used to manage Synthetic Monitors (_only if_ your configuration comprises these resources with a `status = "MUTED"` argument), i.e.
 * [`newrelic_synthetics_monitor`](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/synthetics_monitor)
@@ -29,14 +29,14 @@ Considering the above, it is highly recommended for users to refrain from using 
 There are two key alternatives one can opt for, to replicate the behavior of the `MUTED` status of Synthetic Monitors.
 * [**Alert Muting Rules**](https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/muting-rules-suppress-notifications/)
   * Alert Muting Rules, by definition, are similar to the `MUTED` status of Synthetic Monitors in terms of behavior, though these cater to a wider scope; all kinds of alerts. These help mute alerts on the basis of pre-defined schedules and attribute matching (when alerts match the condition(s) prescribed by the user in terms of incident event attributes, operators and values, they can be muted). See [this page](https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/incident-event-attributes/) for a comprehensive list of attributes supported by Muting Rules.
-  * This feature may be availed from the New Relic One UI, NerdGraph, and also via the resource [`newrelic_alert_muting_rule`](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/alert_muting_rule) in the New Relic Terraform Provider. Check out the example below, for an example explaining how this resource can _exactly_ be used to substitute the `MUTED` status of a Synthetic Monitor.
+  * This feature may be availed from the New Relic One UI, NerdGraph, and also via the resource [`newrelic_alert_muting_rule`](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/alert_muting_rule) in the New Relic Terraform Provider. Check out the example below to find how this resource can _exactly_ be used to substitute the `MUTED` status of a Synthetic Monitor.
 * [**Monitor Downtime**](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/monitor-downtimes-disable-monitoring-during-scheduled-maintenance-times/)
   * A 'Monitor Downtime', as the name suggests, helps set up a 'downtime' or a maintenance window for Synthetic Monitors, in which period they do not run, as a result of which alerts are not raised, and no notifications are received.
-  * This feature is currently available via the New Relic One UI. A Terraform resource to facilitate managing Monitor Downtimes is currently undergoing development, and is expected to be out soon.
+  * This feature may be availed from the New Relic One UI, NerdGraph and also via a _new_ resource that's been built to facilitate managing Monitor Downtimes via Terraform, [`newrelic_monitor_downtime`](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/monitor_downtime). Check out the example below for an understanding of how this resource helps mute monitors.
 
 It is important to note the difference between the functioning of Alert Muting Rules and Monitor Downtimes when these are considered to be used as substitutes to the `MUTED` status of Synthetic Monitors.
-* Since Alert Muting Rules are designed to mute alerts based on conditions they match, alerts generated by checks performed by monitors are muted, but does not affect the checks performed by these monitors, which would continue to function as usual.
-* However, since Monitor Downtimes are dedicated to scheduling "downtime"s of monitors, no alerts would be generated by monitors in this case, as they would stop running checks for the period defined in the downtime.
+* Since Alert Muting Rules are designed to mute alerts based on conditions they match, alerts generated by checks performed by monitors are muted; however, this does not affect the checks performed by these monitors, which would continue to function as usual.
+* Since Monitor Downtimes are dedicated to scheduling "downtime"s of monitors, no alerts would be generated by monitors in this case, as they would stop running checks for the period defined in the downtime.
   Users may need to choose the right alternative, based on the expected behavior they desire, when monitors are muted.
 
 ### Substituting Synthetic Monitors `MUTED` Status With Alert Muting Rules
@@ -50,7 +50,7 @@ resource "newrelic_synthetics_monitor" "sample_synthetics_monitor" {
   period           = "EVERY_MINUTE"
   uri              = "https://www.one.newrelic.com"
   type             = "BROWSER"
-  locations_public = ["AP_SOUTH_1"]
+  locations_public = ["AP_EAST_1"]
   custom_header {
     name  = "some_name"
     value = "some_value"
@@ -84,3 +84,30 @@ resource "newrelic_alert_muting_rule" "sample_alert_muting_rule" {
 ```
 
 The configuration of the muting rule may be customized, based on any apt approach identified - one of which could be to use the attribute `conditionId` in the condition, to match it against the ID of the alert condition that checks for failures of tests run by the preferred Synthetic Monitor (for instance, a `SyntheticCheck` based NRQL Alert Condition), so the muting rule is applied to any alerts originating out of the condition that evaluates monitor failures/successes. Head over to the [documentation of the resource](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/alert_muting_rule) for more details on attributes supported by `condition` blocks.
+
+### Substituting Synthetic Monitors `MUTED` Status With a Monitor Downtime
+
+Setting up a Monitor Downtime resource with GUIDs of the right monitors would disable Synthetic checks in the window specified, thereby, muting the monitor (please read the differences between Muting Rules and Monitor Downtimes, explained above).
+
+```hcl
+resource "newrelic_monitor_downtime" "foo" {
+  name = "Sample Monitor Downtime"
+  monitor_guids = [
+    "<GUID-1>",
+    "<GUID-2>"
+  ]
+  mode       = "WEEKLY"
+  start_time = "2023-11-30T10:30:00"
+  end_time   = "2023-12-10T10:30:00"
+  time_zone  = "Asia/Kolkata"
+  end_repeat {
+    on_date = "2023-12-20"
+  }
+  maintenance_days = [
+    "MONDAY",
+    "TUESDAY",
+  ]
+}
+```
+
+For more examples and details of arguments of the `newrelic_monitor_downtime` resource, head over to [this page](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/monitor_downtime). 

--- a/website/docs/r/monitor_downtime.html.markdown
+++ b/website/docs/r/monitor_downtime.html.markdown
@@ -1,0 +1,179 @@
+---
+layout: "newrelic"
+page_title: "New Relic: newrelic_monitor_downtime"
+sidebar_current: "docs-newrelic-resource-monitor_downtime"
+description: |-
+    Create and manage Monitor Downtimes in New Relic.
+---
+
+# Resource: newrelic\_monitor\_downtime
+
+Use this resource to create, update, and delete Monitor Downtimes in New Relic.
+
+## Example Usage
+
+```hcl
+resource "newrelic_monitor_downtime" "foo" {
+  name = "Sample Monitor Downtime"
+  monitor_guids = [
+    "<GUID-1>",
+    "<GUID-2>"
+  ]
+  mode       = "WEEKLY"
+  start_time = "2023-11-30T10:30:00"
+  end_time   = "2023-12-10T10:30:00"
+  time_zone  = "Asia/Kolkata"
+  end_repeat {
+    on_date = "2023-12-20"
+  }
+  maintenance_days = [
+    "MONDAY",
+    "TUESDAY",
+  ]
+}
+```
+Monitor Downtimes are of four types; once, daily, weekly and monthly. For more details on each type and the right arguments that go with them, check out the [argument reference][#argument-reference] and [examples](#examples) sections below.
+
+## Argument Reference
+
+### Arguments Common To All Four Types of Monitor Downtimes
+
+* `account_id`- (Optional) The account in which the monitor downtime would be created. Defaults to `NEW_RELIC_ACCOUNT_ID` in the environment, if not specified.
+* `name` - (Required) Name of the monitor downtime to be created.
+* `mode` - (Required) One of the four modes of operation of Monitor Downtimes - `ONE_TIME`, `DAILY`, `MONTHLY` or `WEEKLY`.
+* `monitor_guids` - (Optional) A list of GUIDs of monitors the Monitor Downtime would need to be applied to.
+* `start_time` - (Required) The time at which the Monitor Downtime would begin to operate, a timestamp specified in the ISO 8601 format without the offset - for instance, `2023-12-04T14:27:07`.
+* `end_time` - (Required) The time at which the Monitor Downtime would end operating, a timestamp specified in the ISO 8601 format without the offset - for instance, `2023-12-04T14:27:07`.
+* `timezone` - (Required) The timezone in which `start_time` and `end_time` have been specified.
+
+### Arguments Specific Only to Certain Types of Monitor Downtimes
+
+The following arguments go only with certain types of monitor downtimes, and are hence, optional, at a resource schema level. However, some of these are required to be specified with certain types of monitor downtimes - please see notes adjoining arguments in the list below.
+
+* `end_repeat` - Options which may be used to specify when the repeat cycle of the monitor should end. This argument comprises the following nested arguments -
+  * `on_date` - The date on which the monitor downtime's repeat cycle would need to come to an end, a string in "DDDD-MM-YY" format.
+  * `on_repeat` - An integer that specifies the number of occurrences, after which the monitor downtime's repeat cycle would need to come to an end.
+
+-> **NOTE:** `end_repeat` **can only be used with the modes** `DAILY`, `MONTHLY` and `WEEKLY` and **is an optional argument** when monitor downtimes of these modes are created. Additionally, **either** `on_date` or `on_repeat` **are required to be specified with** `end_repeat`, but not both, as `on_date` and `on_repeat` are mutually exclusive.
+
+* `maintenance_days` - A list of days on which monthly monitor downtimes would function. Valid values which go into this list would be `"SUNDAY"`, `"MONDAY"`, `"TUESDAY"`, `"WEDNESDAY"`, `"THURSDAY"`, `"FRIDAY"` and/or `"SATURDAY"`.
+
+-> **NOTE:** `maintenance_days` **can only be used with the mode** `MONTHLY`, and **is a required argument** with weekly monitor downtimes (if the `mode` is `WEEKLY`). 
+
+* `frequency` - Options which may be used to specify the configuration of a monthly monitor downtime. This argument comprises the following nested arguments -
+    * `days_of_month` - A list of integers, specifying the days of a month on which the monthly monitor downtime would function.
+    * `days_of_week` - An argument that specifies a day of a week and its occurrence in a month, on which the monthly monitor downtime would function. This argument, further, comprises the following nested arguments - 
+      * `week_day` - A day of the week (one of `"SUNDAY"`, `"MONDAY"`, `"TUESDAY"`, `"WEDNESDAY"`, `"THURSDAY"`, `"FRIDAY"` or `"SATURDAY"`).
+      * `ordinal_day_of_month` - The occurrence of `week_day` in a month (one of `"FIRST"`, `"SECOND"`, `"THIRD"`, `"FOURTH"`, `"LAST"`).
+
+-> **NOTE:** `frequency` **can only be used with the mode** `WEEKLY`, and **is a required argument** with monthly monitor downtimes (if the `mode` is `MONTHLY`). Additionally, **either** `days_of_month` or `days_of_week` **are required to be specified with** `frequency`, but not both, as `days_of_month` and `days_of_week` are mutually exclusive. If `days_of_week` is specified, values of **both** of its nested arguments, `week_day` and `ordinal_day_of_month` **would need to be specified** too.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID (GUID) of the monitor downtime.
+
+## Examples
+
+### One-Time Monitor Downtime
+
+The below example illustrates creating a 'one-time' monitor downtime. 
+
+```hcl
+resource "newrelic_monitor_downtime" "sample_one_time_newrelic_monitor_downtime" {
+  name = "Sample One Time Monitor Downtime"
+  monitor_guids = [
+    "<GUID-1>",
+    "<GUID-2>",
+  ]
+  mode       = "ONE_TIME"
+  start_time = "2023-12-04T10:15:00"
+  end_time   = "2024-01-04T10:15:00"
+  time_zone  = "America/Los_Angeles"
+}
+```
+
+### Daily Monitor Downtime
+
+The below example illustrates creating a 'daily' monitor downtime. 
+
+Note that `end_repeat` has been specified in the configuration; however, this is optional, in accordance with the rules of `end_repeat` specified in the [argument reference][#argument-reference] section above.
+
+```hcl
+resource "newrelic_monitor_downtime" "sample_daily_newrelic_monitor_downtime" {
+  name = "Sample Daily Monitor Downtime"
+  monitor_guids = [
+    "<GUID-1>",
+    "<GUID-2>",
+  ]
+  mode       = "DAILY"
+  start_time = "2023-12-04T18:15:00"
+  end_time   = "2024-01-04T18:15:00"
+  end_repeat {
+    on_date = "2023-12-25"
+  }
+  time_zone = "Asia/Kolkata"
+}
+```
+
+### Weekly Monitor Downtime
+
+The below example illustrates creating a 'weekly' monitor downtime. 
+
+Note that `maintenance_days` has been specified in the configuration as it is required with weekly monitor downtimes; and `end_repeat` has not been specified as it is optional, all in accordance with the rules of these arguments specified in the [argument reference][#argument-reference] section above.
+
+```hcl
+resource "newrelic_monitor_downtime" "sample_weekly_newrelic_monitor_downtime" {
+  name = "Sample Weekly Monitor Downtime"
+  monitor_guids = [
+    "<GUID-1>",
+    "<GUID-2>",
+  ]
+  mode       = "WEEKLY"
+  start_time = "2023-12-04T14:15:00"
+  end_time   = "2024-01-04T14:15:00"
+  time_zone  = "US/Hawaii"
+  maintenance_days = [
+    "SATURDAY",
+    "SUNDAY"
+  ]
+} 
+```
+
+### Monthly Monitor Downtime
+
+The below example illustrates creating a monthly monitor downtime.
+
+Note that `frequency` has been specified in the configuration as it is required with monthly monitor downtimes, and `end_repeat` has been specified too, though it is optional, all in accordance with the rules of these arguments specified in the [argument reference][#argument-reference] section above.
+
+```hcl
+resource "newrelic_monitor_downtime" "sample_monthly_newrelic_monitor_downtime" {
+  name = "Sample Monthly Monitor Downtime"
+  monitor_guids = [
+    "<GUID-1>",
+    "<GUID-2>",
+  ]
+  mode       = "MONTHLY"
+  start_time = "2023-12-04T07:15:00"
+  end_time   = "2024-01-04T07:15:00"
+  end_repeat {
+    on_repeat = 6
+  }
+  time_zone = "Europe/Dublin"
+  frequency {
+    days_of_week {
+      ordinal_day_of_month = "SECOND"
+      week_day             = "SATURDAY"
+    }
+  }
+} 
+```
+
+## Import
+
+A monitor downtime can be imported into Terraform configuration using its `guid`, i.e.
+
+```bash
+$ terraform import newrelic_monitor_downtime.monitor <guid>
+```

--- a/website/docs/r/monitor_downtime.html.markdown
+++ b/website/docs/r/monitor_downtime.html.markdown
@@ -44,7 +44,7 @@ Monitor Downtimes are of four types; once, daily, weekly and monthly. For more d
 * `monitor_guids` - (Optional) A list of GUIDs of monitors the Monitor Downtime would need to be applied to.
 * `start_time` - (Required) The time at which the Monitor Downtime would begin to operate, a timestamp specified in the ISO 8601 format without the offset - for instance, `2023-12-04T14:27:07`.
 * `end_time` - (Required) The time at which the Monitor Downtime would end operating, a timestamp specified in the ISO 8601 format without the offset - for instance, `2023-12-04T14:27:07`.
-* `timezone` - (Required) The timezone in which `start_time` and `end_time` have been specified.
+* `timezone` - (Required) The timezone in which timestamps `start_time` and `end_time` have been specified. Valid timezones which may be specified with this argument can be found in this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List), in the column '**TZ identifier**'. 
 
 ### Arguments Specific Only to Certain Types of Monitor Downtimes
 


### PR DESCRIPTION
This PR adds a resource `newrelic_monitor_downtime` to support the creation/updates to Monitor Downtimes in New Relic Synthetics.

For a quick gist of arguments supported by this to-be resource and sample configuration, please take a look at this README file.

https://github.com/newrelic/terraform-provider-newrelic/blob/feat/monitor-downtime-v2/website/docs/r/monitor_downtime.html.markdown

All test cases added are seen to pass, latest run 12:30 PDT - https://github.com/newrelic/terraform-provider-newrelic/actions/runs/7169338620/job/19524783432