### PR TITLE
fix(dashboards): fix broken condition when thresholds are nil with billboard widgets

### DIFF
--- a/newrelic/structures_newrelic_one_dashboard.go
+++ b/newrelic/structures_newrelic_one_dashboard.go
@@ -1203,19 +1203,21 @@ func flattenDashboardWidget(in *entities.DashboardWidget, pageGUID string) (stri
 	case "viz.billboard":
 		widgetType = "widget_billboard"
 		out["nrql_query"] = flattenDashboardWidgetNRQLQuery(&rawCfg.NRQLQueries)
-		rawCfgThresholdsFetched := rawCfg.Thresholds.([]interface{})
-		if len(rawCfgThresholdsFetched) > 0 {
-			for _, t := range rawCfgThresholdsFetched {
-				thresholdFetched := t.(map[string]interface{})
-				if thresholdFetched["value"] == nil {
-					continue
-				}
+		if rawCfg.Thresholds != nil {
+			rawCfgThresholdsFetched := rawCfg.Thresholds.([]interface{})
+			if len(rawCfgThresholdsFetched) > 0 {
+				for _, t := range rawCfgThresholdsFetched {
+					thresholdFetched := t.(map[string]interface{})
+					if thresholdFetched["value"] == nil {
+						continue
+					}
 
-				switch thresholdFetched["alertSeverity"].(string) {
-				case string(entities.DashboardAlertSeverityTypes.CRITICAL):
-					out["critical"] = strconv.FormatFloat(thresholdFetched["value"].(float64), 'f', -1, 64)
-				case string(entities.DashboardAlertSeverityTypes.WARNING):
-					out["warning"] = strconv.FormatFloat(thresholdFetched["value"].(float64), 'f', -1, 64)
+					switch thresholdFetched["alertSeverity"].(string) {
+					case string(entities.DashboardAlertSeverityTypes.CRITICAL):
+						out["critical"] = strconv.FormatFloat(thresholdFetched["value"].(float64), 'f', -1, 64)
+					case string(entities.DashboardAlertSeverityTypes.WARNING):
+						out["warning"] = strconv.FormatFloat(thresholdFetched["value"].(float64), 'f', -1, 64)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #2675
(fixes a mishandled condition in #2672)
_____________

### Summary
It has been reported via #2675 that (with the latest release of the provider, `v3.37.0`) running a `terraform plan` on configuration comprising of `widget_billboard` in the resource `newrelic_one_dashboard` is running into panic, and is hence, failing.

### Steps to Reproduce
```hcl
resource "newrelic_one_dashboard" "exampledash" {
  name        = "THRESHOLD TEST DASHBOARD"
  permissions = "public_read_only"

  page {

    name = "New Relic Terraform Example"
    widget_billboard {
      title  = "Billboard Widget 1"
      row    = 1
      column = 1
      width  = 4
      height = 4

      nrql_query {
        query = "FROM Transaction SELECT rate(count(*), 1 minute)"
      }
    }

    widget_billboard {
      title  = "Billboard Widget 2"
      row    = 5
      column = 1
      width  = 4
      height = 3

      nrql_query {
        query = "FROM Transaction SELECT rate(count(*), 1 minute)"
      }

      critical = "300"
      warning  = "500"
    }
  }
}
```
- Shift to versions < `v3.36.0` of the Terraform Provider using `terraform init -upgrade` and run a `terraform plan` and a `terraform apply` on the configuration. After this, run a `terraform plan` again and you will see no error.
- Now, try shifting to version `3.37.0` of the provider again, using `terraform init -upgrade` and then run a `terraform plan` on the same configuration again. The stack trace reported in the issue linked above may be obtained.
-  **Additional point:** Upon recreating all of the above scenario without the second billboard widget in the configuration attached above, the observation that this failure is seen with billboard widgets only when they do not have a threshold defined has been made 
   - (i.e., running this scenario only with the second billboard widget does not seem to throw an error). This helps hint at the fact that something isn't right with the logic when the read function is called by the resource, pertaining to billboard widgets only when they contain threshold specifications (`critical` and/or `warning`) and the issue is not seen when neither of `warning` and `critical` are specified

### The Fix
Based on the observation made above, it appears that the absence of a condition to handle the case when the `Thresholds` attribute of the dashboard's `RawConfiguration` is nil (only in the case of billboard widgets) is leading to this failure; adding a relevant condition should fix the problem, which is what this PR aims at doing.

