### PR TITLE
fix(notifications): Added servicenow app channel option to valid notification channels list

### DIFF
--- a/newrelic/resource_newrelic_notifications_channel.go
+++ b/newrelic/resource_newrelic_notifications_channel.go
@@ -207,6 +207,7 @@ func listValidNotificationsChannelTypes() []string {
 		string(notifications.AiNotificationsChannelTypeTypes.WEBHOOK),
 		string(notifications.AiNotificationsChannelTypeTypes.EMAIL),
 		string(notifications.AiNotificationsChannelTypeTypes.SERVICENOW_INCIDENTS),
+		string(notifications.AiNotificationsChannelTypeTypes.SERVICE_NOW_APP),
 		string(notifications.AiNotificationsChannelTypeTypes.PAGERDUTY_ACCOUNT_INTEGRATION),
 		string(notifications.AiNotificationsChannelTypeTypes.PAGERDUTY_SERVICE_INTEGRATION),
 		string(notifications.AiNotificationsChannelTypeTypes.JIRA_CLASSIC),

--- a/newrelic/resource_newrelic_workflow.go
+++ b/newrelic/resource_newrelic_workflow.go
@@ -578,6 +578,7 @@ func listValidWorkflowsDestinationTypes() []string {
 		string(workflows.AiWorkflowsDestinationTypeTypes.PAGERDUTY_ACCOUNT_INTEGRATION),
 		string(workflows.AiWorkflowsDestinationTypeTypes.PAGERDUTY_SERVICE_INTEGRATION),
 		string(workflows.AiWorkflowsDestinationTypeTypes.SERVICE_NOW),
+		string(workflows.AiWorkflowsDestinationTypeTypes.SERVICE_NOW_APP),
 		string(workflows.AiWorkflowsDestinationTypeTypes.WEBHOOK),
 		string(workflows.AiWorkflowsDestinationTypeTypes.MOBILE_PUSH),
 		string(workflows.AiWorkflowsDestinationTypeTypes.SLACK),

--- a/website/docs/r/notification_channel.html.markdown
+++ b/website/docs/r/notification_channel.html.markdown
@@ -113,8 +113,7 @@ resource "newrelic_notification_channel" "foo" {
   }
 }
 ```
-// TODO: change url + see if its possible to create without properties
-##### [ServiceNowApp](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-api-notifications-channels/#servicenow)
+##### [ServiceNowApp](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-api-notifications-channels/#servicenowapp)
 ```hcl
 resource "newrelic_notification_channel" "foo" {
   account_id = 12345678

--- a/website/docs/r/notification_channel.html.markdown
+++ b/website/docs/r/notification_channel.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `account_id` - (Optional) Determines the New Relic account where the notification channel will be created. Defaults to the account associated with the API key used.
 * `name` - (Required) The name of the channel.
-* `type` - (Required) The type of channel.  One of: `EMAIL`, `SERVICENOW_INCIDENTS`, `WEBHOOK`, `JIRA_CLASSIC`, `MOBILE_PUSH`, `EVENT_BRIDGE`, `SLACK` and `SLACK_COLLABORATION`, `PAGERDUTY_ACCOUNT_INTEGRATION` or `PAGERDUTY_SERVICE_INTEGRATION`.
+* `type` - (Required) The type of channel.  One of: `EMAIL`, `SERVICENOW_INCIDENTS`, `SERVICE_NOW_APP`, `WEBHOOK`, `JIRA_CLASSIC`, `MOBILE_PUSH`, `EVENT_BRIDGE`, `SLACK` and `SLACK_COLLABORATION`, `PAGERDUTY_ACCOUNT_INTEGRATION` or `PAGERDUTY_SERVICE_INTEGRATION`.
 * `destination_id` - (Required) The id of the destination.
 * `product` - (Required) The type of product.  One of: `DISCUSSIONS`, `ERROR_TRACKING` or `IINT` (workflows).
 * `property` - A nested block that describes a notification channel property. See [Nested property blocks](#nested-property-blocks) below for details.
@@ -60,6 +60,7 @@ Each notification channel type supports a specific set of arguments for the `pro
 * `SERVICENOW_INCIDENTS`
   * `description` - (Optional) Free text that represents a description.
   * `short_description` - (Optional) Free text that represents a short description.
+* `SERVICE_NOW_APP` - No Properties.
 * `JIRA_CLASSIC`, `JIRA_NEXTGEN`
   * `project` - (Required) Identifier that specifies jira project id.
   * `issuetype` - (Required) Identifier that specifies the issue type id.
@@ -110,6 +111,17 @@ resource "newrelic_notification_channel" "foo" {
     key = "short_description"
     value = "Short description"
   }
+}
+```
+// TODO: change url + see if its possible to create without properties
+##### [ServiceNowApp](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-api-notifications-channels/#servicenow)
+```hcl
+resource "newrelic_notification_channel" "foo" {
+  account_id = 12345678
+  name = "servicenow-app-example"
+  type = "SERVICE_NOW_APP"
+  destination_id = "00b6bd1d-ac06-4d3d-bd72-49551e70f7a8"
+  product = "IINT"
 }
 ```
 


### PR DESCRIPTION
### ⚠️ Do not merge right now, this PR has changes that depend on [clinet-go changes](https://github.com/newrelic/newrelic-client-go/pull/1200) to be released 

# Description

Please include a summary of the change and which issue is fixed (if relevant).
Added SNow channel type. Follow up to adding SNow destination type [here](https://github.com/newrelic/terraform-provider-newrelic/pull/2693) 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

