### PR TITLE
newrelic_entity_optional - entity that may not exist

### DIFF
--- a/newrelic/data_source_newrelic_entity_optional.go
+++ b/newrelic/data_source_newrelic_entity_optional.go
@@ -1,0 +1,161 @@
+package newrelic
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/entities"
+)
+
+func dataSourceNewRelicEntityOptional() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceNewRelicEntityOptionalRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the entity in New Relic One. The first entity matching this name for the given search parameters will be returned.",
+			},
+			"ignore_case": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Ignore case when searching the entity name.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The entity's type. Valid values are APPLICATION, DASHBOARD, HOST, MONITOR, SERVICE and WORKLOAD.",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.EqualFold(old, new) // Case fold this attribute when diffing
+				},
+			},
+			"domain": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The entity's domain. Valid values are APM, BROWSER, INFRA, MOBILE, SYNTH, and EXT. If not specified, all domains are searched.",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.EqualFold(old, new) // Case fold this attribute when diffing
+				},
+			},
+			"tag": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "A tag applied to the entity.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The tag key.",
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The tag value.",
+						},
+					},
+				},
+			},
+			"account_id": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				Description:  "The New Relic account ID; if specified, constrains the data source to return an entity belonging to the account with this ID, of all matching entities retrieved.",
+				ValidateFunc: validation.IntAtLeast(1),
+			},
+			"application_id": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The domain-specific ID of the entity (only returned for APM and Browser applications).",
+			},
+			"serving_apm_application_id": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The browser-specific ID of the backing APM entity. (only returned for Browser applications)",
+			},
+			"guid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "A unique entity identifier.",
+			},
+		},
+	}
+}
+
+func dataSourceNewRelicEntityOptionalRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*ProviderConfig).NewClient
+	accountID := meta.(*ProviderConfig).AccountID
+	if acc, ok := d.GetOk("account_id"); ok {
+		accountID = acc.(int)
+	}
+
+	log.Printf("[INFO] Reading New Relic entities")
+
+	name := d.Get("name").(string)
+	name = escapeSingleQuote(name)
+	ignoreCase := d.Get("ignore_case").(bool)
+	entityType := strings.ToUpper(d.Get("type").(string))
+	domain := strings.ToUpper(d.Get("domain").(string))
+	tags := d.Get("tag").([]interface{})
+
+	query := buildEntitySearchQuery(name, domain, entityType, tags)
+
+	entityResults, err := client.Entities.GetEntitySearchByQueryWithContext(ctx,
+		entities.EntitySearchOptions{
+			CaseSensitiveTagMatching: ignoreCase,
+		},
+		query,
+		[]entities.EntitySearchSortCriteria{},
+	)
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if entityResults == nil {
+		return diag.FromErr(fmt.Errorf("GetEntitySearchByQuery response was nil"))
+	}
+
+	var entity *entities.EntityOutlineInterface
+	for _, e := range entityResults.Results.Entities {
+		// Conditional on case-sensitive match
+
+		str := e.GetName()
+		str = strings.TrimSpace(str)
+
+		name = revertEscapedSingleQuote(name)
+		if strings.Compare(str, name) == 0 || (ignoreCase && strings.EqualFold(str, name)) {
+			if e.GetAccountID() != accountID {
+				continue
+			} else {
+				entity = &e
+				break
+			}
+
+		}
+	}
+
+	if entity == nil {
+		// Instead of returning an error, set the resource ID and default values
+		d.SetId("not_found") // Use a more appropriate value or generate a UUID
+		// Set default or "empty" values for all expected attributes
+		d.Set("name", "")
+		d.Set("guid", "")
+		d.Set("type", "")
+		d.Set("domain", "")
+		d.Set("account_id", 0)
+		// Note: You might want to adjust the defaults based on what makes sense for your use case
+
+		return nil // No error is returned
+	}
+
+	return diag.FromErr(flattenEntityData(entity, d))
+}

--- a/newrelic/provider.go
+++ b/newrelic/provider.go
@@ -127,6 +127,7 @@ func Provider() *schema.Provider {
 			"newrelic_authentication_domain":        dataSourceNewRelicAuthenticationDomain(),
 			"newrelic_cloud_account":                dataSourceNewRelicCloudAccount(),
 			"newrelic_entity":                       dataSourceNewRelicEntity(),
+			"newrelic_entity_optional":              dataSourceNewRelicEntityOptional(),
 			"newrelic_group":                        dataSourceNewRelicGroup(),
 			"newrelic_key_transaction":              dataSourceNewRelicKeyTransaction(),
 			"newrelic_notification_destination":     dataSourceNewRelicNotificationDestination(),


### PR DESCRIPTION
newrelic_entity_optional - An entity data source that may or may not exist

# Description

Attempt to work around the fact that entities for which data is still retained might no longer exist in the API. By creating a new data source with that specific behavior, we would avoid breaking changes to be introduced to existing code bases, while allowing new relic users which are facing the issue with deleted entities to have a work around.

For more information: https://github.com/newrelic/terraform-provider-newrelic/pull/2599

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [ ] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Step 1
- Step 2
- etc
