### PR TITLE
fix(docs): fix the URL in newrelic-aws-cloud-integrations module

### DIFF
--- a/website/docs/guides/cloud_integrations_guide.html.markdown
+++ b/website/docs/guides/cloud_integrations_guide.html.markdown
@@ -55,7 +55,7 @@ The GitHub repository of the Terraform Provider also has an AWS Cloud Integratio
 
 ```
 module "newrelic-aws-cloud-integrations" {
-  source = "github.com/newrelic/terraform-provider-newrelic/examples/modules/cloud-integrations/aws"
+  source = "github.com/newrelic/terraform-provider-newrelic//examples/modules/cloud-integrations/aws"
 
   newrelic_account_id     = 1234567
   newrelic_account_region = "US"
@@ -101,7 +101,7 @@ The GitHub repository of the Terraform Provider also has an Azure Cloud Integrat
 
 ```
 module "newrelic-azure-cloud-integrations" {
-  source = "github.com/newrelic/terraform-provider-newrelic/examples/modules/cloud-integrations/azure"
+  source = "github.com/newrelic/terraform-provider-newrelic//examples/modules/cloud-integrations/azure"
 
   newrelic_account_id     = 1234567
   name                    = "production"
@@ -141,7 +141,7 @@ The GitHub repository of the Terraform Provider also has an GCP Cloud Integratio
 
 ```
 module "newrelic-gcp-cloud-integrations" {
-  source = "github.com/newrelic/terraform-provider-newrelic/examples/modules/cloud-integrations/gcp"
+  source = "github.com/newrelic/terraform-provider-newrelic//examples/modules/cloud-integrations/gcp"
 
   newrelic_account_id     = 1234567
   name                    = "production"


### PR DESCRIPTION
Sub directories must be referenced using a special double-slash syntax:

https://developer.hashicorp.com/terraform/language/modules/sources#modules-in-package-sub-directories

Without double-slash syntax, dependabot will fail to run.

# Description

Please include a summary of the change and which issue is fixed (if relevant).

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Step 1
- Step 2
- etc
