### PR TITLE
fix(entity_tags): fixed improper error handling in `newrelic_entity_tags` resource

### DIFF
--- a/newrelic/resource_newrelic_entity_tags.go
+++ b/newrelic/resource_newrelic_entity_tags.go
@@ -82,7 +82,7 @@ func resourceNewRelicEntityTagsCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 	if res != nil && len(res.Errors) > 0 {
-		return CreateErrorDiagnostics(res)
+		return handleEntityTagsMutationEmbeddedErrors(res)
 	}
 	d.SetId(string(guid))
 
@@ -154,7 +154,7 @@ func resourceNewRelicEntityTagsUpdate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 	if res != nil && len(res.Errors) > 0 {
-		return CreateErrorDiagnostics(res)
+		return handleEntityTagsMutationEmbeddedErrors(res)
 	}
 
 	retryErr := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
@@ -219,7 +219,7 @@ func resourceNewRelicEntityTagsDelete(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 	if res != nil && len(res.Errors) > 0 {
-		return CreateErrorDiagnostics(res)
+		return handleEntityTagsMutationEmbeddedErrors(res)
 	}
 	return nil
 }
@@ -306,7 +306,7 @@ func getTag(tags []*entities.TaggingTagInput, key string) *entities.TaggingTagIn
 	return nil
 }
 
-func CreateErrorDiagnostics(res *entities.TaggingMutationResult) diag.Diagnostics {
+func handleEntityTagsMutationEmbeddedErrors(res *entities.TaggingMutationResult) diag.Diagnostics {
 	var diags diag.Diagnostics
 	for _, Error := range res.Errors {
 		diags = append(diags, diag.Diagnostic{

--- a/website/docs/r/entity_tags.html.markdown
+++ b/website/docs/r/entity_tags.html.markdown
@@ -85,7 +85,9 @@ The following arguments are supported:
 
 All nested `tag` blocks support the following common arguments:
 
-  * `key` - (Required) The tag key should not use reserved keys (also known as immutable keys), such as account or accountId. It's recommended to choose a unique and descriptive key that does not conflict with existing reserved keys.
+  * `key` - (Required) The key of the tag.
+
+-> **NOTE:** One should not use reserved (immutable) keys with this resource. It is recommended to choose unique and descriptive keys which do not conflict with existing reserved keys.
   * `values` - (Required) The tag values.
 
 ## Import

--- a/website/docs/r/entity_tags.html.markdown
+++ b/website/docs/r/entity_tags.html.markdown
@@ -85,7 +85,7 @@ The following arguments are supported:
 
 All nested `tag` blocks support the following common arguments:
 
-  * `key` - (Required) The tag key.
+  * `key` - (Required) The tag key should not use reserved keys (also known as immutable keys), such as account or accountId. It's recommended to choose a unique and descriptive key that does not conflict with existing reserved keys.
   * `values` - (Required) The tag values.
 
 ## Import


### PR DESCRIPTION
# Description

Currently, In newrelic_entity_tags resource there is improper error handling when we try to update reserved tags(default tags which will be added when we create entity). Please check out the below JIRA ticket for more info.

JIRA Ticket: https://new-relic.atlassian.net/browse/NR-273648

# Fixes
Added a new function CreateErrorDiagnostics which will print all errors if present in the response called nerdgraph APIs. The CreateErrorDiagnostics function is called in resourceNewRelicEntityTagsCreate, resourceNewRelicEntityTagsUpdate, resourceNewRelicEntityTagsDelete.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## Checklist:

Please delete options that are not relevant.

- [ ] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

