### PR TITLE
feat: add support for SERVICE_NOW_APP

### DIFF
--- a/newrelic/resource_newrelic_notifications_destination.go
+++ b/newrelic/resource_newrelic_notifications_destination.go
@@ -401,6 +401,7 @@ func listValidNotificationsDestinationTypes() []string {
 		string(notifications.AiNotificationsDestinationTypeTypes.WEBHOOK),
 		string(notifications.AiNotificationsDestinationTypeTypes.EMAIL),
 		string(notifications.AiNotificationsDestinationTypeTypes.SERVICE_NOW),
+		string(notifications.AiNotificationsDestinationTypeTypes.SERVICE_NOW_APP),
 		string(notifications.AiNotificationsDestinationTypeTypes.PAGERDUTY_ACCOUNT_INTEGRATION),
 		string(notifications.AiNotificationsDestinationTypeTypes.PAGERDUTY_SERVICE_INTEGRATION),
 		string(notifications.AiNotificationsDestinationTypeTypes.JIRA),

--- a/website/docs/d/notification_destination.html.markdown
+++ b/website/docs/d/notification_destination.html.markdown
@@ -72,7 +72,7 @@ Optional:
 In addition to all arguments above, the following attributes are exported:
 
 * `name` - The name of the notification destination.
-* `type` - The notification destination type, either: `EMAIL`, `SERVICE_NOW`, `WEBHOOK`, `JIRA`, `MOBILE_PUSH`, `EVENT_BRIDGE`, `PAGERDUTY_ACCOUNT_INTEGRATION` or `PAGERDUTY_SERVICE_INTEGRATION`, `SLACK` and `SLACK_COLLABORATION`.
+* `type` - The notification destination type, either: `EMAIL`, `SERVICE_NOW`, `SERVICE_NOW_APP`, `WEBHOOK`, `JIRA`, `MOBILE_PUSH`, `EVENT_BRIDGE`, `PAGERDUTY_ACCOUNT_INTEGRATION` or `PAGERDUTY_SERVICE_INTEGRATION`, `SLACK` and `SLACK_COLLABORATION`.
 * `property` - A nested block that describes a notification destination property.
 * `active` - An indication whether the notification destination is active or not.
 * `status` - The status of the notification destination.

--- a/website/docs/r/notification_destination.html.markdown
+++ b/website/docs/r/notification_destination.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `account_id` - (Optional) Determines the New Relic account where the notification destination will be created. Defaults to the account associated with the API key used.
 * `name` - (Required) The name of the destination.
-* `type` - (Required) The type of destination.  One of: `EMAIL`, `SERVICE_NOW`, `WEBHOOK`, `JIRA`, `MOBILE_PUSH`, `EVENT_BRIDGE`, `PAGERDUTY_ACCOUNT_INTEGRATION` or `PAGERDUTY_SERVICE_INTEGRATION`. The types `SLACK` and `SLACK_COLLABORATION` can only be imported, updated and destroyed (cannot be created via terraform).
+* `type` - (Required) The type of destination.  One of: `EMAIL`, `SERVICE_NOW`, `SERVICE_NOW_APP`, `WEBHOOK`, `JIRA`, `MOBILE_PUSH`, `EVENT_BRIDGE`, `PAGERDUTY_ACCOUNT_INTEGRATION` or `PAGERDUTY_SERVICE_INTEGRATION`. The types `SLACK` and `SLACK_COLLABORATION` can only be imported, updated and destroyed (cannot be created via terraform).
 * `auth_basic` - (Optional) A nested block that describes a basic username and password authentication credentials. Only one auth_basic block is permitted per notification destination definition.  See [Nested auth_basic blocks](#nested-auth_basic-blocks) below for details.
 * `auth_token` - (Optional) A nested block that describes a token authentication credentials. Only one auth_token block is permitted per notification destination definition.  See [Nested auth_token blocks](#nested-auth_token-blocks) below for details.
 * `auth_custom_header` - (Optional) A nested block that describes a custom header authentication credentials. Multiple blocks are permitted per notification destination definition. [Nested auth_custom_header blocks](#nested-authcustomheader-blocks) below for details.
@@ -88,6 +88,8 @@ Each notification destination type supports a specific set of arguments for the 
 * `SERVICE_NOW`
   * `url` - (Required) The service now destination url (only base url).
   * `two_way_integration` - (Optional) A boolean that represents the two-way integration on/off flag.
+* `SERVICE_NOW_APP`
+  * `url` - (Required) The service now destination url (only base url).
 * `JIRA`
   * `url` - (Required) The jira url (only base url).
   * `two_way_integration` - (Optional) A boolean that represents the two-way integration on/off flag.


### PR DESCRIPTION
# Description

This adds support for the Service Now Certified App integration, as an alternative to the legacy Service Now integration.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Create a `newrelic_notification_destination` with `type = SERVICE_NOW_APP`.
