### PR TITLE
docs(cloud-integration): Fix documentation defects cloud integration resources

### DIFF
--- a/website/docs/r/cloud_aws_integrations.html.markdown
+++ b/website/docs/r/cloud_aws_integrations.html.markdown
@@ -31,19 +31,21 @@ resource "newrelic_cloud_aws_link_account" "foo" {
 
 resource "newrelic_cloud_aws_integrations" "bar" {
   linked_account_id = newrelic_cloud_aws_link_account.foo.id
-  billing {}
+  billing {
+    metrics_polling_interval = 3600
+  }
   cloudtrail {
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
     aws_regions              = ["us-east-1", "us-east-2"]
   }
   health {
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   trusted_advisor {
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 3600
   }
   vpc {
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 900
     aws_regions              = ["us-east-1", "us-east-2"]
     fetch_nat_gateway        = true
     fetch_vpn                = false
@@ -51,26 +53,26 @@ resource "newrelic_cloud_aws_integrations" "bar" {
     tag_value                = "tag value"
   }
   x_ray {
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
     aws_regions              = ["us-east-1", "us-east-2"]
   }
   s3 {
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 3600
   }
   doc_db {
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   sqs {
     fetch_extended_inventory = true
     fetch_tags               = true
     queue_prefixes           = ["queue prefix"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
     aws_regions              = ["us-east-1"]
     tag_key                  = "tag key"
     tag_value                = "tag value"
   }
   ebs {
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 900
     fetch_extended_inventory = true
     aws_regions              = ["us-east-1"]
     tag_key                  = "tag key"
@@ -80,7 +82,7 @@ resource "newrelic_cloud_aws_integrations" "bar" {
     fetch_extended_inventory = true
     fetch_tags               = true
     load_balancer_prefixes   = ["load balancer prefix"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
     aws_regions              = ["us-east-1"]
     tag_key                  = "tag key"
     tag_value                = "tag value"
@@ -88,12 +90,12 @@ resource "newrelic_cloud_aws_integrations" "bar" {
   elasticache {
     aws_regions              = ["us-east-1"]
     fetch_tags               = true
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
     tag_key                  = "tag key"
     tag_value                = "tag value"
   }
   api_gateway {
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
     aws_regions              = ["us-east-1"]
     stage_prefixes           = ["stage prefix"]
     tag_key                  = "tag key"
@@ -101,67 +103,67 @@ resource "newrelic_cloud_aws_integrations" "bar" {
   }
   auto_scaling {
     aws_regions              = ["us-east-1"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   aws_app_sync {
     aws_regions              = ["us-east-1"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   aws_athena {
     aws_regions              = ["us-east-1"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   aws_cognito {
     aws_regions              = ["us-east-1"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   aws_connect {
     aws_regions              = ["us-east-1"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   aws_direct_connect {
     aws_regions              = ["us-east-1"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   aws_fsx {
     aws_regions              = ["us-east-1"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   aws_glue {
     aws_regions              = ["us-east-1"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   aws_kinesis_analytics {
     aws_regions              = ["us-east-1"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   aws_media_convert {
     aws_regions              = ["us-east-1"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   aws_media_package_vod {
     aws_regions              = ["us-east-1"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   aws_mq {
     aws_regions              = ["us-east-1"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   aws_msk {
     aws_regions              = ["us-east-1"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   aws_neptune {
     aws_regions              = ["us-east-1"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   aws_qldb {
     aws_regions              = ["us-east-1"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   aws_route53resolver {
     aws_regions              = ["us-east-1"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   aws_states {
     aws_regions              = ["us-east-1"]
@@ -169,20 +171,20 @@ resource "newrelic_cloud_aws_integrations" "bar" {
   }
   aws_transit_gateway {
     aws_regions              = ["us-east-1"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   aws_waf {
     aws_regions              = ["us-east-1"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   aws_wafv2 {
     aws_regions              = ["us-east-1"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   cloudfront {
     fetch_lambdas_at_edge    = true
     fetch_tags               = true
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
     tag_key                  = "tag key"
     tag_value                = "tag value"
   }
@@ -190,7 +192,7 @@ resource "newrelic_cloud_aws_integrations" "bar" {
     aws_regions              = ["us-east-1"]
     fetch_extended_inventory = true
     fetch_tags               = true
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
     tag_key                  = "tag key"
     tag_value                = "tag value"
   }
@@ -198,21 +200,21 @@ resource "newrelic_cloud_aws_integrations" "bar" {
     aws_regions              = ["us-east-1"]
     duplicate_ec2_tags       = true
     fetch_ip_addresses       = true
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
     tag_key                  = "tag key"
     tag_value                = "tag value"
   }
   ecs {
     aws_regions              = ["us-east-1"]
     fetch_tags               = true
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
     tag_key                  = "tag key"
     tag_value                = "tag value"
   }
   efs {
     aws_regions              = ["us-east-1"]
     fetch_tags               = true
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
     tag_key                  = "tag key"
     tag_value                = "tag value"
   }
@@ -220,14 +222,14 @@ resource "newrelic_cloud_aws_integrations" "bar" {
     aws_regions              = ["us-east-1"]
     fetch_extended_inventory = true
     fetch_tags               = true
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
     tag_key                  = "tag key"
     tag_value                = "tag value"
   }
   elasticsearch {
     aws_regions              = ["us-east-1"]
     fetch_nodes              = true
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
     tag_key                  = "tag key"
     tag_value                = "tag value"
   }
@@ -235,68 +237,68 @@ resource "newrelic_cloud_aws_integrations" "bar" {
     aws_regions              = ["us-east-1"]
     fetch_extended_inventory = true
     fetch_tags               = true
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   emr {
     aws_regions              = ["us-east-1"]
     fetch_tags               = true
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
     tag_key                  = "tag key"
     tag_value                = "tag value"
   }
   iam {
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
     tag_key                  = "tag key"
     tag_value                = "tag value"
   }
   iot {
     aws_regions              = ["us-east-1"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   kinesis {
     aws_regions              = ["us-east-1"]
     fetch_shards             = true
     fetch_tags               = true
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 900
     tag_key                  = "tag key"
     tag_value                = "tag value"
   }
   kinesis_firehose {
     aws_regions              = ["us-east-1"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   lambda {
     aws_regions              = ["us-east-1"]
     fetch_tags               = true
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
     tag_key                  = "tag key"
     tag_value                = "tag value"
   }
   rds {
     aws_regions              = ["us-east-1"]
     fetch_tags               = true
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
     tag_key                  = "tag key"
     tag_value                = "tag value"
   }
   redshift {
     aws_regions              = ["us-east-1"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
     tag_key                  = "tag key"
     tag_value                = "tag value"
   }
   route53 {
     fetch_extended_inventory = true
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   ses {
     aws_regions              = ["us-east-1"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   sns {
     aws_regions              = ["us-east-1"]
     fetch_extended_inventory = true
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
 }
 ```
@@ -372,7 +374,7 @@ All other arguments are dependent on the services to be integrated, which have b
 
 All `integration` blocks support the following common arguments:
 
-* `metrics_polling_interval` - (Optional) The data polling interval in seconds.
+* `metrics_polling_interval` - (Optional) The data polling interval **in seconds**.
 
 <details>
   <summary> Some integration types support an additional set of arguments. Expand this section to take a look at these supported arguments. </summary>

--- a/website/docs/r/cloud_aws_integrations.html.markdown
+++ b/website/docs/r/cloud_aws_integrations.html.markdown
@@ -376,6 +376,8 @@ All `integration` blocks support the following common arguments:
 
 * `metrics_polling_interval` - (Optional) The data polling interval **in seconds**.
 
+-> **NOTE** For more information kindly refer to [amazon-integrations](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/get-started/introduction-aws-integrations/) documentaion.
+
 <details>
   <summary> Some integration types support an additional set of arguments. Expand this section to take a look at these supported arguments. </summary>
 * `cloudtrail`

--- a/website/docs/r/cloud_aws_integrations.html.markdown
+++ b/website/docs/r/cloud_aws_integrations.html.markdown
@@ -167,7 +167,7 @@ resource "newrelic_cloud_aws_integrations" "bar" {
   }
   aws_states {
     aws_regions              = ["us-east-1"]
-    metrics_polling_interval = 6000
+    metrics_polling_interval = 300
   }
   aws_transit_gateway {
     aws_regions              = ["us-east-1"]

--- a/website/docs/r/cloud_aws_integrations.html.markdown
+++ b/website/docs/r/cloud_aws_integrations.html.markdown
@@ -309,6 +309,67 @@ resource "newrelic_cloud_aws_integrations" "bar" {
 * `account_id` - (Optional) The New Relic account ID to operate on.  This allows the user to override the `account_id` attribute set on the provider. Defaults to the environment variable `NEW_RELIC_ACCOUNT_ID`.
 * `linked_account_id` - (Required) The ID of the linked AWS account in New Relic.
 
+
+The following arguments are supported with minimum metrics polling interval of 300 seconds
+
+* `alb` - (Optional) AWS ALB. See [Integration blocks](#integration-blocks) below for details.
+* `api_gateway` - (Optional) AWS API Gateway. See [Integration blocks](#integration-blocks) below for details.
+* `auto_scaling` - (Optional) AWS Auto Scaling. See [Integration blocks](#integration-blocks) below for details.
+* `aws_app_sync` - (Optional) AWS AppSync. See [Integration blocks](#integration-blocks) below for details.
+* `aws_athena` - (Optional) AWS Athena. See [Integration blocks](#integration-blocks) below for details.
+* `aws_cognito` - (Optional) AWS Cognito. See [Integration blocks](#integration-blocks) below for details.
+* `aws_connect` - (Optional) AWS Connect. See [Integration blocks](#integration-blocks) below for details.
+* `aws_direct_connect` - (Optional) AWS Direct Connect. See [Integration blocks](#integration-blocks) below for details.
+* `aws_fsx` - (Optional) AWS FSx. See [Integration blocks](#integration-blocks) below for details.
+* `aws_glue` - (Optional) AWS Glue. See [Integration blocks](#integration-blocks) below for details.
+* `aws_kinesis_analytics` - (Optional) AWS Kinesis Data Analytics. See [Integration blocks](#integration-blocks) below for details.
+* `aws_media_convert` - (Optional) AWS Media Convert. See [Integration blocks](#integration-blocks) below for details.
+* `aws_media_package_vod` - (Optional) AWS MediaPackage VOD. See [Integration blocks](#integration-blocks) below for details.
+* `aws_mq` - (Optional) AWS MQ. See [Integration blocks](#integration-blocks) below for details.
+* `aws_msk` - (Optional) Amazon Managed Kafka (MSK). See [Integration blocks](#integration-blocks) below for details.
+* `aws_neptune` - (Optional) AWS Neptune. See [Integration blocks](#integration-blocks) below for details.
+* `aws_route53resolver` - (Optional) AWS Route53 Resolver. See [Integration blocks](#integration-blocks) below for details.
+* `aws_qldb` - (Optional) Amazon QLDB. See [Integration blocks](#integration-blocks) below for details.
+* `aws_transit_gateway` - (Optional) Amazon Transit Gateway. See [Integration blocks](#integration-blocks) below for details.
+* `aws_waf` - (Optional) AWS WAF. See [Integration blocks](#integration-blocks) below for details.
+* `aws_wafv2` - (Optional) AWS WAF V2. See [Integration blocks](#integration-blocks) below for details.
+* `cloudfront` - (Optional) AWS CloudFront. See [Integration blocks](#integration-blocks) below for details.
+* `cloudtrail` - (Optional) AWS CloudTrail. See [Integration blocks](#integration-blocks) below for details.
+* `doc_db` - (Optional) AWS DocumentDB. See [Integration blocks](#integration-blocks) below for details.
+* `dynamodb` - (Optional) Amazon DynamoDB. See [Integration blocks](#integration-blocks) below for details.
+* `ec2` - (Optional) Amazon EC2. See [Integration blocks](#integration-blocks) below for details.
+* `ecs` - (Optional) Amazon ECS. See [Integration blocks](#integration-blocks) below for details.
+* `efs` - (Optional) Amazon EFS. See [Integration blocks](#integration-blocks) below for details.
+* `elasticache` - (Optional) AWS ElastiCache. See [Integration blocks](#integration-blocks) below for details.
+* `elasticbeanstalk` - (Optional) AWS Elastic Beanstalk. See [Integration blocks](#integration-blocks) below for details.
+* `elasticsearch` - (Optional) AWS ElasticSearch. See [Integration blocks](#integration-blocks) below for details.
+* `elb` - (Optional) AWS ELB (Classic). See [Integration blocks](#integration-blocks) below for details.
+* `emr` - (Optional) AWS EMR. See [Integration blocks](#integration-blocks) below for details.
+* `health` - (Optional) AWS Health. See [Integration blocks](#integration-blocks) below for details.
+* `iam` - (Optional) AWS IAM. See [Integration blocks](#integration-blocks) below for details.
+* `iot` - (Optional) AWS IoT. See [Integration blocks](#integration-blocks) below for details.
+* `kinesis_firehose` - (Optional) Amazon Kinesis Data Firehose. See [Integration blocks](#integration-blocks) below for details.
+* `lambda` - (Optional) AWS Lambda. See [Integration blocks](#integration-blocks) below for details.
+* `rds` - (Optional) Amazon RDS. See [Integration blocks](#integration-blocks) below for details.
+* `redshift` - (Optional) Amazon Redshift. See [Integration blocks](#integration-blocks) below for details.
+* `route53` - (Optional) Amazon Route 53. See [Integration blocks](#integration-blocks) below for details.
+* `s3` - (Optional) Amazon S3. See [Integration blocks](#integration-blocks) below for details.
+* `ses` - (Optional) Amazon SES. See [Integration blocks](#integration-blocks) below for details.
+* `sns` - (Optional) AWS SNS. See [Integration blocks](#integration-blocks) below for details.
+* `sqs` - (Optional) AWS SQS. See [Integration blocks](#integration-blocks) below for details.
+* `x_ray` - (Optional) AWS X-Ray. See [Integration blocks](#integration-blocks) below for details.
+x
+
+The following arguments are supported with minimum metrics polling interval of 900 seconds
+
+* `ebs` - (Optional) Amazon EBS. See [Integration blocks](#integration-blocks) below for details.
+* `kinesis` - (Optional) AWS Kinesis. See [Integration blocks](#integration-blocks) below for details.
+
+The following arguments are supported with minimum metrics polling interval of 3600 seconds
+
+* `billing` - (Optional) AWS Billing. See [Integration blocks](#integration-blocks) below for details.
+* `trusted_advisor` - (Optional) AWS Trusted Advisor. See [Integration blocks](#integration-blocks) below for details.
+
 All other arguments are dependent on the services to be integrated, which have been listed in the collapsible section below. All of these are **optional** blocks that can be added in any required combination. **For details on arguments that can be used with each service, check out the [`Integration` blocks](#integration-blocks) section below.**
 <details>
   <summary>Expand this section to view all supported AWS services supported, that may be integrated via this resource.</summary>

--- a/website/docs/r/cloud_aws_integrations.html.markdown
+++ b/website/docs/r/cloud_aws_integrations.html.markdown
@@ -372,7 +372,7 @@ resource "newrelic_cloud_aws_integrations" "bar" {
 * `linked_account_id` - (Required) The ID of the linked AWS account in New Relic.
 
 
-The following arguments/integration blocks are intended to be used with a minimum metrics polling interval of 300 seconds
+The following arguments/integration blocks are intended to be used with a minimum `metrics_polling_interval` of 300 seconds.
 
 * `alb` - (Optional) AWS ALB. See [Integration blocks](#integration-blocks) below for details.
 * `api_gateway` - (Optional) AWS API Gateway. See [Integration blocks](#integration-blocks) below for details.
@@ -422,12 +422,12 @@ The following arguments/integration blocks are intended to be used with a minimu
 * `x_ray` - (Optional) AWS X-Ray. See [Integration blocks](#integration-blocks) below for details.
 x
 
-The following arguments/integration blocks are intended to be used with a minimum metrics polling interval of 900 seconds
+The following arguments/integration blocks are intended to be used with a minimum `metrics_polling_interval` of 900 seconds.
 
 * `ebs` - (Optional) Amazon EBS. See [Integration blocks](#integration-blocks) below for details.
 * `kinesis` - (Optional) AWS Kinesis. See [Integration blocks](#integration-blocks) below for details.
 
-The following arguments/integration blocks are intended to be used with a minimum metrics polling interval of 3600 seconds
+The following arguments/integration blocks are intended to be used with a minimum `metrics_polling_interval` of 3600 seconds.
 
 * `billing` - (Optional) AWS Billing. See [Integration blocks](#integration-blocks) below for details.
 * `trusted_advisor` - (Optional) AWS Trusted Advisor. See [Integration blocks](#integration-blocks) below for details.

--- a/website/docs/r/cloud_aws_integrations.html.markdown
+++ b/website/docs/r/cloud_aws_integrations.html.markdown
@@ -376,7 +376,8 @@ All `integration` blocks support the following common arguments:
 
 * `metrics_polling_interval` - (Optional) The data polling interval **in seconds**.
 
--> **NOTE** For more information kindly refer to [amazon-integrations](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/get-started/introduction-aws-integrations/) documentaion.
+-> **NOTE** For more information on the ranges of metric polling intervals of each of these integrations, head over to [this page](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/get-started/introduction-aws-integrations/)
+
 
 <details>
   <summary> Some integration types support an additional set of arguments. Expand this section to take a look at these supported arguments. </summary>

--- a/website/docs/r/cloud_aws_integrations.html.markdown
+++ b/website/docs/r/cloud_aws_integrations.html.markdown
@@ -302,75 +302,8 @@ resource "newrelic_cloud_aws_integrations" "bar" {
   }
 }
 ```
-## Argument Reference
 
--> **WARNING:** Starting with [v3.27.2](https://registry.terraform.io/providers/newrelic/newrelic/3.27.2) of the New Relic Terraform Provider, updating the `linked_account_id` of a `newrelic_cloud_aws_integrations` resource that has been applied would **force a replacement** of the resource (destruction of the resource, followed by the creation of a new resource). Please carefully review the output of `terraform plan`, which would clearly indicate a replacement of this resource, before performing a `terraform apply`.
-
-* `account_id` - (Optional) The New Relic account ID to operate on.  This allows the user to override the `account_id` attribute set on the provider. Defaults to the environment variable `NEW_RELIC_ACCOUNT_ID`.
-* `linked_account_id` - (Required) The ID of the linked AWS account in New Relic.
-
-
-The following arguments are supported with minimum metrics polling interval of 300 seconds
-
-* `alb` - (Optional) AWS ALB. See [Integration blocks](#integration-blocks) below for details.
-* `api_gateway` - (Optional) AWS API Gateway. See [Integration blocks](#integration-blocks) below for details.
-* `auto_scaling` - (Optional) AWS Auto Scaling. See [Integration blocks](#integration-blocks) below for details.
-* `aws_app_sync` - (Optional) AWS AppSync. See [Integration blocks](#integration-blocks) below for details.
-* `aws_athena` - (Optional) AWS Athena. See [Integration blocks](#integration-blocks) below for details.
-* `aws_cognito` - (Optional) AWS Cognito. See [Integration blocks](#integration-blocks) below for details.
-* `aws_connect` - (Optional) AWS Connect. See [Integration blocks](#integration-blocks) below for details.
-* `aws_direct_connect` - (Optional) AWS Direct Connect. See [Integration blocks](#integration-blocks) below for details.
-* `aws_fsx` - (Optional) AWS FSx. See [Integration blocks](#integration-blocks) below for details.
-* `aws_glue` - (Optional) AWS Glue. See [Integration blocks](#integration-blocks) below for details.
-* `aws_kinesis_analytics` - (Optional) AWS Kinesis Data Analytics. See [Integration blocks](#integration-blocks) below for details.
-* `aws_media_convert` - (Optional) AWS Media Convert. See [Integration blocks](#integration-blocks) below for details.
-* `aws_media_package_vod` - (Optional) AWS MediaPackage VOD. See [Integration blocks](#integration-blocks) below for details.
-* `aws_mq` - (Optional) AWS MQ. See [Integration blocks](#integration-blocks) below for details.
-* `aws_msk` - (Optional) Amazon Managed Kafka (MSK). See [Integration blocks](#integration-blocks) below for details.
-* `aws_neptune` - (Optional) AWS Neptune. See [Integration blocks](#integration-blocks) below for details.
-* `aws_route53resolver` - (Optional) AWS Route53 Resolver. See [Integration blocks](#integration-blocks) below for details.
-* `aws_qldb` - (Optional) Amazon QLDB. See [Integration blocks](#integration-blocks) below for details.
-* `aws_transit_gateway` - (Optional) Amazon Transit Gateway. See [Integration blocks](#integration-blocks) below for details.
-* `aws_waf` - (Optional) AWS WAF. See [Integration blocks](#integration-blocks) below for details.
-* `aws_wafv2` - (Optional) AWS WAF V2. See [Integration blocks](#integration-blocks) below for details.
-* `cloudfront` - (Optional) AWS CloudFront. See [Integration blocks](#integration-blocks) below for details.
-* `cloudtrail` - (Optional) AWS CloudTrail. See [Integration blocks](#integration-blocks) below for details.
-* `doc_db` - (Optional) AWS DocumentDB. See [Integration blocks](#integration-blocks) below for details.
-* `dynamodb` - (Optional) Amazon DynamoDB. See [Integration blocks](#integration-blocks) below for details.
-* `ec2` - (Optional) Amazon EC2. See [Integration blocks](#integration-blocks) below for details.
-* `ecs` - (Optional) Amazon ECS. See [Integration blocks](#integration-blocks) below for details.
-* `efs` - (Optional) Amazon EFS. See [Integration blocks](#integration-blocks) below for details.
-* `elasticache` - (Optional) AWS ElastiCache. See [Integration blocks](#integration-blocks) below for details.
-* `elasticbeanstalk` - (Optional) AWS Elastic Beanstalk. See [Integration blocks](#integration-blocks) below for details.
-* `elasticsearch` - (Optional) AWS ElasticSearch. See [Integration blocks](#integration-blocks) below for details.
-* `elb` - (Optional) AWS ELB (Classic). See [Integration blocks](#integration-blocks) below for details.
-* `emr` - (Optional) AWS EMR. See [Integration blocks](#integration-blocks) below for details.
-* `health` - (Optional) AWS Health. See [Integration blocks](#integration-blocks) below for details.
-* `iam` - (Optional) AWS IAM. See [Integration blocks](#integration-blocks) below for details.
-* `iot` - (Optional) AWS IoT. See [Integration blocks](#integration-blocks) below for details.
-* `kinesis_firehose` - (Optional) Amazon Kinesis Data Firehose. See [Integration blocks](#integration-blocks) below for details.
-* `lambda` - (Optional) AWS Lambda. See [Integration blocks](#integration-blocks) below for details.
-* `rds` - (Optional) Amazon RDS. See [Integration blocks](#integration-blocks) below for details.
-* `redshift` - (Optional) Amazon Redshift. See [Integration blocks](#integration-blocks) below for details.
-* `route53` - (Optional) Amazon Route 53. See [Integration blocks](#integration-blocks) below for details.
-* `s3` - (Optional) Amazon S3. See [Integration blocks](#integration-blocks) below for details.
-* `ses` - (Optional) Amazon SES. See [Integration blocks](#integration-blocks) below for details.
-* `sns` - (Optional) AWS SNS. See [Integration blocks](#integration-blocks) below for details.
-* `sqs` - (Optional) AWS SQS. See [Integration blocks](#integration-blocks) below for details.
-* `x_ray` - (Optional) AWS X-Ray. See [Integration blocks](#integration-blocks) below for details.
-x
-
-The following arguments are supported with minimum metrics polling interval of 900 seconds
-
-* `ebs` - (Optional) Amazon EBS. See [Integration blocks](#integration-blocks) below for details.
-* `kinesis` - (Optional) AWS Kinesis. See [Integration blocks](#integration-blocks) below for details.
-
-The following arguments are supported with minimum metrics polling interval of 3600 seconds
-
-* `billing` - (Optional) AWS Billing. See [Integration blocks](#integration-blocks) below for details.
-* `trusted_advisor` - (Optional) AWS Trusted Advisor. See [Integration blocks](#integration-blocks) below for details.
-
-All other arguments are dependent on the services to be integrated, which have been listed in the collapsible section below. All of these are **optional** blocks that can be added in any required combination. **For details on arguments that can be used with each service, check out the [`Integration` blocks](#integration-blocks) section below.**
+## Supported AWS Integrations
 <details>
   <summary>Expand this section to view all supported AWS services supported, that may be integrated via this resource.</summary>
 
@@ -431,13 +364,83 @@ All other arguments are dependent on the services to be integrated, which have b
 
 </details>
 
+## Argument Reference
+
+-> **WARNING:** Starting with [v3.27.2](https://registry.terraform.io/providers/newrelic/newrelic/3.27.2) of the New Relic Terraform Provider, updating the `linked_account_id` of a `newrelic_cloud_aws_integrations` resource that has been applied would **force a replacement** of the resource (destruction of the resource, followed by the creation of a new resource). Please carefully review the output of `terraform plan`, which would clearly indicate a replacement of this resource, before performing a `terraform apply`.
+
+* `account_id` - (Optional) The New Relic account ID to operate on.  This allows the user to override the `account_id` attribute set on the provider. Defaults to the environment variable `NEW_RELIC_ACCOUNT_ID`.
+* `linked_account_id` - (Required) The ID of the linked AWS account in New Relic.
+
+
+The following arguments/integration blocks are intended to be used with a minimum metrics polling interval of 300 seconds
+
+* `alb` - (Optional) AWS ALB. See [Integration blocks](#integration-blocks) below for details.
+* `api_gateway` - (Optional) AWS API Gateway. See [Integration blocks](#integration-blocks) below for details.
+* `auto_scaling` - (Optional) AWS Auto Scaling. See [Integration blocks](#integration-blocks) below for details.
+* `aws_app_sync` - (Optional) AWS AppSync. See [Integration blocks](#integration-blocks) below for details.
+* `aws_athena` - (Optional) AWS Athena. See [Integration blocks](#integration-blocks) below for details.
+* `aws_cognito` - (Optional) AWS Cognito. See [Integration blocks](#integration-blocks) below for details.
+* `aws_connect` - (Optional) AWS Connect. See [Integration blocks](#integration-blocks) below for details.
+* `aws_direct_connect` - (Optional) AWS Direct Connect. See [Integration blocks](#integration-blocks) below for details.
+* `aws_fsx` - (Optional) AWS FSx. See [Integration blocks](#integration-blocks) below for details.
+* `aws_glue` - (Optional) AWS Glue. See [Integration blocks](#integration-blocks) below for details.
+* `aws_kinesis_analytics` - (Optional) AWS Kinesis Data Analytics. See [Integration blocks](#integration-blocks) below for details.
+* `aws_media_convert` - (Optional) AWS Media Convert. See [Integration blocks](#integration-blocks) below for details.
+* `aws_media_package_vod` - (Optional) AWS MediaPackage VOD. See [Integration blocks](#integration-blocks) below for details.
+* `aws_mq` - (Optional) AWS MQ. See [Integration blocks](#integration-blocks) below for details.
+* `aws_msk` - (Optional) Amazon Managed Kafka (MSK). See [Integration blocks](#integration-blocks) below for details.
+* `aws_neptune` - (Optional) AWS Neptune. See [Integration blocks](#integration-blocks) below for details.
+* `aws_route53resolver` - (Optional) AWS Route53 Resolver. See [Integration blocks](#integration-blocks) below for details.
+* `aws_qldb` - (Optional) Amazon QLDB. See [Integration blocks](#integration-blocks) below for details.
+* `aws_transit_gateway` - (Optional) Amazon Transit Gateway. See [Integration blocks](#integration-blocks) below for details.
+* `aws_waf` - (Optional) AWS WAF. See [Integration blocks](#integration-blocks) below for details.
+* `aws_wafv2` - (Optional) AWS WAF V2. See [Integration blocks](#integration-blocks) below for details.
+* `cloudfront` - (Optional) AWS CloudFront. See [Integration blocks](#integration-blocks) below for details.
+* `cloudtrail` - (Optional) AWS CloudTrail. See [Integration blocks](#integration-blocks) below for details.
+* `doc_db` - (Optional) AWS DocumentDB. See [Integration blocks](#integration-blocks) below for details.
+* `dynamodb` - (Optional) Amazon DynamoDB. See [Integration blocks](#integration-blocks) below for details.
+* `ec2` - (Optional) Amazon EC2. See [Integration blocks](#integration-blocks) below for details.
+* `ecs` - (Optional) Amazon ECS. See [Integration blocks](#integration-blocks) below for details.
+* `efs` - (Optional) Amazon EFS. See [Integration blocks](#integration-blocks) below for details.
+* `elasticache` - (Optional) AWS ElastiCache. See [Integration blocks](#integration-blocks) below for details.
+* `elasticbeanstalk` - (Optional) AWS Elastic Beanstalk. See [Integration blocks](#integration-blocks) below for details.
+* `elasticsearch` - (Optional) AWS ElasticSearch. See [Integration blocks](#integration-blocks) below for details.
+* `elb` - (Optional) AWS ELB (Classic). See [Integration blocks](#integration-blocks) below for details.
+* `emr` - (Optional) AWS EMR. See [Integration blocks](#integration-blocks) below for details.
+* `health` - (Optional) AWS Health. See [Integration blocks](#integration-blocks) below for details.
+* `iam` - (Optional) AWS IAM. See [Integration blocks](#integration-blocks) below for details.
+* `iot` - (Optional) AWS IoT. See [Integration blocks](#integration-blocks) below for details.
+* `kinesis_firehose` - (Optional) Amazon Kinesis Data Firehose. See [Integration blocks](#integration-blocks) below for details.
+* `lambda` - (Optional) AWS Lambda. See [Integration blocks](#integration-blocks) below for details.
+* `rds` - (Optional) Amazon RDS. See [Integration blocks](#integration-blocks) below for details.
+* `redshift` - (Optional) Amazon Redshift. See [Integration blocks](#integration-blocks) below for details.
+* `route53` - (Optional) Amazon Route 53. See [Integration blocks](#integration-blocks) below for details.
+* `s3` - (Optional) Amazon S3. See [Integration blocks](#integration-blocks) below for details.
+* `ses` - (Optional) Amazon SES. See [Integration blocks](#integration-blocks) below for details.
+* `sns` - (Optional) AWS SNS. See [Integration blocks](#integration-blocks) below for details.
+* `sqs` - (Optional) AWS SQS. See [Integration blocks](#integration-blocks) below for details.
+* `x_ray` - (Optional) AWS X-Ray. See [Integration blocks](#integration-blocks) below for details.
+x
+
+The following arguments/integration blocks are intended to be used with a minimum metrics polling interval of 900 seconds
+
+* `ebs` - (Optional) Amazon EBS. See [Integration blocks](#integration-blocks) below for details.
+* `kinesis` - (Optional) AWS Kinesis. See [Integration blocks](#integration-blocks) below for details.
+
+The following arguments/integration blocks are intended to be used with a minimum metrics polling interval of 3600 seconds
+
+* `billing` - (Optional) AWS Billing. See [Integration blocks](#integration-blocks) below for details.
+* `trusted_advisor` - (Optional) AWS Trusted Advisor. See [Integration blocks](#integration-blocks) below for details.
+
+All other arguments are dependent on the services to be integrated, which have been listed in the collapsible section below. All of these are **optional** blocks that can be added in any required combination. **For details on arguments that can be used with each service, check out the [`Integration` blocks](#integration-blocks) section below.**
+
 ### `Integration` blocks
 
 All `integration` blocks support the following common arguments:
 
 * `metrics_polling_interval` - (Optional) The data polling interval **in seconds**.
 
--> **NOTE** For more information on the ranges of metric polling intervals of each of these integrations, head over to [this page](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/get-started/introduction-aws-integrations/)
+-> **NOTE** For more information on the ranges of metric polling intervals of each of these integrations, head over to [this page](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/get-started/introduction-aws-integrations/).
 
 
 <details>

--- a/website/docs/r/cloud_azure_integrations.html.markdown
+++ b/website/docs/r/cloud_azure_integrations.html.markdown
@@ -38,27 +38,27 @@ resource "newrelic_cloud_azure_integrations" "foo" {
   account_id = "The New Relic account ID"
 
   api_management {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 300
     resource_groups = ["resource_groups"]
   }
 
   app_gateway {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 300
     resource_groups = ["resource_groups"]
   }
 
   app_service {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 300
     resource_groups = ["resource_groups"]
   }
 
   containers {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 300
     resource_groups = ["resource_groups"]
   }
 
   cosmos_db {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 300
     resource_groups = ["resource_groups"]
   }
 
@@ -68,62 +68,62 @@ resource "newrelic_cloud_azure_integrations" "foo" {
   }
 
   data_factory {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 300
     resource_groups = ["resource_groups"]
   }
 
   event_hub {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 300
     resource_groups = ["resource_groups"]
   }
 
   express_route {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 300
     resource_groups = ["resource_groups"]
   }
 
   firewalls {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 300
     resource_groups = ["resource_groups"]
   }
 
   front_door {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 300
     resource_groups = ["resource_groups"]
   }
 
   functions {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 300
     resource_groups = ["resource_groups"]
   }
 
   key_vault {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 300
     resource_groups = ["resource_groups"]
   }
 
   load_balancer {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 300
     resource_groups = ["resource_groups"]
   }
 
   logic_apps {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 300
     resource_groups = ["resource_groups"]
   }
 
   machine_learning {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 300
     resource_groups = ["resource_groups"]
   }
 
   maria_db {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 3600
     resource_groups = ["resource_groups"]
   }
 
   monitor {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 60
     resource_groups          = ["resource_groups"]
     include_tags             = ["env:production"]
     exclude_tags             = ["env:staging", "env:testing"]
@@ -132,72 +132,72 @@ resource "newrelic_cloud_azure_integrations" "foo" {
   }
   
   mysql {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 3600
     resource_groups = ["resource_groups"]
   }
 
   mysql_flexible {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 3600
     resource_groups = ["resource_groups"]
   }
 
   postgresql {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 3600
     resource_groups = ["resource_groups"]
   }
 
   postgresql_flexible {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 3600
     resource_groups = ["resource_groups"]
   }
 
   power_bi_dedicated {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 300
     resource_groups = ["resource_groups"]
   }
 
   redis_cache {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 300
     resource_groups = ["resource_groups"]
   }
 
   service_bus {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 300
     resource_groups = ["resource_groups"]
   }
 
   sql {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 300
     resource_groups = ["resource_groups"]
   }
 
   sql_managed {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 300
     resource_groups = ["resource_groups"]
   }
 
   storage {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 1800
     resource_groups = ["resource_groups"]
   }
 
   virtual_machine {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 300
     resource_groups = ["resource_groups"]
   }
 
   virtual_networks {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 300
     resource_groups = ["resource_groups"]
   }
 
   vms {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 300
     resource_groups = ["resource_groups"]
   }
 
   vpn_gateway {
-    metrics_polling_interval = 1200
+    metrics_polling_interval = 300
     resource_groups = ["resource_groups"]
   }
 }
@@ -253,7 +253,7 @@ Below argument supports the minimum metric polling interval of 3600 seconds
 
 All `integration` blocks support the following common arguments:
 
-* `metrics_polling_interval` - (Optional) The data polling interval in seconds.
+* `metrics_polling_interval` - (Optional) The data polling interval **in seconds**.
 * `resource_groups` - (Optional) Specify each Resource group associated with the resources that you want to monitor. Filter values are case-sensitive
 
 Other integration type support an additional argument:

--- a/website/docs/r/cloud_azure_integrations.html.markdown
+++ b/website/docs/r/cloud_azure_integrations.html.markdown
@@ -255,7 +255,7 @@ All `integration` blocks support the following common arguments:
 
 * `metrics_polling_interval` - (Optional) The data polling interval **in seconds**.
 
--> **NOTE** For more information kindly refer to [microsoft-azure-integrations](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations/) documentaion.
+-> **NOTE** For more information on the ranges of metric polling intervals of each of these integrations, head over to [this page](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations/)
 
 * `resource_groups` - (Optional) Specify each Resource group associated with the resources that you want to monitor. Filter values are case-sensitive
 

--- a/website/docs/r/cloud_azure_integrations.html.markdown
+++ b/website/docs/r/cloud_azure_integrations.html.markdown
@@ -254,6 +254,9 @@ Below argument supports the minimum metric polling interval of 3600 seconds
 All `integration` blocks support the following common arguments:
 
 * `metrics_polling_interval` - (Optional) The data polling interval **in seconds**.
+
+-> **NOTE** For more information kindly refer to [microsoft-azure-integrations](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations/) documentaion.
+
 * `resource_groups` - (Optional) Specify each Resource group associated with the resources that you want to monitor. Filter values are case-sensitive
 
 Other integration type support an additional argument:

--- a/website/docs/r/cloud_azure_integrations.html.markdown
+++ b/website/docs/r/cloud_azure_integrations.html.markdown
@@ -206,10 +206,16 @@ resource "newrelic_cloud_azure_integrations" "foo" {
 
 -> **WARNING:** Starting with [v3.27.2](https://registry.terraform.io/providers/newrelic/newrelic/3.27.2) of the New Relic Terraform Provider, updating the `linked_account_id` of a `newrelic_cloud_azure_integrations` resource that has been applied would **force a replacement** of the resource (destruction of the resource, followed by the creation of a new resource). When such an update is performed, please carefully review the output of `terraform plan`, which would clearly indicate a replacement of this resource, before performing a `terraform apply`.
 
-The following arguments are supported with minimum metric polling interval of 300 seconds
-
 * `account_id` - (Optional) The New Relic account ID to operate on.  This allows the user to override the `account_id` attribute set on the provider. Defaults to the environment variable `NEW_RELIC_ACCOUNT_ID`.
 * `linked_account_id` - (Required) The ID of the linked Azure account in New Relic.
+
+
+The following arguments are supported with minimum metrics polling interval of 60 seconds
+
+* `monitor` - (Optional) Azure Monitor. See [Integration blocks](#integration-blocks) below for details.
+
+The following arguments are supported with minimum metrics polling interval of 300 seconds
+
 * `api_management` - (Optional) Azure API Management. See [Integration blocks](#integration-blocks) below for details.
 * `app_gateway` - (Optional) Azure App Gateway. See [Integration blocks](#integration-blocks) below for details. 
 * `app_service` - (Optional) Azure App Service. See [Integration blocks](#integration-blocks) below for details.
@@ -225,29 +231,28 @@ The following arguments are supported with minimum metric polling interval of 30
 * `load_balancer` - (Optional) Azure Load Balancer. See [Integration blocks](#integration-blocks) below for details.
 * `logic_apps` - (Optional) Azure Logic Apps. See [Integration blocks](#integration-blocks) below for details.
 * `machine_learning` - (Optional) Azure Machine Learning. See [Integration blocks](#integration-blocks) below for details.
-* `maria_db` - (Optional) Azure MariaDB. See [Integration blocks](#integration-blocks) below for details.
-* `monitor` - (Optional) Azure Monitor. See [Integration blocks](#integration-blocks) below for details.
-* `mysql` - (Optional) Azure MySQL. See [Integration blocks](#integration-blocks) below for details.
-* `mysql_flexible` - (Optional) Azure MySQL Flexible Server. See [Integration blocks](#integration-blocks) below for details.
-* `postgresql` - (Optional) Azure PostgreSQL. See [Integration blocks](#integration-blocks) below for details.
-* `postgresql_flexible` - (Optional) Azure PostgreSQL Flexible Server. See [Integration blocks](#integration-blocks) below for details.
 * `power_bi_dedicated` - (Optional) Azure Power BI Dedicated. See [Integration blocks](#integration-blocks) below for details.
 * `redis_cache` - (Optional) Azure Redis Cache. See [Integration blocks](#integration-blocks) below for details.
 * `service_bus` - (Optional) Azure Service Bus. See [Integration blocks](#integration-blocks) below for details.
 * `sql` - (Optional) Azure SQL. See [Integration blocks](#integration-blocks) below for details.
 * `sql_managed` - (Optional) Azure SQL Managed. See [Integration blocks](#integration-blocks) below for details.
 * `virtual_machine` - (Optional) Azure Virtual machine. See [Integration blocks](#integration-blocks) below for details.
+* `virtual_networks` - (Optional) for Azure Virtual networks. See [Integration blocks](#integration-blocks) below for details.
 * `vms` - (Optional) Azure VMs. See [Integration blocks](#integration-blocks) below for details.
 * `vpn_gateway` - (Optional) Azure VPN Gateway. See [Integration blocks](#integration-blocks) below for details.
 
-Below arguments supports the minimum metric polling interval of 900 seconds
+The following arguments are supported with minimum metrics polling interval of 1800 seconds
 
 * `storage` - (Optional) for Azure Storage. See [Integration blocks](#integration-blocks) below for details.
-* `virtual_networks` - (Optional) for Azure Virtual networks. See [Integration blocks](#integration-blocks) below for details.
 
-Below argument supports the minimum metric polling interval of 3600 seconds
+The following arguments are supported with minimum metrics polling interval of 3600 seconds
 
 * `cost_management` - (Optional) Azure Cost Management. See [Integration blocks](#integration-blocks) below for details.
+* `maria_db` - (Optional) Azure MariaDB. See [Integration blocks](#integration-blocks) below for details.
+* `mysql` - (Optional) Azure MySQL. See [Integration blocks](#integration-blocks) below for details.
+* `mysql_flexible` - (Optional) Azure MySQL Flexible Server. See [Integration blocks](#integration-blocks) below for details.
+* `postgresql` - (Optional) Azure PostgreSQL. See [Integration blocks](#integration-blocks) below for details.
+* `postgresql_flexible` - (Optional) Azure PostgreSQL Flexible Server. See [Integration blocks](#integration-blocks) below for details.
 
 ### `Integration` blocks
 

--- a/website/docs/r/cloud_azure_integrations.html.markdown
+++ b/website/docs/r/cloud_azure_integrations.html.markdown
@@ -210,11 +210,11 @@ resource "newrelic_cloud_azure_integrations" "foo" {
 * `linked_account_id` - (Required) The ID of the linked Azure account in New Relic.
 
 
-The following arguments are supported with minimum metrics polling interval of 60 seconds
+The following arguments/integration blocks are intended to be used with a minimum metrics polling interval of 60 seconds
 
 * `monitor` - (Optional) Azure Monitor. See [Integration blocks](#integration-blocks) below for details.
 
-The following arguments are supported with minimum metrics polling interval of 300 seconds
+The following arguments/integration blocks are intended to be used with a minimum metrics polling interval of 300 seconds
 
 * `api_management` - (Optional) Azure API Management. See [Integration blocks](#integration-blocks) below for details.
 * `app_gateway` - (Optional) Azure App Gateway. See [Integration blocks](#integration-blocks) below for details. 
@@ -241,11 +241,11 @@ The following arguments are supported with minimum metrics polling interval of 3
 * `vms` - (Optional) Azure VMs. See [Integration blocks](#integration-blocks) below for details.
 * `vpn_gateway` - (Optional) Azure VPN Gateway. See [Integration blocks](#integration-blocks) below for details.
 
-The following arguments are supported with minimum metrics polling interval of 1800 seconds
+The following arguments/integration blocks are intended to be used with a minimum metrics polling interval of 1800 seconds
 
 * `storage` - (Optional) for Azure Storage. See [Integration blocks](#integration-blocks) below for details.
 
-The following arguments are supported with minimum metrics polling interval of 3600 seconds
+The following arguments/integration blocks are intended to be used with a minimum metrics polling interval of 3600 seconds
 
 * `cost_management` - (Optional) Azure Cost Management. See [Integration blocks](#integration-blocks) below for details.
 * `maria_db` - (Optional) Azure MariaDB. See [Integration blocks](#integration-blocks) below for details.
@@ -260,7 +260,7 @@ All `integration` blocks support the following common arguments:
 
 * `metrics_polling_interval` - (Optional) The data polling interval **in seconds**.
 
--> **NOTE** For more information on the ranges of metric polling intervals of each of these integrations, head over to [this page](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations/)
+-> **NOTE** For more information on the ranges of metric polling intervals of each of these integrations, head over to [this page](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations/).
 
 * `resource_groups` - (Optional) Specify each Resource group associated with the resources that you want to monitor. Filter values are case-sensitive
 

--- a/website/docs/r/cloud_azure_integrations.html.markdown
+++ b/website/docs/r/cloud_azure_integrations.html.markdown
@@ -210,11 +210,11 @@ resource "newrelic_cloud_azure_integrations" "foo" {
 * `linked_account_id` - (Required) The ID of the linked Azure account in New Relic.
 
 
-The following arguments/integration blocks are intended to be used with a minimum metrics polling interval of 60 seconds
+The following arguments/integration blocks are intended to be used with a minimum `metrics_polling_interval` of 60 seconds.
 
 * `monitor` - (Optional) Azure Monitor. See [Integration blocks](#integration-blocks) below for details.
 
-The following arguments/integration blocks are intended to be used with a minimum metrics polling interval of 300 seconds
+The following arguments/integration blocks are intended to be used with a minimum `metrics_polling_interval` of 300 seconds.
 
 * `api_management` - (Optional) Azure API Management. See [Integration blocks](#integration-blocks) below for details.
 * `app_gateway` - (Optional) Azure App Gateway. See [Integration blocks](#integration-blocks) below for details. 
@@ -241,11 +241,11 @@ The following arguments/integration blocks are intended to be used with a minimu
 * `vms` - (Optional) Azure VMs. See [Integration blocks](#integration-blocks) below for details.
 * `vpn_gateway` - (Optional) Azure VPN Gateway. See [Integration blocks](#integration-blocks) below for details.
 
-The following arguments/integration blocks are intended to be used with a minimum metrics polling interval of 1800 seconds
+The following arguments/integration blocks are intended to be used with a minimum `metrics_polling_interval` of 1800 seconds.
 
 * `storage` - (Optional) for Azure Storage. See [Integration blocks](#integration-blocks) below for details.
 
-The following arguments/integration blocks are intended to be used with a minimum metrics polling interval of 3600 seconds
+The following arguments/integration blocks are intended to be used with a minimum `metrics_polling_interval` of 3600 seconds.
 
 * `cost_management` - (Optional) Azure Cost Management. See [Integration blocks](#integration-blocks) below for details.
 * `maria_db` - (Optional) Azure MariaDB. See [Integration blocks](#integration-blocks) below for details.

--- a/website/docs/r/cloud_gcp_integrations.html.markdown
+++ b/website/docs/r/cloud_gcp_integrations.html.markdown
@@ -150,6 +150,8 @@ All `integration` blocks support the following common arguments:
 
 * `metrics_polling_interval` - (Optional) The data polling interval **in seconds**.
 
+-> **NOTE** For more information kindly refer to [google-cloud-platform-integrations](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/get-started/introduction-google-cloud-platform-integrations/) documentaion.
+
 Other integration supports an additional argument:
 
 * `big_query`

--- a/website/docs/r/cloud_gcp_integrations.html.markdown
+++ b/website/docs/r/cloud_gcp_integrations.html.markdown
@@ -29,83 +29,83 @@ resource "newrelic_cloud_gcp_link_account" "foo" {
 resource "newrelic_cloud_gcp_integrations" "foo1" {
   linked_account_id = newrelic_cloud_gcp_link_account.foo.id
   app_engine {
-    metrics_polling_interval = 400
+    metrics_polling_interval = 300
   }
   big_query {
-    metrics_polling_interval = 400
+    metrics_polling_interval = 300
     fetch_tags = true
   }
   big_table {
-    metrics_polling_interval = 400
+    metrics_polling_interval = 300
   }
   composer {
-    metrics_polling_interval = 400
+    metrics_polling_interval = 300
   }
   data_flow {
-    metrics_polling_interval = 400
+    metrics_polling_interval = 300
   }
   data_proc {
-    metrics_polling_interval = 400
+    metrics_polling_interval = 300
   }
   data_store {
-    metrics_polling_interval = 400
+    metrics_polling_interval = 300
   }
   fire_base_database {
-    metrics_polling_interval = 400
+    metrics_polling_interval = 300
   }
   fire_base_hosting {
-    metrics_polling_interval = 400
+    metrics_polling_interval = 300
   }
   fire_base_storage {
-    metrics_polling_interval = 400
+    metrics_polling_interval = 300
   }
   fire_store {
-    metrics_polling_interval = 400
+    metrics_polling_interval = 300
   }
   functions {
-    metrics_polling_interval = 400
+    metrics_polling_interval = 300
   }
   interconnect {
-    metrics_polling_interval = 400
+    metrics_polling_interval = 300
   }
   kubernetes {
-    metrics_polling_interval = 400
+    metrics_polling_interval = 300
   }
   load_balancing {
-    metrics_polling_interval = 400
+    metrics_polling_interval = 300
   }
   mem_cache {
-    metrics_polling_interval = 400
+    metrics_polling_interval = 300
   }
   pub_sub {
-    metrics_polling_interval = 400
+    metrics_polling_interval = 300
     fetch_tags=true
   }
   redis {
-    metrics_polling_interval = 400
+    metrics_polling_interval = 300
   }
   router {
-    metrics_polling_interval = 400
+    metrics_polling_interval = 300
   }
   run {
-    metrics_polling_interval = 400
+    metrics_polling_interval = 300
   }
   spanner {
-    metrics_polling_interval = 400
+    metrics_polling_interval = 300
     fetch_tags=true
   }
   sql {
-    metrics_polling_interval = 400
+    metrics_polling_interval = 300
   }
   storage {
-    metrics_polling_interval = 400
+    metrics_polling_interval = 300
     fetch_tags=true
   }
   virtual_machines {
-    metrics_polling_interval = 400
+    metrics_polling_interval = 300
   }
   vpc_access {
-    metrics_polling_interval = 400
+    metrics_polling_interval = 300
   }
 }
 ```
@@ -148,7 +148,7 @@ The following arguments are supported:
 
 All `integration` blocks support the following common arguments:
 
-* `metrics_polling_interval` - (Optional) The data polling interval in seconds.
+* `metrics_polling_interval` - (Optional) The data polling interval **in seconds**.
 
 Other integration supports an additional argument:
 

--- a/website/docs/r/cloud_gcp_integrations.html.markdown
+++ b/website/docs/r/cloud_gcp_integrations.html.markdown
@@ -113,10 +113,11 @@ resource "newrelic_cloud_gcp_integrations" "foo1" {
 
 -> **WARNING:** Starting with [v3.27.2](https://registry.terraform.io/providers/newrelic/newrelic/3.27.2) of the New Relic Terraform Provider, updating the `linked_account_id` of a `newrelic_cloud_gcp_integrations` resource that has been applied would **force a replacement** of the resource (destruction of the resource, followed by the creation of a new resource). When such an update is performed, please carefully review the output of `terraform plan`, which would clearly indicate a replacement of this resource, before performing a `terraform apply`.
 
-The following arguments are supported:
-
 * `account_id` - (Optional) The New Relic account ID to operate on.  This allows the user to override the `account_id` attribute set on the provider. Defaults to the environment variable `NEW_RELIC_ACCOUNT_ID`.
 * `linked_account_id` - (Required) The ID of the linked GCP account in New Relic.
+
+The following supported arguments are with minimum metrics polling interval of 300 seconds
+
 * `alloy_db` - (Optional) Alloy DB integration. See [Integration blocks](#integration-blocks) below for details.
 * `app_engine` - (Optional) App Engine integration. See [Integration blocks](#integration-blocks) below for details.
 * `big_query` - (Optional) Biq Query integration. See [Integration blocks](#integration-blocks) below for details.

--- a/website/docs/r/cloud_gcp_integrations.html.markdown
+++ b/website/docs/r/cloud_gcp_integrations.html.markdown
@@ -150,7 +150,7 @@ All `integration` blocks support the following common arguments:
 
 * `metrics_polling_interval` - (Optional) The data polling interval **in seconds**.
 
--> **NOTE** For more information kindly refer to [google-cloud-platform-integrations](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/get-started/introduction-google-cloud-platform-integrations/) documentaion.
+-> **NOTE** For more information on the ranges of metric polling intervals of each of these integrations, head over to [this page](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/get-started/introduction-google-cloud-platform-integrations/)
 
 Other integration supports an additional argument:
 

--- a/website/docs/r/cloud_gcp_integrations.html.markdown
+++ b/website/docs/r/cloud_gcp_integrations.html.markdown
@@ -116,7 +116,7 @@ resource "newrelic_cloud_gcp_integrations" "foo1" {
 * `account_id` - (Optional) The New Relic account ID to operate on.  This allows the user to override the `account_id` attribute set on the provider. Defaults to the environment variable `NEW_RELIC_ACCOUNT_ID`.
 * `linked_account_id` - (Required) The ID of the linked GCP account in New Relic.
 
-The following arguments/integration blocks are intended to be used with a minimum metrics polling interval of 300 seconds
+The following arguments/integration blocks are intended to be used with a minimum `metrics_polling_interval` of 300 seconds.
 
 * `alloy_db` - (Optional) Alloy DB integration. See [Integration blocks](#integration-blocks) below for details.
 * `app_engine` - (Optional) App Engine integration. See [Integration blocks](#integration-blocks) below for details.

--- a/website/docs/r/cloud_gcp_integrations.html.markdown
+++ b/website/docs/r/cloud_gcp_integrations.html.markdown
@@ -116,7 +116,7 @@ resource "newrelic_cloud_gcp_integrations" "foo1" {
 * `account_id` - (Optional) The New Relic account ID to operate on.  This allows the user to override the `account_id` attribute set on the provider. Defaults to the environment variable `NEW_RELIC_ACCOUNT_ID`.
 * `linked_account_id` - (Required) The ID of the linked GCP account in New Relic.
 
-The following supported arguments are with minimum metrics polling interval of 300 seconds
+The following arguments/integration blocks are intended to be used with a minimum metrics polling interval of 300 seconds
 
 * `alloy_db` - (Optional) Alloy DB integration. See [Integration blocks](#integration-blocks) below for details.
 * `app_engine` - (Optional) App Engine integration. See [Integration blocks](#integration-blocks) below for details.
@@ -151,7 +151,7 @@ All `integration` blocks support the following common arguments:
 
 * `metrics_polling_interval` - (Optional) The data polling interval **in seconds**.
 
--> **NOTE** For more information on the ranges of metric polling intervals of each of these integrations, head over to [this page](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/get-started/introduction-google-cloud-platform-integrations/)
+-> **NOTE** For more information on the ranges of metric polling intervals of each of these integrations, head over to [this page](https://docs.newrelic.com/docs/infrastructure/google-cloud-platform-integrations/get-started/introduction-google-cloud-platform-integrations/).
 
 Other integration supports an additional argument:
 


### PR DESCRIPTION
# Description

This PR will enhance the documentation of all of the cloud integration resources by placing realistic values of metric polling intervals.

JIRA: [NR-262902](https://new-relic.atlassian.net/browse/NR-262902)

Metric polling interval values for the resources located in [newrelic-terraform](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs) docs has been updated referencing UI and [NR docs](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/get-started/introduction-aws-integrations/)


## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation



[NR-262902]: https://new-relic.atlassian.net/browse/NR-262902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ