### PR TITLE
fix(entity): add argument `ignore_not_found` to ignore "not found" errors

### DIFF
--- a/newrelic/data_source_newrelic_entity.go
+++ b/newrelic/data_source_newrelic_entity.go
@@ -162,9 +162,9 @@ func dataSourceNewRelicEntityRead(ctx context.Context, d *schema.ResourceData, m
 					"used elsewhere, since the value of all exported attributes would be null. Please use this attribute at your own risk.\n",
 			})
 			return diags
-		} else {
-			return diag.FromErr(fmt.Errorf("no entities found for the provided search parameters, please ensure your schema attributes are valid"))
 		}
+		return diag.FromErr(fmt.Errorf("no entities found for the provided search parameters, please ensure your schema attributes are valid"))
+
 	}
 
 	return diag.FromErr(flattenEntityData(entity, d))

--- a/newrelic/data_source_newrelic_entity.go
+++ b/newrelic/data_source_newrelic_entity.go
@@ -158,8 +158,8 @@ func dataSourceNewRelicEntityRead(ctx context.Context, d *schema.ResourceData, m
 				Severity: diag.Warning,
 				Summary: "no entities found for the provided search parameters, please ensure your schema attributes are valid.\n" +
 					"This message is being displayed as a warning and not as an error as `ignore_not_found` has been set to true.\n" +
-					"Ignoring the 'not found' error can lead to downstream errors if the values exported by this data source are\n" +
-					"used elsewhere, since the value of all exported attributes would be null. Please use this attribute at your own risk.\n",
+					"Ignoring the 'not found' error can lead to downstream errors if the values of attributes exported by this\n" +
+					"data source are used elsewhere, since all of these values would be null. Please use this attribute at your own risk.\n",
 			})
 			return diags
 		}

--- a/newrelic/data_source_newrelic_entity.go
+++ b/newrelic/data_source_newrelic_entity.go
@@ -45,6 +45,12 @@ func dataSourceNewRelicEntity() *schema.Resource {
 					return strings.EqualFold(old, new) // Case fold this attribute when diffing
 				},
 			},
+			"ignore_not_found": {
+				Type:        schema.TypeBool,
+				Default:     false,
+				Optional:    true,
+				Description: "A boolean attribute which when set to true, does not throw an error if the queried entity is not found.",
+			},
 			"tag": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -144,7 +150,21 @@ func dataSourceNewRelicEntityRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if entity == nil {
-		return diag.FromErr(fmt.Errorf("no entities found for the provided search parameters, please ensure your schema attributes are valid"))
+		if d.Get("ignore_not_found").(bool) {
+			log.Printf("[INFO] Entity not found, ignoring error")
+			d.SetId("")
+			var diags diag.Diagnostics
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary: "no entities found for the provided search parameters, please ensure your schema attributes are valid.\n" +
+					"This message is being displayed as a warning and not as an error as `ignore_not_found` has been set to true.\n" +
+					"Ignoring the 'not found' error can lead to downstream errors if the values exported by this data source are\n" +
+					"used elsewhere, since the value of all exported attributes would be null. Please use this attribute at your own risk.\n",
+			})
+			return diags
+		} else {
+			return diag.FromErr(fmt.Errorf("no entities found for the provided search parameters, please ensure your schema attributes are valid"))
+		}
 	}
 
 	return diag.FromErr(flattenEntityData(entity, d))

--- a/website/docs/d/entity.html.markdown
+++ b/website/docs/d/entity.html.markdown
@@ -147,6 +147,9 @@ The following arguments are supported:
 * `type` - (Optional) The entity's type. Valid values are APPLICATION, DASHBOARD, HOST, MONITOR, WORKLOAD, AWSLAMBDAFUNCTION, SERVICE_LEVEL, and KEY_TRANSACTION. Note: Other entity types may also be queryable as the list of entity types may fluctuate over time.
 * `domain` - (Optional) The entity's domain. Valid values are APM, BROWSER, INFRA, MOBILE, SYNTH, and EXT. If not specified, all domains are searched.
 * `tag` - (Optional) A tag applied to the entity. See [Nested tag blocks](#nested-`tag`-blocks) below for details.
+* `ignore_not_found`- (Optional) A boolean argument that, when set to true, prevents an error from being thrown when the queried entity is not found. Instead, a warning is displayed. Defaults to `false`.
+
+-> **WARNING:** Setting the `ignore_not_found` argument to `true` will display an 'entity not found' warning instead of throwing an error. This can lead to downstream errors if the values of attributes exported by this data source are used elsewhere, as all of these values would be null. Please use this argument at your own risk. 
 
 ### Nested `tag` blocks
 


### PR DESCRIPTION
#### New Relic Internal
[Jira](https://new-relic.atlassian.net/browse/NR-250438)

#### Summary
This PR proposes the addition of a new attribute `ignore_not_found` to the `newrelic_entity` data source in order to "ignore" not found errors if set `true` in the configuration, thereby stopping automated Terraform pipelines from halting if the entity is lost, which is useful in cases when the entity abruptly expires (see original usecase proposed by the customer in #2599).

#### Testing
The changes have been manually verified multifold. The test cases could not be updated because they fail with an `"id" not found error`, since the data source fetches no entity, which we try validating (without the expectation of an error being thrown, instead).

