### PR TITLE
 fix(cloud-integrations): Add error handling in the resource newrelic_cloud_gcp_integrations

### DIFF
--- a/newrelic/resource_newrelic_cloud_gcp_integrations.go
+++ b/newrelic/resource_newrelic_cloud_gcp_integrations.go
@@ -464,7 +464,7 @@ func resourceNewrelicCloudGcpIntegrationsCreate(ctx context.Context, d *schema.R
 	cloudGcpIntegrationinputs, _ := expandCloudGcpIntegrationsinputs(d)
 	gcpIntegrationspayload, err := client.Cloud.CloudConfigureIntegrationWithContext(ctx, accountID, cloudGcpIntegrationinputs)
 	if err != nil {
-		diag.FromErr(err)
+		return diag.FromErr(err)
 	}
 	var diags diag.Diagnostics
 	if len(gcpIntegrationspayload.Errors) > 0 {
@@ -1203,7 +1203,7 @@ func resourceNewrelicCloudGcpIntegrationsRead(ctx context.Context, d *schema.Res
 			d.SetId("")
 			return nil
 		}
-		diag.FromErr(err)
+		return diag.FromErr(err)
 	}
 	flattenCloudGcpLinkedAccount(d, linkedAccount)
 	return nil


### PR DESCRIPTION
# Description

This PR will fix error handling upon trying to run `terraform apply` (in Staging) with the resource `newrelic_cloud_gcp_integrations`.

Ticket : [NR-262901](https://new-relic.atlassian.net/browse/NR-262901)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code



[NR-262901]: https://new-relic.atlassian.net/browse/NR-262901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ