### PR TITLE
docs: Update Synthetic Monitor resources with Legacy Runtime EOL Notice

### DIFF
--- a/website/docs/r/synthetics_broken_links_monitor.html.markdown
+++ b/website/docs/r/synthetics_broken_links_monitor.html.markdown
@@ -8,6 +8,8 @@ description: |-
 
 # Resource: newrelic\_synthetics\_broken\_links\_monitor
 
+-> **WARNING** Support for legacy Synthetics runtimes **will reach its end-of-life (EOL) on October 22, 2024**. In addition, creating **_new_** monitors using the legacy runtime **will no longer be supported after June 30, 2024**. In light of the above, kindly **upgrade your Synthetic Monitors to the new runtime** at the earliest, if they are still using the legacy runtime. Please check out [this page](https://forum.newrelic.com/s/hubtopic/aAXPh0000001brxOAA/upcoming-endoflife-legacy-synthetics-runtimes-and-cpm) for more details on the EOL, action needed (specific to monitors using public and private locations), relevant resources, and more.
+
 Use this resource to create, update, and delete a Synthetics Broken Links monitor in New Relic.
 
 ## Example Usage
@@ -46,6 +48,9 @@ The following are the arguments supported by this resource.
 * `runtime_type_version` - (Optional) The specific version of the runtime type selected.
 
 -> **NOTE:** Currently, the values of `runtime_type` and `runtime_type_version` supported by this resource are `NODE_API` and `16.10` respectively. In order to run the monitor in the new runtime, both `runtime_type` and `runtime_type_version` need to be specified; however, specifying neither of these attributes would set this monitor to use the legacy runtime. It may also be noted that the runtime opted for would only be effective with private locations. For public locations, all traffic has been shifted to the new runtime, irrespective of the selection made.
+
+-> **WARNING** Support for legacy Synthetics runtimes **will reach its end-of-life (EOL) on October 22, 2024**. In addition, creating **_new_** monitors using the legacy runtime **will no longer be supported after June 30, 2024**. In light of the above, kindly **upgrade your Synthetic Monitors to the new runtime** at the earliest, if they are still using the legacy runtime. Please check out [this page](https://forum.newrelic.com/s/hubtopic/aAXPh0000001brxOAA/upcoming-endoflife-legacy-synthetics-runtimes-and-cpm) for more details on the EOL, action needed (specific to monitors using public and private locations), relevant resources, and more.
+
 * `tag` - (Optional) The tags that will be associated with the monitor. See [Nested tag blocks](#nested-tag-blocks) below for details
 
 ### Nested `tag` blocks

--- a/website/docs/r/synthetics_cert_check_monitor.html.markdown
+++ b/website/docs/r/synthetics_cert_check_monitor.html.markdown
@@ -8,6 +8,8 @@ description: |-
 
 # Resource: newrelic\_synthetics\_cert\_check\_monitor
 
+-> **WARNING** Support for legacy Synthetics runtimes **will reach its end-of-life (EOL) on October 22, 2024**. In addition, creating **_new_** monitors using the legacy runtime **will no longer be supported after June 30, 2024**. In light of the above, kindly **upgrade your Synthetic Monitors to the new runtime** at the earliest, if they are still using the legacy runtime. Please check out [this page](https://forum.newrelic.com/s/hubtopic/aAXPh0000001brxOAA/upcoming-endoflife-legacy-synthetics-runtimes-and-cpm) for more details on the EOL, action needed (specific to monitors using public and private locations), relevant resources, and more.
+
 Use this resource to create, update, and delete a Synthetics Certificate Check monitor in New Relic.
 
 ## Example Usage
@@ -49,6 +51,8 @@ The following are the arguments supported by this resource.
 * `runtime_type_version` - (Optional) The specific version of the runtime type selected.
 
 -> **NOTE:** Currently, the values of `runtime_type` and `runtime_type_version` supported by this resource are `NODE_API` and `16.10` respectively. In order to run the monitor in the new runtime, both `runtime_type` and `runtime_type_version` need to be specified; however, specifying neither of these attributes would set this monitor to use the legacy runtime. It may also be noted that the runtime opted for would only be effective with private locations. For public locations, all traffic has been shifted to the new runtime, irrespective of the selection made.
+
+-> **WARNING** Support for legacy Synthetics runtimes **will reach its end-of-life (EOL) on October 22, 2024**. In addition, creating **_new_** monitors using the legacy runtime **will no longer be supported after June 30, 2024**. In light of the above, kindly **upgrade your Synthetic Monitors to the new runtime** at the earliest, if they are still using the legacy runtime. Please check out [this page](https://forum.newrelic.com/s/hubtopic/aAXPh0000001brxOAA/upcoming-endoflife-legacy-synthetics-runtimes-and-cpm) for more details on the EOL, action needed (specific to monitors using public and private locations), relevant resources, and more.
 
 * `tag` - (Optional) The tags that will be associated with the monitor. See [Nested tag blocks](#nested-tag-blocks) below for details
 

--- a/website/docs/r/synthetics_monitor.html.markdown
+++ b/website/docs/r/synthetics_monitor.html.markdown
@@ -8,6 +8,8 @@ description: |-
 
 # Resource: newrelic\_synthetics\_monitor
 
+-> **WARNING** Support for legacy Synthetics runtimes **will reach its end-of-life (EOL) on October 22, 2024**. In addition, creating **_new_** monitors using the legacy runtime **will no longer be supported after June 30, 2024**. In light of the above, kindly **upgrade your Synthetic Monitors to the new runtime** at the earliest, if they are still using the legacy runtime. Please check out [this page](https://forum.newrelic.com/s/hubtopic/aAXPh0000001brxOAA/upcoming-endoflife-legacy-synthetics-runtimes-and-cpm) for more details on the EOL, action needed (specific to monitors using public and private locations), relevant resources, and more.
+
 Use this resource to create, update, and delete a Simple or Browser Synthetics Monitor in New Relic.
 
 ## Example Usage
@@ -101,8 +103,7 @@ The `BROWSER` monitor type supports the following additional arguments:
 
 If you want to use the legacy runtime you can set the `runtime_type`, `runtime_type_version` and `script_language` to empty string `""`. 
 
--> **NOTE:** The old runtime will be deprecated in the future, so use the new version whenever you can. Additionally, if you detect any terraform drift while using default runtime values, 
-please utilise the [ignore_changes](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes) lifecycle meta argument to resolve them.
+-> **WARNING** Support for legacy Synthetics runtimes **will reach its end-of-life (EOL) on October 22, 2024**. In addition, creating **_new_** monitors using the legacy runtime **will no longer be supported after June 30, 2024**. In light of the above, kindly **upgrade your Synthetic Monitors to the new runtime** at the earliest, if they are still using the legacy runtime. Please check out [this page](https://forum.newrelic.com/s/hubtopic/aAXPh0000001brxOAA/upcoming-endoflife-legacy-synthetics-runtimes-and-cpm) for more details on the EOL, action needed (specific to monitors using public and private locations), relevant resources, and more. 
 
 ### Example Usage
 

--- a/website/docs/r/synthetics_script_monitor.html.markdown
+++ b/website/docs/r/synthetics_script_monitor.html.markdown
@@ -8,6 +8,8 @@ description: |-
 
 # Resource: newrelic\_synthetics\_script\_monitor
 
+-> **WARNING** Support for legacy Synthetics runtimes **will reach its end-of-life (EOL) on October 22, 2024**. In addition, creating **_new_** monitors using the legacy runtime **will no longer be supported after June 30, 2024**. In light of the above, kindly **upgrade your Synthetic Monitors to the new runtime** at the earliest, if they are still using the legacy runtime. Please check out [this page](https://forum.newrelic.com/s/hubtopic/aAXPh0000001brxOAA/upcoming-endoflife-legacy-synthetics-runtimes-and-cpm) for more details on the EOL, action needed (specific to monitors using public and private locations), relevant resources, and more.
+
 Use this resource to create update, and delete a Script API or Script Browser Synthetics Monitor in New Relic.
 
 ## Example Usage
@@ -89,7 +91,7 @@ The `SCRIPTED_BROWSER` monitor type supports the following additional argument:
 
 If you want to use a legacy runtime (Node 10 or Chrome 72) you can set the `runtime_type`, `runtime_type_version` and `script_language` to empty string `""`. 
 
--> **NOTE:** The old runtime will be deprecated in the future, so use the new version whenever you can.
+-> **WARNING** Support for legacy Synthetics runtimes **will reach its end-of-life (EOL) on October 22, 2024**. In addition, creating **_new_** monitors using the legacy runtime **will no longer be supported after June 30, 2024**. In light of the above, kindly **upgrade your Synthetic Monitors to the new runtime** at the earliest, if they are still using the legacy runtime. Please check out [this page](https://forum.newrelic.com/s/hubtopic/aAXPh0000001brxOAA/upcoming-endoflife-legacy-synthetics-runtimes-and-cpm) for more details on the EOL, action needed (specific to monitors using public and private locations), relevant resources, and more.
 
 ### Nested `tag` blocks
 

--- a/website/docs/r/synthetics_step_monitor.html.markdown
+++ b/website/docs/r/synthetics_step_monitor.html.markdown
@@ -8,6 +8,8 @@ description: |-
 
 # Resource: newrelic\_synthetics\_step\_monitor
 
+-> **WARNING** Support for legacy Synthetics runtimes **will reach its end-of-life (EOL) on October 22, 2024**. In addition, creating **_new_** monitors using the legacy runtime **will no longer be supported after June 30, 2024**. In light of the above, kindly **upgrade your Synthetic Monitors to the new runtime** at the earliest, if they are still using the legacy runtime. Please check out [this page](https://forum.newrelic.com/s/hubtopic/aAXPh0000001brxOAA/upcoming-endoflife-legacy-synthetics-runtimes-and-cpm) for more details on the EOL, action needed (specific to monitors using public and private locations), relevant resources, and more.
+
 Use this resource to create, update, and delete a Synthetics Step monitor in New Relic.
 
 ## Example Usage
@@ -51,6 +53,8 @@ The following are the common arguments supported for `STEP` monitor:
 * `runtime_type_version` - (Optional) The specific version of the runtime type selected.
 
 -> **NOTE:** Currently, the values of `runtime_type` and `runtime_type_version` supported by this resource are `CHROME_BROWSER` and `100` respectively. In order to run the monitor in the new runtime, both `runtime_type` and `runtime_type_version` need to be specified; however, specifying neither of these attributes would set this monitor to use the legacy runtime. It may also be noted that the runtime opted for would only be effective with private locations. For public locations, all traffic has been shifted to the new runtime, irrespective of the selection made.
+
+-> **WARNING** Support for legacy Synthetics runtimes **will reach its end-of-life (EOL) on October 22, 2024**. In addition, creating **_new_** monitors using the legacy runtime **will no longer be supported after June 30, 2024**. In light of the above, kindly **upgrade your Synthetic Monitors to the new runtime** at the earliest, if they are still using the legacy runtime. Please check out [this page](https://forum.newrelic.com/s/hubtopic/aAXPh0000001brxOAA/upcoming-endoflife-legacy-synthetics-runtimes-and-cpm) for more details on the EOL, action needed (specific to monitors using public and private locations), relevant resources, and more.
 
 * `steps` - (Required) The steps that make up the script the monitor will run. See [Nested steps blocks](#nested-steps-blocks) below for details.
 * `tag` - (Optional) The tags that will be associated with the monitor. See [Nested tag blocks](#nested-tag-blocks) below for details.


### PR DESCRIPTION
Ref: https://forum.newrelic.com/s/hubtopic/aAXPh0000001brxOAA/upcoming-endoflife-legacy-synthetics-runtimes-and-cpm

Adds documentation changes to add a EOL notice specifying the EOL of the legacy runtime of Synthetic Monitors, slated to be hit on October 22, 2024, and a link to resources.

Changes have been made just under the heading of the resource and later, under the definition of the arguments `runtime_type` and `runtime_type_version`; for instance - 

<img width="620" alt="image" src="https://github.com/newrelic/terraform-provider-newrelic/assets/127438038/1b3c5789-2365-427d-97a3-2aa669886da5">

<img width="645" alt="image" src="https://github.com/newrelic/terraform-provider-newrelic/assets/127438038/0d1fd191-2f1c-4cfe-bf85-d22ff92a42f2">
