### PR TITLE
feat(notifications): increase timeout on mutations

### DIFF
--- a/newrelic/resource_newrelic_notifications_channel.go
+++ b/newrelic/resource_newrelic_notifications_channel.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/newrelic/newrelic-client-go/v2/pkg/ai"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/notifications"
@@ -76,6 +77,10 @@ func resourceNewRelicNotificationChannel() *schema.Resource {
 				Computed:    true,
 				Description: "The status of the channel.",
 			},
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(16 * time.Second),
+			Update: schema.DefaultTimeout(16 * time.Second),
 		},
 	}
 }

--- a/newrelic/resource_newrelic_notifications_destination.go
+++ b/newrelic/resource_newrelic_notifications_destination.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/newrelic/newrelic-client-go/v2/pkg/ai"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/notifications"
@@ -159,6 +160,10 @@ func resourceNewRelicNotificationDestination() *schema.Resource {
 				Upgrade: migrateStateNewRelicNotificationDestinationV0toV1,
 				Version: 0,
 			},
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(16 * time.Second),
+			Update: schema.DefaultTimeout(16 * time.Second),
 		},
 	}
 }


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed (if relevant).
The NG timeout for our schemas include a 15 seconds timeout, which is not exhibited by our TF schemas.
This change will allow users to create longer mutations and avoid retries when it's unneeded

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

