### PR TITLE
fix(service_levels_alert_helper): Unify suggested queries with the UI

### DIFF
--- a/newrelic/data_source_newrelic_service_level_alert_helper.go
+++ b/newrelic/data_source_newrelic_service_level_alert_helper.go
@@ -135,9 +135,9 @@ func fillData(d *schema.ResourceData, evaluationPeriod int, toleratedBudgetConsu
 
 	var nrql string
 	if d.Get("is_bad_events").(bool) {
-		nrql = fmt.Sprintf("FROM Metric SELECT 100 - clamp_max((sum(newrelic.sli.valid) - sum(newrelic.sli.bad)) / sum(newrelic.sli.valid) * 100, 100) as 'SLO compliance' WHERE sli.guid = '%v'", d.Get("sli_guid"))
+		nrql = fmt.Sprintf("FROM Metric SELECT 100 - clamp_max((sum(newrelic.sli.valid) - sum(newrelic.sli.bad)) / sum(newrelic.sli.valid) * 100, 100) AS 'Error rate' WHERE entity.guid = '%v'", d.Get("sli_guid"))
 	} else {
-		nrql = fmt.Sprintf("FROM Metric SELECT 100 - clamp_max(sum(newrelic.sli.good) / sum(newrelic.sli.valid) * 100, 100) as 'SLO compliance' WHERE sli.guid = '%v'", d.Get("sli_guid"))
+		nrql = fmt.Sprintf("FROM Metric SELECT 100 - clamp_max(sum(newrelic.sli.good) / sum(newrelic.sli.valid) * 100, 100) AS 'Error rate' WHERE entity.guid = '%v'", d.Get("sli_guid"))
 	}
 	if err := d.Set("nrql", nrql); err != nil {
 		return err

--- a/newrelic/data_source_newrelic_service_level_alert_helper_integration_test.go
+++ b/newrelic/data_source_newrelic_service_level_alert_helper_integration_test.go
@@ -247,7 +247,7 @@ func testAccCheckNewRelicServiceLevelAlertHelper_FastBurn(n string) resource.Tes
 			"tolerated_budget_consumption":        "2",
 			"threshold":                           "1.3439999999999237",
 			"sli_guid":                            "sliGuid",
-			"nrql":                                "FROM Metric SELECT 100 - clamp_max(sum(newrelic.sli.good) / sum(newrelic.sli.valid) * 100, 100) as 'SLO compliance' WHERE sli.guid = 'sliGuid'",
+			"nrql":                                "FROM Metric SELECT 100 - clamp_max(sum(newrelic.sli.good) / sum(newrelic.sli.valid) * 100, 100) AS 'Error rate' WHERE entity.guid = 'sliGuid'",
 		}
 
 		for attrName, expectedVal := range testCases {
@@ -283,7 +283,7 @@ func testAccCheckNewRelicServiceLevelAlertHelper_SlowBurn(n string) resource.Tes
 			"tolerated_budget_consumption":        "5",
 			"threshold":                           "0.5599999999999682",
 			"sli_guid":                            "sliGuid",
-			"nrql":                                "FROM Metric SELECT 100 - clamp_max(sum(newrelic.sli.good) / sum(newrelic.sli.valid) * 100, 100) as 'SLO compliance' WHERE sli.guid = 'sliGuid'",
+			"nrql":                                "FROM Metric SELECT 100 - clamp_max(sum(newrelic.sli.good) / sum(newrelic.sli.valid) * 100, 100) AS 'Error rate' WHERE entity.guid = 'sliGuid'",
 		}
 
 		for attrName, expectedVal := range testCases {
@@ -332,7 +332,7 @@ func testAccCheckNewRelicServiceLevelAlertHelper_Custom(n string) resource.TestC
 			"tolerated_budget_consumption":        "5",
 			"threshold":                           "8.4",
 			"sli_guid":                            "sliGuidCustom",
-			"nrql":                                "FROM Metric SELECT 100 - clamp_max(sum(newrelic.sli.good) / sum(newrelic.sli.valid) * 100, 100) as 'SLO compliance' WHERE sli.guid = 'sliGuidCustom'",
+			"nrql":                                "FROM Metric SELECT 100 - clamp_max(sum(newrelic.sli.good) / sum(newrelic.sli.valid) * 100, 100) AS 'Error rate' WHERE entity.guid = 'sliGuidCustom'",
 		}
 
 		for attrName, expectedVal := range testCases {
@@ -382,7 +382,7 @@ func testAccCheckNewRelicServiceLevelAlertHelper_CustomBadEvents(n string) resou
 			"tolerated_budget_consumption":        "5",
 			"threshold":                           "8.4",
 			"sli_guid":                            "sliGuidCustom",
-			"nrql":                                "FROM Metric SELECT 100 - clamp_max((sum(newrelic.sli.valid) - sum(newrelic.sli.bad)) / sum(newrelic.sli.valid) * 100, 100) as 'SLO compliance' WHERE sli.guid = 'sliGuidCustom'",
+			"nrql":                                "FROM Metric SELECT 100 - clamp_max((sum(newrelic.sli.valid) - sum(newrelic.sli.bad)) / sum(newrelic.sli.valid) * 100, 100) AS 'Error rate' WHERE entity.guid = 'sliGuidCustom'",
 		}
 
 		for attrName, expectedVal := range testCases {


### PR DESCRIPTION
# Description

Until now the UI and the provider were suggesting two different queries (with the same result). We decided to unify them for a more consistent experience.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

