### PR TITLE
fix(service_level_alert_helper): fix value returned by evaluation_period

### DIFF
--- a/newrelic/data_source_newrelic_service_level_alert_helper.go
+++ b/newrelic/data_source_newrelic_service_level_alert_helper.go
@@ -96,7 +96,7 @@ func dataSourceNewRelicServiceLevelAlertHelperRead(ctx context.Context, d *schem
 			return diag.Errorf("For 'fast_burn' alert type do not fill 'custom_evaluation_period' or 'custom_tolerated_budget_consumption', we use 60 minutes and 2%%.")
 		}
 
-		if err := fillData(d, 60, 2); err != nil {
+		if err := fillData(d, 3600, 2); err != nil {
 			return diag.FromErr(err)
 		}
 
@@ -105,7 +105,7 @@ func dataSourceNewRelicServiceLevelAlertHelperRead(ctx context.Context, d *schem
 			return diag.Errorf("For 'slow_burn' alert type do not fill 'custom_evaluation_period' or 'custom_tolerated_budget_consumption', we use 360 minutes and 5%%.")
 		}
 
-		if err := fillData(d, 360, 5); err != nil {
+		if err := fillData(d, 21600, 5); err != nil {
 			return diag.FromErr(err)
 		}
 
@@ -154,5 +154,5 @@ func fillData(d *schema.ResourceData, evaluationPeriod int, toleratedBudgetConsu
 }
 
 func calculateThreshold(sloTarget float64, toleratedBudgetConsumption float64, sloPeriod int, evaluationPeriod int) float64 {
-	return (100.0 - sloTarget) * ((toleratedBudgetConsumption / 100 * float64(sloPeriod) * 24) / (float64(evaluationPeriod) / 60.0))
+	return (100.0 - sloTarget) * ((toleratedBudgetConsumption / 100 * float64(sloPeriod) * 24) / (float64(evaluationPeriod) / 3600.0))
 }

--- a/newrelic/data_source_newrelic_service_level_alert_helper_integration_test.go
+++ b/newrelic/data_source_newrelic_service_level_alert_helper_integration_test.go
@@ -243,7 +243,7 @@ func testAccCheckNewRelicServiceLevelAlertHelper_FastBurn(n string) resource.Tes
 			"alert_type":                          "fast_burn",
 			"custom_evaluation_period":            "",
 			"custom_tolerated_budget_consumption": "",
-			"evaluation_period":                   "60",
+			"evaluation_period":                   "3600",
 			"tolerated_budget_consumption":        "2",
 			"threshold":                           "1.3439999999999237",
 			"sli_guid":                            "sliGuid",
@@ -279,7 +279,7 @@ func testAccCheckNewRelicServiceLevelAlertHelper_SlowBurn(n string) resource.Tes
 			"alert_type":                          "slow_burn",
 			"custom_evaluation_period":            "",
 			"custom_tolerated_budget_consumption": "",
-			"evaluation_period":                   "360",
+			"evaluation_period":                   "21600",
 			"tolerated_budget_consumption":        "5",
 			"threshold":                           "0.5599999999999682",
 			"sli_guid":                            "sliGuid",
@@ -304,7 +304,7 @@ data "newrelic_service_level_alert_helper" "custom" {
     slo_target = 98
     slo_period = 7
     custom_tolerated_budget_consumption = 5
-    custom_evaluation_period = 120
+    custom_evaluation_period = 7200
 }
 `)
 }
@@ -326,9 +326,9 @@ func testAccCheckNewRelicServiceLevelAlertHelper_Custom(n string) resource.TestC
 			"slo_period":                          "7",
 			"slo_target":                          "98",
 			"alert_type":                          "custom",
-			"custom_evaluation_period":            "120",
+			"custom_evaluation_period":            "7200",
 			"custom_tolerated_budget_consumption": "5",
-			"evaluation_period":                   "120",
+			"evaluation_period":                   "7200",
 			"tolerated_budget_consumption":        "5",
 			"threshold":                           "8.4",
 			"sli_guid":                            "sliGuidCustom",
@@ -353,7 +353,7 @@ data "newrelic_service_level_alert_helper" "custom" {
     slo_target = 98
     slo_period = 7
     custom_tolerated_budget_consumption = 5
-    custom_evaluation_period = 120
+    custom_evaluation_period = 7200
     is_bad_events = true
 }
 `)
@@ -376,9 +376,9 @@ func testAccCheckNewRelicServiceLevelAlertHelper_CustomBadEvents(n string) resou
 			"slo_period":                          "7",
 			"slo_target":                          "98",
 			"alert_type":                          "custom",
-			"custom_evaluation_period":            "120",
+			"custom_evaluation_period":            "7200",
 			"custom_tolerated_budget_consumption": "5",
-			"evaluation_period":                   "120",
+			"evaluation_period":                   "7200",
 			"tolerated_budget_consumption":        "5",
 			"threshold":                           "8.4",
 			"sli_guid":                            "sliGuidCustom",

--- a/newrelic/data_source_newrelic_service_level_alert_helper_unit_test.go
+++ b/newrelic/data_source_newrelic_service_level_alert_helper_unit_test.go
@@ -13,7 +13,7 @@ func TestCalculateAlertThreshold(t *testing.T) {
 	var sloPeriod = 28
 	var sloTarget = 99.9
 	var toleratedBudgetConsumption = 2.0
-	var evaluationPeriod = 60
+	var evaluationPeriod = 3600
 
 	threshold := calculateThreshold(sloTarget, toleratedBudgetConsumption, sloPeriod, evaluationPeriod)
 


### PR DESCRIPTION
# Description

There was a issue with the value returned for `evaluation_period`, it was returned in minutes and what the alert needs is seconds. Fixed that and updated documentation accordingly.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Use the example on the documentation to create a slow_burn or a fast_burn alert for a service level. All the code needed to do so is in the documentation
