### PR TITLE
chore(monitor_downtime): fixes to error handling, `account_id` default to that in `provider{}`

### DIFF
--- a/build/tools.mk
+++ b/build/tools.mk
@@ -14,10 +14,10 @@ TOOL_CONFIG  ?= $(TOOL_DIR)/tools.go
 
 GOTOOLS ?= $(shell cd $(TOOL_DIR) && go list -f '{{ .Imports }}' -tags tools |tr -d '[]')
 
-tools: check-version
-	@echo "=== $(PROJECT_NAME) === [ tools            ]: Installing tools required by the project..."
-	@cd $(TOOL_DIR) && $(VENDOR_CMD)
-	@cd $(TOOL_DIR) && $(GO) install $(GOTOOLS)
+#tools: check-version
+#	@echo "=== $(PROJECT_NAME) === [ tools            ]: Installing tools required by the project..."
+#	@cd $(TOOL_DIR) && $(VENDOR_CMD)
+#	@cd $(TOOL_DIR) && $(GO) install $(GOTOOLS)
 
 tools-outdated: check-version
 	@echo "=== $(PROJECT_NAME) === [ tools-outdated   ]: Finding outdated tool deps with $(GO_MOD_OUTDATED)..."

--- a/build/tools.mk
+++ b/build/tools.mk
@@ -14,10 +14,10 @@ TOOL_CONFIG  ?= $(TOOL_DIR)/tools.go
 
 GOTOOLS ?= $(shell cd $(TOOL_DIR) && go list -f '{{ .Imports }}' -tags tools |tr -d '[]')
 
-#tools: check-version
-#	@echo "=== $(PROJECT_NAME) === [ tools            ]: Installing tools required by the project..."
-#	@cd $(TOOL_DIR) && $(VENDOR_CMD)
-#	@cd $(TOOL_DIR) && $(GO) install $(GOTOOLS)
+tools: check-version
+	@echo "=== $(PROJECT_NAME) === [ tools            ]: Installing tools required by the project..."
+	@cd $(TOOL_DIR) && $(VENDOR_CMD)
+	@cd $(TOOL_DIR) && $(GO) install $(GOTOOLS)
 
 tools-outdated: check-version
 	@echo "=== $(PROJECT_NAME) === [ tools-outdated   ]: Finding outdated tool deps with $(GO_MOD_OUTDATED)..."

--- a/newrelic/resource_newrelic_monitor_downtime.go
+++ b/newrelic/resource_newrelic_monitor_downtime.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"os"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -40,10 +39,10 @@ func resourceNewRelicMonitorDowntime() *schema.Resource {
 				// ValidateFunc: validation included in validateMonitorDowntimeMonitorGUIDs as this is a set and is unsupported by the "validation" package
 			},
 			"account_id": {
-				Type:        schema.TypeString,
-				Description: "The ID of the New Relic account in which the Monitor Downtime shall be created. Defaults to NEW_RELIC_ACCOUNT_ID if not specified.",
+				Type:        schema.TypeInt,
+				Description: "The ID of the New Relic account in which the Monitor Downtime shall be created. Defaults to the `account_id` in the provider{} configuration if not specified.",
 				Optional:    true,
-				Default:     os.Getenv("NEW_RELIC_ACCOUNT_ID"),
+				Computed:    true,
 			},
 			"start_time": {
 				Type:         schema.TypeString,
@@ -162,7 +161,7 @@ func resourceNewRelicMonitorDowntime() *schema.Resource {
 func resourceNewRelicMonitorDowntimeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
 	client := providerConfig.NewClient
-	commonArgumentsObject, err := getMonitorDowntimeValuesOfCommonArguments(d)
+	commonArgumentsObject, err := getMonitorDowntimeValuesOfCommonArguments(d, providerConfig)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -177,7 +176,7 @@ func resourceNewRelicMonitorDowntimeCreate(ctx context.Context, d *schema.Resour
 		guid, err := oneTimeCreateObject.createMonitorDowntimeOneTime(ctx, client)
 		if err != nil {
 			d.SetId("")
-			diag.FromErr(err)
+			return diag.FromErr(err)
 		}
 
 		d.SetId(guid)
@@ -190,7 +189,7 @@ func resourceNewRelicMonitorDowntimeCreate(ctx context.Context, d *schema.Resour
 		guid, err := dailyCreateObject.createMonitorDowntimeDaily(ctx, client)
 		if err != nil {
 			d.SetId("")
-			diag.FromErr(err)
+			return diag.FromErr(err)
 		}
 
 		d.SetId(guid)
@@ -203,7 +202,7 @@ func resourceNewRelicMonitorDowntimeCreate(ctx context.Context, d *schema.Resour
 		guid, err := weeklyCreateObject.createMonitorDowntimeWeekly(ctx, client)
 		if err != nil {
 			d.SetId("")
-			diag.FromErr(err)
+			return diag.FromErr(err)
 		}
 
 		d.SetId(guid)
@@ -216,7 +215,7 @@ func resourceNewRelicMonitorDowntimeCreate(ctx context.Context, d *schema.Resour
 		guid, err := monthlyCreateObject.createMonitorDowntimeMonthly(ctx, client)
 		if err != nil {
 			d.SetId("")
-			diag.FromErr(err)
+			return diag.FromErr(err)
 		}
 
 		d.SetId(guid)
@@ -281,7 +280,7 @@ func resourceNewRelicMonitorDowntimeRead(ctx context.Context, d *schema.Resource
 func resourceNewRelicMonitorDowntimeUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
 	client := providerConfig.NewClient
-	commonArgumentsObject, err := getMonitorDowntimeValuesOfCommonArguments(d)
+	commonArgumentsObject, err := getMonitorDowntimeValuesOfCommonArguments(d, providerConfig)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -296,7 +295,7 @@ func resourceNewRelicMonitorDowntimeUpdate(ctx context.Context, d *schema.Resour
 		guid, err := oneTimeUpdateObject.updateMonitorDowntimeOneTime(ctx, client, synthetics.EntityGUID(d.Id()))
 		if err != nil {
 			// d.SetId("")
-			diag.FromErr(err)
+			return diag.FromErr(err)
 		}
 
 		d.SetId(guid)
@@ -309,7 +308,7 @@ func resourceNewRelicMonitorDowntimeUpdate(ctx context.Context, d *schema.Resour
 		guid, err := dailyUpdateObject.updateMonitorDowntimeDaily(ctx, client, synthetics.EntityGUID(d.Id()))
 		if err != nil {
 			// d.SetId("")
-			diag.FromErr(err)
+			return diag.FromErr(err)
 		}
 
 		d.SetId(guid)
@@ -322,7 +321,7 @@ func resourceNewRelicMonitorDowntimeUpdate(ctx context.Context, d *schema.Resour
 		guid, err := weeklyUpdateObject.updateMonitorDowntimeWeekly(ctx, client, synthetics.EntityGUID(d.Id()))
 		if err != nil {
 			// d.SetId("")
-			diag.FromErr(err)
+			return diag.FromErr(err)
 		}
 
 		d.SetId(guid)
@@ -335,7 +334,7 @@ func resourceNewRelicMonitorDowntimeUpdate(ctx context.Context, d *schema.Resour
 		guid, err := monthlyUpdateObject.updateMonitorDowntimeMonthly(ctx, client, synthetics.EntityGUID(d.Id()))
 		if err != nil {
 			// d.SetId("")
-			diag.FromErr(err)
+			return diag.FromErr(err)
 		}
 
 		d.SetId(guid)

--- a/newrelic/structures_newrelic_monitor_downtime.go
+++ b/newrelic/structures_newrelic_monitor_downtime.go
@@ -277,21 +277,6 @@ func getMonitorDowntimeValuesOfCommonArguments(d *schema.ResourceData, providerC
 	return commonArgumentsObject, nil
 }
 
-func getMonitorDowntimeAccountIDFromConfiguration(d *schema.ResourceData, providerConfig *ProviderConfig) (int, error) {
-	val, ok := d.GetOk("account_id")
-	if ok {
-		if val.(string) == "" {
-			return 0, fmt.Errorf("%s has value \"\"", `account_id`)
-		}
-		accountIDAsInteger, err := strconv.Atoi(val.(string))
-		if err != nil {
-			return 0, err
-		}
-		return accountIDAsInteger, nil
-	}
-	return providerConfig.AccountID, nil
-}
-
 func getMonitorDowntimeNameFromConfiguration(d *schema.ResourceData) (string, error) {
 	val, ok := d.GetOk("name")
 	if ok {

--- a/newrelic/structures_newrelic_monitor_downtime.go
+++ b/newrelic/structures_newrelic_monitor_downtime.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -232,13 +231,10 @@ type SyntheticsMonitorDowntimeMonthlyInput struct {
 }
 
 // GET functions used to fetch values from the configuration
-func getMonitorDowntimeValuesOfCommonArguments(d *schema.ResourceData) (*SyntheticsMonitorDowntimeCommonArgumentsInput, error) {
+func getMonitorDowntimeValuesOfCommonArguments(d *schema.ResourceData, providerConfig *ProviderConfig) (*SyntheticsMonitorDowntimeCommonArgumentsInput, error) {
 	commonArgumentsObject := &SyntheticsMonitorDowntimeCommonArgumentsInput{}
 
-	accountID, err := getMonitorDowntimeAccountIDFromConfiguration(d)
-	if err != nil {
-		return nil, err
-	}
+	accountID := selectAccountID(providerConfig, d)
 
 	name, err := getMonitorDowntimeNameFromConfiguration(d)
 	if err != nil {
@@ -281,7 +277,7 @@ func getMonitorDowntimeValuesOfCommonArguments(d *schema.ResourceData) (*Synthet
 	return commonArgumentsObject, nil
 }
 
-func getMonitorDowntimeAccountIDFromConfiguration(d *schema.ResourceData) (int, error) {
+func getMonitorDowntimeAccountIDFromConfiguration(d *schema.ResourceData, providerConfig *ProviderConfig) (int, error) {
 	val, ok := d.GetOk("account_id")
 	if ok {
 		if val.(string) == "" {
@@ -293,11 +289,7 @@ func getMonitorDowntimeAccountIDFromConfiguration(d *schema.ResourceData) (int, 
 		}
 		return accountIDAsInteger, nil
 	}
-	accountIDAsInteger, err := strconv.Atoi(os.Getenv("NEW_RELIC_ACCOUNT_ID"))
-	if err != nil {
-		return 0, err
-	}
-	return accountIDAsInteger, nil
+	return providerConfig.AccountID, nil
 }
 
 func getMonitorDowntimeNameFromConfiguration(d *schema.ResourceData) (string, error) {
@@ -825,8 +817,10 @@ func setMonitorDowntimeEndRepeat(d *schema.ResourceData, tags []entities.EntityT
 
 }
 
-func setMonitorDowntimeAccountID(tags []entities.EntityTag) string {
-	return getStringEntityTag(tags, "accountId")
+func setMonitorDowntimeAccountID(tags []entities.EntityTag) int {
+	fetchedAccountID := getStringEntityTag(tags, "accountId")
+	x, _ := strconv.Atoi(fetchedAccountID)
+	return x
 }
 
 func setMonitorDowntimeMode(tags []entities.EntityTag) string {


### PR DESCRIPTION
This PR aims at fixing the following - 
- Issue noticed in https://github.com/newrelic/terraform-provider-newrelic/issues/2546; the `account_id` attribute of the resource would need to default to `account_id` in the `provider{}` block and not directly depend on `NEW_RELIC_ACCOUNT_ID` in the environment (given, `NEW_RELIC_ACCOUNT_ID` in the environment would be taken up by `account_id` in the `provider{}` block anyway, unless the `account_id` in the `provider{}` block is overridden, which is the expected outcome of this fix)
- A few fixes to error handling