### PR TITLE
feat: Support Host Not Reporting as NRQL conditions

### DIFF
--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -200,6 +200,11 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 				Description:   "A condition term with priority set to warning.",
 				ConflictsWith: []string{"term"},
 			},
+			"infra_host_clean_shutdown": {
+				Type:	schema.TypeBool,
+				Optional: true,
+				Description: "Indicates whether an alert condition should ignore clean shutdowns of infrastructure hosts when considering whether to create a loss of signal violation. Only for use with conditions monitoring 'host not reporting' signals. Defaults to false.",
+			},
 			"violation_time_limit_seconds": {
 				Type:     schema.TypeInt,
 				Optional: true,

--- a/newrelic/structures_newrelic_nrql_alert_condition.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition.go
@@ -364,6 +364,7 @@ func expandExpiration(d *schema.ResourceData) (*alerts.AlertsNrqlConditionExpira
 
 	expiration.OpenViolationOnExpiration = d.Get("open_violation_on_expiration").(bool)
 	expiration.CloseViolationsOnExpiration = d.Get("close_violations_on_expiration").(bool)
+	expiration.InfraHostCleanShutdown = d.Get("infra_host_clean_shutdown").(bool)
 
 	// 0 is not a valid expiration duration so don't set it if it's nonexistent
 	if expirationDuration, ok := d.GetOk("expiration_duration"); ok {
@@ -579,6 +580,10 @@ func flattenExpiration(d *schema.ResourceData, expiration *alerts.AlertsNrqlCond
 
 	if err := d.Set("expiration_duration", expiration.ExpirationDuration); err != nil {
 		return fmt.Errorf("[DEBUG] Error setting nrql alert condition `expiration_duration`: %v", err)
+	}
+
+	if err := d.Set("infra_host_clean_shutdown", expiration.InfraHostCleanShutdown); err != nil {
+		return fmt.Errorf("[DEBUG] Error setting nrql alert conditions `infra_host_clean_shutdown`: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
# Description

**Add support for configuring Host Not Reporting conditions as NRQL conditions.**
https://new-relic.atlassian.net/browse/NR-232401

NRQL Alert conditions will be receiving a new feature. Users will be able to use NRQL alert conditions to notify when New Relic stopped receiving data from an infrastructure agent.

The boolean on the expiration field will not trigger alerts for hosts that perform a clean shutdown option

This PR adds the boolean `infra_host_clean_shutdown` to the `newrelic_nrql_alert_condition` resource. By default it is set to false at our API level.

**Please do not merge until merging this change for the Go client**: https://github.com/newrelic/newrelic-client-go/pull/1111



## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.TF
