### PR TITLE
feat(sl_alert_helper): add slow_burn service levels alert helper

### DIFF
--- a/newrelic/data_source_newrelic_service_level_alert_helper.go
+++ b/newrelic/data_source_newrelic_service_level_alert_helper.go
@@ -105,7 +105,7 @@ func dataSourceNewRelicServiceLevelAlertHelperRead(ctx context.Context, d *schem
 			return diag.FromErr(err)
 		}
 
-        return setDataWithErrors(d, 60, 2)
+		return setDataWithErrors(d, 60, 2)
 
 	case serviceLevelAlertTypes.slowBurn:
 		if tOk || eOk {
@@ -118,7 +118,7 @@ func dataSourceNewRelicServiceLevelAlertHelperRead(ctx context.Context, d *schem
 			return diag.FromErr(err)
 		}
 
-        return setDataWithErrors(d, 360, 5)
+		return setDataWithErrors(d, 360, 5)
 
 	case serviceLevelAlertTypes.custom:
 		if !tOk || !eOk {
@@ -127,13 +127,13 @@ func dataSourceNewRelicServiceLevelAlertHelperRead(ctx context.Context, d *schem
 
 		toleratedBudgetConsumption := d.Get("custom_tolerated_budget_consumption").(float64)
 		evaluationPeriod := d.Get("custom_evaluation_period").(int)
-        threshold := calculateThreshold(sloTarget, toleratedBudgetConsumption, sloPeriod, evaluationPeriod)
+		threshold := calculateThreshold(sloTarget, toleratedBudgetConsumption, sloPeriod, evaluationPeriod)
 
 		if err := d.Set("threshold", threshold); err != nil {
 			return diag.FromErr(err)
 		}
 
-        return setDataWithErrors(d, evaluationPeriod, toleratedBudgetConsumption)
+		return setDataWithErrors(d, evaluationPeriod, toleratedBudgetConsumption)
 	}
 
 	return nil
@@ -164,4 +164,3 @@ func setDataWithErrors(d *schema.ResourceData, evaluationPeriod int, toleratedBu
 
 	return nil
 }
-

--- a/newrelic/data_source_newrelic_service_level_alert_helper_integration_test.go
+++ b/newrelic/data_source_newrelic_service_level_alert_helper_integration_test.go
@@ -247,7 +247,7 @@ func testAccCheckNewRelicServiceLevelAlertHelper_FastBurn(n string) resource.Tes
 			"tolerated_budget_consumption":        "2",
 			"threshold":                           "1.3439999999999237",
 			"sli_guid":                            "sliGuid",
-			"nrql":                                "FROM Metric SELECT 100 - clamp_max(sum(newrelic.sli.good) / sum(newrelic.sli.valid) * 100, 100) as 'SLO compliance'  WHERE sli.guid = 'sliGuid'",
+			"nrql":                                "FROM Metric SELECT 100 - clamp_max(sum(newrelic.sli.good) / sum(newrelic.sli.valid) * 100, 100) as 'SLO compliance' WHERE sli.guid = 'sliGuid'",
 		}
 
 		for attrName, expectedVal := range testCases {
@@ -283,7 +283,7 @@ func testAccCheckNewRelicServiceLevelAlertHelper_SlowBurn(n string) resource.Tes
 			"tolerated_budget_consumption":        "5",
 			"threshold":                           "0.5599999999999682",
 			"sli_guid":                            "sliGuid",
-			"nrql":                                "FROM Metric SELECT 100 - clamp_max(sum(newrelic.sli.good) / sum(newrelic.sli.valid) * 100, 100) as 'SLO compliance'  WHERE sli.guid = 'sliGuid'",
+			"nrql":                                "FROM Metric SELECT 100 - clamp_max(sum(newrelic.sli.good) / sum(newrelic.sli.valid) * 100, 100) as 'SLO compliance' WHERE sli.guid = 'sliGuid'",
 		}
 
 		for attrName, expectedVal := range testCases {
@@ -332,7 +332,7 @@ func testAccCheckNewRelicServiceLevelAlertHelper_Custom(n string) resource.TestC
 			"tolerated_budget_consumption":        "5",
 			"threshold":                           "8.4",
 			"sli_guid":                            "sliGuidCustom",
-			"nrql":                                "FROM Metric SELECT 100 - clamp_max(sum(newrelic.sli.good) / sum(newrelic.sli.valid) * 100, 100) as 'SLO compliance'  WHERE sli.guid = 'sliGuidCustom'",
+			"nrql":                                "FROM Metric SELECT 100 - clamp_max(sum(newrelic.sli.good) / sum(newrelic.sli.valid) * 100, 100) as 'SLO compliance' WHERE sli.guid = 'sliGuidCustom'",
 		}
 
 		for attrName, expectedVal := range testCases {

--- a/website/docs/d/service_level_alert_helper.html.markdown
+++ b/website/docs/d/service_level_alert_helper.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Data Source: newrelic\_service\_level\_alert\_helper
 
-Use this data source to obtain the necessary fields to set up alerts on your service levels. It can be used for a `custom` alert_type in order to set up an alert with custom tolerated budget consumption and custom evaluation period or for recommended ones like `fast_burn`. For more information check [the documentation](https://docs.newrelic.com/docs/service-level-management/alerts-slm/).
+Use this data source to obtain the necessary fields to set up alerts on your service levels. It can be used for a `custom` alert_type in order to set up an alert with custom tolerated budget consumption and custom evaluation period or for recommended ones like `fast_burn` or `slow_burn`. For more information check [the documentation](https://docs.newrelic.com/docs/service-level-management/alerts-slm/).
 
 ## Example Usage
 
@@ -98,6 +98,7 @@ The following arguments are supported:
   * `alert_type` - (Required) The type of alert we want to set. Valid values are:
     * `custom` - Tolerated budget consumption and evaluation period have to be specified.
     * `fast_burn` - Tolerated budget consumption is 2% and evaluation period is 60min.
+    * `slow_burn` - Tolerated budget consumption is 5% and evaluation period is 360min.
   * `sli_guid` - (Required) The guid of the sli we want to set the alert on.
   * `slo_target` - (Required) The target of the Service Level Objective, valid values between `0` and `100`.
   * `slo_period` - (Required) The time window of the Service Level Objective in days. Valid values are `1`, `7` and `28`.


### PR DESCRIPTION
# Description

Add `slow_burn` to the default alert types the helper provides help for.

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Following the instructions in the readme for the data source and creating one for `slow_burn`, then verify the exported fields are correct. There are integration tests that do this, so those can be taken as an example.
