### PR TITLE
feat(dashboards): Added ignore time picker as options field to the da…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.27.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.23.0
+	github.com/newrelic/newrelic-client-go/v2 v2.23.1-0.20240111075350-daafaf84cc4b
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 )

--- a/go.sum
+++ b/go.sum
@@ -267,8 +267,8 @@ github.com/newrelic/go-agent/v3 v3.27.0 h1:Z3XB49d8FKjRcGzCyViCO9itBxiLPSpwjY1Hl
 github.com/newrelic/go-agent/v3 v3.27.0/go.mod h1:TUzePinDc0BMH4Sui66rl4SBe6yOKJ5X/bRJekwuAtM=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.23.0 h1:ULqiPv4Z0QVLjMjX6uP13wSxPDL3uiKTt5U8vFsvpCQ=
-github.com/newrelic/newrelic-client-go/v2 v2.23.0/go.mod h1:VPWTvEfKvnTZLunAC7fiW33y4e0srznNfN5HJH2cOp8=
+github.com/newrelic/newrelic-client-go/v2 v2.23.1-0.20240111075350-daafaf84cc4b h1:vGE8yvkcXCzHo61KqOzMRYdPc0eyVeBEz2wwSBHkfyQ=
+github.com/newrelic/newrelic-client-go/v2 v2.23.1-0.20240111075350-daafaf84cc4b/go.mod h1:VPWTvEfKvnTZLunAC7fiW33y4e0srznNfN5HJH2cOp8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/newrelic/resource_newrelic_one_dashboard.go
+++ b/newrelic/resource_newrelic_one_dashboard.go
@@ -113,6 +113,20 @@ func dashboardVariableSchemaElem() *schema.Resource {
 				Required:    true,
 				Description: "The variable identifier.",
 			},
+			"options": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Options applied to the variable.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ignore_time_range": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "Only applies to variables of type NRQL. With this turned on, the time range for the NRQL query will override the time picker on dashboards and other pages. Turn this off to use the time picker as normal.",
+						},
+					},
+				},
+			},
 			"nrql_query": {
 				Type:        schema.TypeList,
 				Optional:    true,

--- a/newrelic/resource_newrelic_one_dashboard_json_test.go
+++ b/newrelic/resource_newrelic_one_dashboard_json_test.go
@@ -161,6 +161,9 @@ func testAccCheckNewRelicOneDashboardJsonConfig_Full(pageName string, accountID 
 					"query": "FROM Transaction SELECT average(duration) FACET appName"
 				},
 				"name": "variableNRQL",
+			    "options": {
+					"ignoreTimeRange": true,
+				},
 				"replacementStrategy": "DEFAULT",
 				"title": "title",
 				"type": "NRQL"

--- a/newrelic/structures_newrelic_one_dashboard.go
+++ b/newrelic/structures_newrelic_one_dashboard.go
@@ -86,21 +86,28 @@ func expandDashboardVariablesInput(variables []interface{}) []dashboards.Dashboa
 			variable.Type = dashboards.DashboardVariableType(strings.ToUpper(ty.(string)))
 		}
 
+		if i, ok := v["options"]; ok {
+			ignoreTimeRange, is := i.(bool)
+			if is {
+				variable.Options = dashboards.DashboardVariableOptionsInput{IgnoreTimeRange: ignoreTimeRange}
+			}
+		}
+
 		expanded[i] = variable
 	}
 	return expanded
 }
 
-func expandVariableDefaultValues(in []interface{}) *[]dashboards.DashboardVariableDefaultItemInput {
-	out := make([]dashboards.DashboardVariableDefaultItemInput, len(in))
+func expandVariableDefaultValues(in []interface{}) []*dashboards.DashboardVariableDefaultItemInput {
+	out := make([]*dashboards.DashboardVariableDefaultItemInput, len(in))
 
 	for i, v := range in {
 		cfg := v.(string)
-		expanded := dashboards.DashboardVariableDefaultItemInput{Value: dashboards.DashboardVariableDefaultValueInput{String: cfg}}
-		out[i] = expanded
+		expanded := dashboards.DashboardVariableDefaultItemInput{Value: &dashboards.DashboardVariableDefaultValueInput{String: cfg}}
+		out[i] = &expanded
 	}
 
-	return &out
+	return out
 }
 
 func expandVariableItems(in []interface{}) []dashboards.DashboardVariableEnumItemInput {
@@ -118,7 +125,7 @@ func expandVariableItems(in []interface{}) []dashboards.DashboardVariableEnumIte
 	return out
 }
 
-func expandVariableNRQLQuery(in []interface{}) *dashboards.DashboardVariableNRQLQueryInput {
+func expandVariableNRQLQuery(in []interface{}) dashboards.DashboardVariableNRQLQueryInput {
 	var out dashboards.DashboardVariableNRQLQueryInput
 
 	for _, v := range in {
@@ -128,7 +135,7 @@ func expandVariableNRQLQuery(in []interface{}) *dashboards.DashboardVariableNRQL
 			Query:      nrdb.NRQL(cfg["query"].(string))}
 	}
 
-	return &out
+	return out
 }
 
 func expandVariableAccountIDs(in []interface{}) []int {


### PR DESCRIPTION
[**DO NOT MERGE** - Deployment to be followed by a change on NerdGraph]
Dashboard Variables

# Description

Added a new field called ignore time range enclosed as options under the dashboard variables.

This option applies only to variables of type NRQL. With this turned on, the time range for the NRQL query will override the time picker on dashboards and other pages. Turn this off to use the time picker as normal.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.
