### PR TITLE
fix(dashboards): fix to dashboard name update failure with filter_current_dashboard

### DIFF
--- a/newrelic/resource_newrelic_one_dashboard.go
+++ b/newrelic/resource_newrelic_one_dashboard.go
@@ -648,7 +648,7 @@ func resourceNewRelicOneDashboardCreate(ctx context.Context, d *schema.ResourceD
 	defaultInfo := map[string]interface{}{
 		"account_id": accountID,
 	}
-	dashboard, err := expandDashboardInput(d, defaultInfo)
+	dashboard, err := expandDashboardInput(d, defaultInfo, "")
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -691,7 +691,7 @@ func resourceNewRelicOneDashboardCreate(ctx context.Context, d *schema.ResourceD
 			return diag.FromErr(err)
 		}
 
-		dashboard, err := expandDashboardInput(d, defaultInfo)
+		dashboard, err := expandDashboardInput(d, defaultInfo, created.EntityResult.Name)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -748,7 +748,7 @@ func resourceNewRelicOneDashboardUpdate(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
-	dashboard, err := expandDashboardInput(d, defaultInfo)
+	dashboard, err := expandDashboardInput(d, defaultInfo, "")
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -783,7 +783,7 @@ func resourceNewRelicOneDashboardUpdate(ctx context.Context, d *schema.ResourceD
 			return diag.FromErr(err)
 		}
 
-		dashboard, err = expandDashboardInput(d, defaultInfo)
+		dashboard, err = expandDashboardInput(d, defaultInfo, updated.EntityResult.Name)
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/newrelic/structures_newrelic_one_dashboard.go
+++ b/newrelic/structures_newrelic_one_dashboard.go
@@ -19,11 +19,15 @@ import (
 
 // Assemble the *dashboards.DashboardInput struct.
 // Used by the newrelic_one_dashboard Create function.
-func expandDashboardInput(d *schema.ResourceData, meta interface{}) (*dashboards.DashboardInput, error) {
+func expandDashboardInput(d *schema.ResourceData, meta interface{}, dashboardNameCustom string) (*dashboards.DashboardInput, error) {
 	var err error
 
-	dash := dashboards.DashboardInput{
-		Name: d.Get("name").(string),
+	dash := dashboards.DashboardInput{}
+
+	if dashboardNameCustom != "" {
+		dash.Name = dashboardNameCustom
+	} else {
+		dash.Name = d.Get("name").(string)
 	}
 
 	dash.Pages, err = expandDashboardPageInput(d, d.Get("page").([]interface{}), meta)


### PR DESCRIPTION
#### Background

Via a recent support case, it was observed that if the `name` of a dashboard is updated, it wouldn't get updated (neither in the Terraform state, nor in the UI) while all other attributes would. 

Upon further investigation (lots of trial and error), it was identified that this was happening because two API calls went out  when Terraform would try updating configuration, which made obvious that the following section of the code was the culprit (as this comprises the **second** update call performed within the update function). 

This also made clear that the failure of the dashboard's name getting updated was seen only upon using the attribute `filter_current_dashboard` as control flow would only then enter the following section of code as the number of widgets to filter would be > 0. In any way, the second update call was causing this issue, and the following section explains how.

https://github.com/newrelic/terraform-provider-newrelic/blob/429cdb953f81c6f141a5858bccf1f31429e5447c/newrelic/resource_newrelic_one_dashboard.go#L765-L780

#### The Problem

If no widgets to be filtered are specified (e.g. no `filter_current_dashboard`), control flow does not enter this block and the flow works as depicted in the following diagram. In summary, though the read call after the update API call gets the old (wrong) name of the dashboard, the last function called in the update function makes sure the name obtained in the response of the update API call is set to the state.

<img width="1645" alt="image" src="https://github.com/newrelic/terraform-provider-newrelic/assets/127438038/d52a4ede-ff3e-4dfa-a992-b0200662245c">

On the contrary, with widgets to filter, control flow enters the block of code specified above, and a second update call is made. Since this second update call makes use of `expandDashboardInput` which gets the name of the dashboard using `d.Get("name")` and prior to this function call, the read function would set the old dashboard's name already (because of late entity indexing), this old name is fetched and put into the body of the request used in the second update call, leading to the updated name being re-updated to the old name via the second update call. This continues to remain in the state (and also, obviously, does not reflect in the UI because we have "updated" it back to its old name).

<img width="1663" alt="image" src="https://github.com/newrelic/terraform-provider-newrelic/assets/127438038/2099ef92-3bb6-45f4-bb4e-b7e266ec14d1">

#### The Solution

When control flow enters the block specified above, we need to make sure the old name of the dashboard is not used and the name fetched from the response of the first update call is used. This PR proposes changes along the lines of the same.