### PR TITLE
feat(destinations): add `update_original_message` to destination configurations

### DIFF
--- a/newrelic/resource_newrelic_workflow.go
+++ b/newrelic/resource_newrelic_workflow.go
@@ -459,16 +459,6 @@ func resourceNewRelicWorkflowV0() *schema.Resource {
 	}
 }
 
-func suppressDefaultBool(defaultValue bool) schema.SchemaDiffSuppressFunc {
-	return func(k, old, new string, d *schema.ResourceData) bool {
-		// Convert old and new values to booleans
-		oldBool, newBool := old == "", new == "true"
-
-		// Suppress the diff if the new value is not set (default) and the old value is the default value
-		return newBool == defaultValue && oldBool == defaultValue
-	}
-}
-
 func resourceNewRelicWorkflowCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderConfig).NewClient
 	workflowInput, err := expandWorkflow(d)

--- a/newrelic/resource_newrelic_workflow.go
+++ b/newrelic/resource_newrelic_workflow.go
@@ -64,6 +64,13 @@ func resourceNewRelicWorkflow() *schema.Resource {
 							Computed:    true,
 							Description: fmt.Sprintf("(Required) The type of the destination. One of: (%s).", strings.Join(listValidWorkflowsDestinationTypes(), ", ")),
 						},
+						// Computed
+						"update_original_message": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Computed:    true,
+							Description: "Update original notification message (Slack channels only)",
+						},
 					},
 				},
 			},

--- a/newrelic/resource_newrelic_workflow.go
+++ b/newrelic/resource_newrelic_workflow.go
@@ -68,6 +68,7 @@ func resourceNewRelicWorkflow() *schema.Resource {
 						"update_original_message": {
 							Type:        schema.TypeBool,
 							Optional:    true,
+							DefaultFunc: func() (interface{}, error) { return true, nil },
 							Computed:    true,
 							Description: "Update original notification message (Slack channels only)",
 						},
@@ -455,6 +456,16 @@ func resourceNewRelicWorkflowV0() *schema.Resource {
 			},
 		},
 		SchemaVersion: 0,
+	}
+}
+
+func suppressDefaultBool(defaultValue bool) schema.SchemaDiffSuppressFunc {
+	return func(k, old, new string, d *schema.ResourceData) bool {
+		// Convert old and new values to booleans
+		oldBool, newBool := old == "", new == "true"
+
+		// Suppress the diff if the new value is not set (default) and the old value is the default value
+		return newBool == defaultValue && oldBool == defaultValue
 	}
 }
 

--- a/newrelic/structures_newrelic_workflow.go
+++ b/newrelic/structures_newrelic_workflow.go
@@ -412,7 +412,12 @@ func flattenWorkflowDestinationConfiguration(d *workflows.AiWorkflowsDestination
 	destinationConfigurationResult["channel_id"] = d.ChannelId
 	destinationConfigurationResult["name"] = d.Name
 	destinationConfigurationResult["type"] = d.Type
-	destinationConfigurationResult["update_original_message"] = d.UpdateOriginalMessage
+	if currentState == nil || currentState["update_original_message"] == nil {
+		b := true
+		destinationConfigurationResult["update_original_message"] = &b
+	} else {
+		destinationConfigurationResult["update_original_message"] = d.UpdateOriginalMessage
+	}
 
 	if currentState == nil || currentState["notification_triggers"] == nil {
 		destinationConfigurationResult["notification_triggers"] = d.NotificationTriggers

--- a/newrelic/structures_newrelic_workflow.go
+++ b/newrelic/structures_newrelic_workflow.go
@@ -194,6 +194,10 @@ func expandWorkflowDestinationConfiguration(cfg map[string]interface{}) workflow
 		destinationConfigurationInput.ChannelId = channelID.(string)
 	}
 
+	if updateOriginalMessage, ok := cfg["update_original_message"]; ok {
+		destinationConfigurationInput.UpdateOriginalMessage = updateOriginalMessage.(bool)
+	}
+
 	if notificationTriggers, ok := cfg["notification_triggers"]; ok {
 		for _, p := range notificationTriggers.([]interface{}) {
 			notificationTriggersInput = append(notificationTriggersInput, workflows.AiWorkflowsNotificationTrigger(p.(string)))
@@ -407,6 +411,7 @@ func flattenWorkflowDestinationConfiguration(d *workflows.AiWorkflowsDestination
 	destinationConfigurationResult["channel_id"] = d.ChannelId
 	destinationConfigurationResult["name"] = d.Name
 	destinationConfigurationResult["type"] = d.Type
+	destinationConfigurationResult["update_original_message"] = d.UpdateOriginalMessage
 
 	if currentState == nil || currentState["notification_triggers"] == nil {
 		destinationConfigurationResult["notification_triggers"] = d.NotificationTriggers

--- a/newrelic/structures_newrelic_workflow.go
+++ b/newrelic/structures_newrelic_workflow.go
@@ -195,7 +195,8 @@ func expandWorkflowDestinationConfiguration(cfg map[string]interface{}) workflow
 	}
 
 	if updateOriginalMessage, ok := cfg["update_original_message"]; ok {
-		destinationConfigurationInput.UpdateOriginalMessage = updateOriginalMessage.(bool)
+		b := updateOriginalMessage.(bool)
+		destinationConfigurationInput.UpdateOriginalMessage = &b
 	}
 
 	if notificationTriggers, ok := cfg["notification_triggers"]; ok {

--- a/newrelic/structures_newrelic_workflow_test.go
+++ b/newrelic/structures_newrelic_workflow_test.go
@@ -186,10 +186,9 @@ func TestFlattenWorkflow(t *testing.T) {
 	}}
 
 	destinationConfigurations := []workflows.AiWorkflowsDestinationConfiguration{{
-		Name:                  "destination-test",
-		Type:                  workflows.AiWorkflowsDestinationTypeTypes.WEBHOOK,
-		ChannelId:             "300848f9-c713-463c-9036-40b45c4c970f",
-		UpdateOriginalMessage: nil,
+		Name:      "destination-test",
+		Type:      workflows.AiWorkflowsDestinationTypeTypes.WEBHOOK,
+		ChannelId: "300848f9-c713-463c-9036-40b45c4c970f",
 	}}
 
 	destinationConfigurationsWithNotificationTriggers := destinationConfigurations

--- a/newrelic/structures_newrelic_workflow_test.go
+++ b/newrelic/structures_newrelic_workflow_test.go
@@ -186,9 +186,10 @@ func TestFlattenWorkflow(t *testing.T) {
 	}}
 
 	destinationConfigurations := []workflows.AiWorkflowsDestinationConfiguration{{
-		Name:      "destination-test",
-		Type:      workflows.AiWorkflowsDestinationTypeTypes.WEBHOOK,
-		ChannelId: "300848f9-c713-463c-9036-40b45c4c970f",
+		Name:                  "destination-test",
+		Type:                  workflows.AiWorkflowsDestinationTypeTypes.WEBHOOK,
+		ChannelId:             "300848f9-c713-463c-9036-40b45c4c970f",
+		UpdateOriginalMessage: nil,
 	}}
 
 	destinationConfigurationsWithNotificationTriggers := destinationConfigurations
@@ -432,6 +433,8 @@ func testFlattenWorkflowsDestinationConfiguration(t *testing.T, v interface{}, c
 				assert.Equal(t, cv, string(configuration.Type))
 			case "notification_triggers":
 				assert.Equal(t, cv, configuration.NotificationTriggers)
+			case "update_original_message":
+				assert.Equal(t, cv, configuration.UpdateOriginalMessage)
 			}
 		}
 	}

--- a/website/docs/r/workflow.html.markdown
+++ b/website/docs/r/workflow.html.markdown
@@ -166,7 +166,8 @@ workflow.
 Block's arguments:
 * `channel_id` - (Required) Id of a [notification_channel](notification_channel.html) to use for notifications. Please note that you have to use a 
 **notification** channel, not an `alert_channel`.
-* `notification_triggers` - (Optional) Issue events to notify on. The value is a list of possible issue events. See [Notification Triggers](#notification-triggers) below for details. 
+* `notification_triggers` - (Optional) Issue events to notify on. The value is a list of possible issue events. See [Notification Triggers](#notification-triggers) below for details.
+* `update_original_message` - (Optional) Update original notification message (Slack channels only).
 
 ### Notification Triggers
 


### PR DESCRIPTION
# Description

Approved, but needs tiny changes - **please do not merge right now**.

Please include a summary of the change and which issue is fixed (if relevant).
Added a new field to destination block called update_original_message which for the moment only works for Slack channels.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

The test is solely minimal to see that a workflow can be created with the field, as it requires a slack channel for the field to change.
