### PR TITLE
docs: Add a GitHub Issue Explaining the Synthetics Legacy Runtime EOL

### DIFF
--- a/website/synthetics-legacy-runtime-eol.md
+++ b/website/synthetics-legacy-runtime-eol.md
@@ -1,6 +1,5 @@
 Hello!
 
-
 As already communicated by New Relic, support for legacy Synthetics runtimes **will reach its end-of-life (EOL) on October 22, 2024**. In addition, creating **new** monitors using the legacy runtime **will no longer be supported after June 30, 2024**. This would affect Synthetic Monitors running on the legacy runtime, created using any of the following resources used to manage Synthetic Monitors:
 
 - [newrelic_synthetics_monitor](https://registry.terraform.io/providers/newrelic/newrelic/3.36.1/docs/resources/synthetics_monitor)

--- a/website/synthetics-legacy-runtime-eol.md
+++ b/website/synthetics-legacy-runtime-eol.md
@@ -12,7 +12,7 @@ In light of the above, kindly **upgrade your Synthetic Monitors to the new runti
 
 We will synchronize relevant changes in the New Relic Terraform Provider with the Synthetics team. Watch this space for more updates.
 
-The article linked above comprises key details around the EOL and has been published by New Relic Synthetics. We shall also continue to share any useful information around the EOL via this thread, or via the documentation of the New Relic Terraform Provider.
+We shall also continue to share any useful information around the EOL via this thread, or via the documentation of the New Relic Terraform Provider.
 
 Should you have any questions/suggestions, please feel free to let us know in this thread.
 

--- a/website/synthetics-legacy-runtime-eol.md
+++ b/website/synthetics-legacy-runtime-eol.md
@@ -1,6 +1,6 @@
 Hello!
 
-As already communicated by New Relic, support for legacy Synthetics runtimes **will reach end-of-life (EOL) on October 22, 2024**. In addition, creating **new** monitors using the legacy runtime **will no longer be supported after June 30, 2024**. This affects Synthetic Monitors running on the legacy runtime, created using any of the following resources:
+As already [communicated by New Relic](https://docs.newrelic.com/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm/#:~:text=On%20October%2022%2C%202024%2C%20New,version%2010%20(or%20older)%20runtimes), support for legacy Synthetics runtimes **will reach end-of-life (EOL) on October 22, 2024**. In addition, creating **new** monitors using the legacy runtime **will no longer be supported after June 30, 2024**. This affects Synthetic Monitors running on the legacy runtime, created using any of the following resources:
 
 - [newrelic_synthetics_monitor](https://registry.terraform.io/providers/newrelic/newrelic/3.36.1/docs/resources/synthetics_monitor)
 - [newrelic_synthetics_script_monitor](https://registry.terraform.io/providers/newrelic/newrelic/3.36.1/docs/resources/synthetics_script_monitor)

--- a/website/synthetics-legacy-runtime-eol.md
+++ b/website/synthetics-legacy-runtime-eol.md
@@ -1,6 +1,6 @@
 Hello!
 
-As already communicated by New Relic, support for legacy Synthetics runtimes **will reach its end-of-life (EOL) on October 22, 2024**. In addition, creating **new** monitors using the legacy runtime **will no longer be supported after June 30, 2024**. This would affect Synthetic Monitors running on the legacy runtime, created using any of the following resources used to manage Synthetic Monitors:
+As already communicated by New Relic, support for legacy Synthetics runtimes **will reach end-of-life (EOL) on October 22, 2024**. In addition, creating **new** monitors using the legacy runtime **will no longer be supported after June 30, 2024**. This affects Synthetic Monitors running on the legacy runtime, created using any of the following resources used to manage Synthetic Monitors:
 
 - [newrelic_synthetics_monitor](https://registry.terraform.io/providers/newrelic/newrelic/3.36.1/docs/resources/synthetics_monitor)
 - [newrelic_synthetics_script_monitor](https://registry.terraform.io/providers/newrelic/newrelic/3.36.1/docs/resources/synthetics_script_monitor)

--- a/website/synthetics-legacy-runtime-eol.md
+++ b/website/synthetics-legacy-runtime-eol.md
@@ -8,7 +8,7 @@ As already communicated by New Relic, support for legacy Synthetics runtimes **w
 - [newrelic_synthetics_cert_check_monitor](https://registry.terraform.io/providers/newrelic/newrelic/3.36.1/docs/resources/synthetics_cert_check_monitor)
 - [newrelic_synthetics_broken_links_monitor](https://registry.terraform.io/providers/newrelic/newrelic/3.36.1/docs/resources/synthetics_broken_links_monitor)
 
-In light of the above, kindly **upgrade your Synthetic Monitors to the new runtime** at the earliest (before the date of the EOL), if they are still using the legacy runtime. Check out [this page](https://forum.newrelic.com/s/hubtopic/aAXPh0000001brxOAA/upcoming-endoflife-legacy-synthetics-runtimes-and-cpm) for more details on the EOL, action needed (specific to monitors using public and private locations), relevant resources, and more.
+In light of the above, kindly **upgrade your Synthetic Monitors to the new runtime** before the EOL date. Check out [this page](https://forum.newrelic.com/s/hubtopic/aAXPh0000001brxOAA/upcoming-endoflife-legacy-synthetics-runtimes-and-cpm) for more details on the EOL, actions needed, relevant resources, and more.
 
 We shall be working with Synthetics to ensure the timelines of any relevant changes in the New Relic Terraform Provider (as a consequence of the EOL) are well aligned with their plans around the EOL. Watch this space for more updates on changes to be introduced in the New Relic Terraform Provider (if any), in order to facilitate the EOL.
 

--- a/website/synthetics-legacy-runtime-eol.md
+++ b/website/synthetics-legacy-runtime-eol.md
@@ -1,6 +1,6 @@
 Hello!
 
-As already communicated by New Relic, support for legacy Synthetics runtimes **will reach end-of-life (EOL) on October 22, 2024**. In addition, creating **new** monitors using the legacy runtime **will no longer be supported after June 30, 2024**. This affects Synthetic Monitors running on the legacy runtime, created using any of the following resources used to manage Synthetic Monitors:
+As already communicated by New Relic, support for legacy Synthetics runtimes **will reach end-of-life (EOL) on October 22, 2024**. In addition, creating **new** monitors using the legacy runtime **will no longer be supported after June 30, 2024**. This affects Synthetic Monitors running on the legacy runtime, created using any of the following resources:
 
 - [newrelic_synthetics_monitor](https://registry.terraform.io/providers/newrelic/newrelic/3.36.1/docs/resources/synthetics_monitor)
 - [newrelic_synthetics_script_monitor](https://registry.terraform.io/providers/newrelic/newrelic/3.36.1/docs/resources/synthetics_script_monitor)

--- a/website/synthetics-legacy-runtime-eol.md
+++ b/website/synthetics-legacy-runtime-eol.md
@@ -12,7 +12,7 @@ In light of the above, kindly **upgrade your Synthetic Monitors to the new runti
 
 We will synchronize relevant changes in the New Relic Terraform Provider with the Synthetics team. Watch this space for more updates.
 
-The article linked above comprises key details around the EOL and has been published by New Relic Synthetics. We shall also continue to share any useful information around the EOL via this thread, or via the documentation of the New Relic Terraform Provider, if we find such information can be useful to a larger audience.
+The article linked above comprises key details around the EOL and has been published by New Relic Synthetics. We shall also continue to share any useful information around the EOL via this thread, or via the documentation of the New Relic Terraform Provider.
 
 Should you have any questions/suggestions, please feel free to let us know in this thread.
 

--- a/website/synthetics-legacy-runtime-eol.md
+++ b/website/synthetics-legacy-runtime-eol.md
@@ -1,0 +1,22 @@
+Hello!
+
+This issue/post has been created to convey details about the upcoming end-of-life (EOL) of the Synthetics Legacy Runtime, which would, post the end-of-life, affect all Synthetic Monitors created using the legacy runtime.
+
+As already communicated by New Relic, support for legacy Synthetics runtimes **will reach its end-of-life (EOL) on October 22, 2024**. In addition, creating **new** monitors using the legacy runtime **will no longer be supported after June 30, 2024**. This would affect Synthetic Monitors running on the legacy runtime, created using any of the following resources used to manage Synthetic Monitors:
+
+- [newrelic_synthetics_monitor](https://registry.terraform.io/providers/newrelic/newrelic/3.36.1/docs/resources/synthetics_monitor)
+- [newrelic_synthetics_script_monitor](https://registry.terraform.io/providers/newrelic/newrelic/3.36.1/docs/resources/synthetics_script_monitor)
+- [newrelic_synthetics_step_monitor](https://registry.terraform.io/providers/newrelic/newrelic/3.36.1/docs/resources/setics_step_monitor)
+- [newrelic_synthetics_cert_check_monitor](https://registry.terraform.io/providers/newrelic/newrelic/3.36.1/docs/resources/synthetics_cert_check_monitor)
+- [newrelic_synthetics_broken_links_monitor](https://registry.terraform.io/providers/newrelic/newrelic/3.36.1/docs/resources/synthetics_broken_links_monitor)
+
+In light of the above, kindly **upgrade your Synthetic Monitors to the new runtime** at the earliest (before the date of the EOL), if they are still using the legacy runtime. Check out [this page](https://forum.newrelic.com/s/hubtopic/aAXPh0000001brxOAA/upcoming-endoflife-legacy-synthetics-runtimes-and-cpm) for more details on the EOL, action needed (specific to monitors using public and private locations), relevant resources, and more.
+
+We shall be working with Synthetics to ensure the timelines of any relevant changes in the New Relic Terraform Provider (as a consequence of the EOL) are well aligned with their plans around the EOL. Watch this space for more updates on changes to be introduced in the New Relic Terraform Provider (if any), in order to facilitate the EOL.
+
+The article linked above comprises key details around the EOL and has been published by New Relic Synthetics. We shall also continue to share any useful information around the EOL via this thread, or via the documentation of the New Relic Terraform Provider, if we find such information can be useful to a larger audience.
+
+Should you have any questions/suggestions, please feel free to let us know in this thread.
+
+Thanks a lot
+The Observability as Code team

--- a/website/synthetics-legacy-runtime-eol.md
+++ b/website/synthetics-legacy-runtime-eol.md
@@ -10,7 +10,7 @@ As already communicated by New Relic, support for legacy Synthetics runtimes **w
 
 In light of the above, kindly **upgrade your Synthetic Monitors to the new runtime** before the EOL date. Check out [this page](https://forum.newrelic.com/s/hubtopic/aAXPh0000001brxOAA/upcoming-endoflife-legacy-synthetics-runtimes-and-cpm) for more details on the EOL, actions needed, relevant resources, and more.
 
-We shall be working with Synthetics to ensure the timelines of any relevant changes in the New Relic Terraform Provider (as a consequence of the EOL) are well aligned with their plans around the EOL. Watch this space for more updates on changes to be introduced in the New Relic Terraform Provider (if any), in order to facilitate the EOL.
+We will synchronize relevant changes in the New Relic Terraform Provider with the Synthetics team. Watch this space for more updates.
 
 The article linked above comprises key details around the EOL and has been published by New Relic Synthetics. We shall also continue to share any useful information around the EOL via this thread, or via the documentation of the New Relic Terraform Provider, if we find such information can be useful to a larger audience.
 

--- a/website/synthetics-legacy-runtime-eol.md
+++ b/website/synthetics-legacy-runtime-eol.md
@@ -1,6 +1,5 @@
 Hello!
 
-This issue/post has been created to convey details about the upcoming end-of-life (EOL) of the Synthetics Legacy Runtime, which would, post the end-of-life, affect all Synthetic Monitors created using the legacy runtime.
 
 As already communicated by New Relic, support for legacy Synthetics runtimes **will reach its end-of-life (EOL) on October 22, 2024**. In addition, creating **new** monitors using the legacy runtime **will no longer be supported after June 30, 2024**. This would affect Synthetic Monitors running on the legacy runtime, created using any of the following resources used to manage Synthetic Monitors:
 


### PR DESCRIPTION
### Update (24 May 2024)
The EOL post has been published here: https://github.com/newrelic/terraform-provider-newrelic/issues/2673
________
### Original Description of the PR
The following is a draft of the GitHub Issue we'd like to create to notify customers about the upcoming end-of-life of the legacy runtime of Synthetic Monitors in October 2024, similar to #2286.

#### Important
@pranav-new-relic : **DO NOT MERGE this PR**. We do not want to have this file created in the specified folder. 

The idea of this PR is to have this reviewed, after which the contents of this file would be moved to a new GitHub issue with the title `⚠️ EOL Notice for the Synthetics Legacy Runtime in use with Synthetic Monitors`, created and pinned in the list of GitHub issues, in alignment with a similar EOL notice we posted earlier via #2286.

<img width="845" alt="image" src="https://github.com/newrelic/terraform-provider-newrelic/assets/127438038/d450b7ce-9240-4ff0-9174-42cdaf0f0098">

