### PR TITLE
fix: Add creation/updation of synthetic(simple/browser) monitor with empty custom headers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/newrelic/terraform-provider-newrelic/v2
 
 go 1.21
 
-replace github.com/newrelic/newrelic-client-go/v2 => github.com/newrelic/newrelic-client-go/v2 v2.42.1-0.20240807084013-dc7b566b12a7
+replace github.com/newrelic/newrelic-client-go/v2 => github.com/newrelic/newrelic-client-go/v2 v2.42.1-0.20240807095203-278e54660b2b
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1

--- a/go.mod
+++ b/go.mod
@@ -2,14 +2,12 @@ module github.com/newrelic/terraform-provider-newrelic/v2
 
 go 1.21
 
-replace github.com/newrelic/newrelic-client-go/v2 => github.com/newrelic/newrelic-client-go/v2 v2.42.1-0.20240807095203-278e54660b2b
-
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.30.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.42.0
+	github.com/newrelic/newrelic-client-go/v2 v2.42.1
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 )

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/newrelic/terraform-provider-newrelic/v2
 
 go 1.21
 
-replace github.com/newrelic/newrelic-client-go/v2 => github.com/newrelic/newrelic-client-go/v2 v2.41.4-0.20240807081127-b43497bd3acd
+replace github.com/newrelic/newrelic-client-go/v2 => github.com/newrelic/newrelic-client-go/v2 v2.42.1-0.20240807084013-dc7b566b12a7
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/newrelic/terraform-provider-newrelic/v2
 
 go 1.21
 
+replace github.com/newrelic/newrelic-client-go/v2 => github.com/newrelic/newrelic-client-go/v2 v2.41.4-0.20240807081127-b43497bd3acd
+
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.42.1-0.20240807095203-278e54660b2b h1:ZbjRs/P9pBn2fOynVKv/BU8Rd2BHPsg6XYvpgQls3HE=
-github.com/newrelic/newrelic-client-go/v2 v2.42.1-0.20240807095203-278e54660b2b/go.mod h1:pDFY24/6iIMEbPIdowTRrRn9YYwkXc3j+B+XpTb4oF4=
+github.com/newrelic/newrelic-client-go/v2 v2.42.1 h1:IztJJ2coZaU87y1MZfKueGO/setV/zIYC5Yamg7Mxi0=
+github.com/newrelic/newrelic-client-go/v2 v2.42.1/go.mod h1:pDFY24/6iIMEbPIdowTRrRn9YYwkXc3j+B+XpTb4oF4=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.42.0 h1:XWZWKF9bjYG8TXuBNwNosG+QnZaltnJahgsfcQxvdDo=
-github.com/newrelic/newrelic-client-go/v2 v2.42.0/go.mod h1:pDFY24/6iIMEbPIdowTRrRn9YYwkXc3j+B+XpTb4oF4=
+github.com/newrelic/newrelic-client-go/v2 v2.41.4-0.20240807081127-b43497bd3acd h1:5OFY7g+lQqMv1Ly4BxNfUsM8SEpB7CWGAErzU06Dasg=
+github.com/newrelic/newrelic-client-go/v2 v2.41.4-0.20240807081127-b43497bd3acd/go.mod h1:pDFY24/6iIMEbPIdowTRrRn9YYwkXc3j+B+XpTb4oF4=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.41.4-0.20240807081127-b43497bd3acd h1:5OFY7g+lQqMv1Ly4BxNfUsM8SEpB7CWGAErzU06Dasg=
-github.com/newrelic/newrelic-client-go/v2 v2.41.4-0.20240807081127-b43497bd3acd/go.mod h1:pDFY24/6iIMEbPIdowTRrRn9YYwkXc3j+B+XpTb4oF4=
+github.com/newrelic/newrelic-client-go/v2 v2.42.1-0.20240807084013-dc7b566b12a7 h1:G9BYabGz6eGedSu009U8bA8j3oHP0C4QFtgazJqu2C8=
+github.com/newrelic/newrelic-client-go/v2 v2.42.1-0.20240807084013-dc7b566b12a7/go.mod h1:pDFY24/6iIMEbPIdowTRrRn9YYwkXc3j+B+XpTb4oF4=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.42.1-0.20240807084013-dc7b566b12a7 h1:G9BYabGz6eGedSu009U8bA8j3oHP0C4QFtgazJqu2C8=
-github.com/newrelic/newrelic-client-go/v2 v2.42.1-0.20240807084013-dc7b566b12a7/go.mod h1:pDFY24/6iIMEbPIdowTRrRn9YYwkXc3j+B+XpTb4oF4=
+github.com/newrelic/newrelic-client-go/v2 v2.42.1-0.20240807095203-278e54660b2b h1:ZbjRs/P9pBn2fOynVKv/BU8Rd2BHPsg6XYvpgQls3HE=
+github.com/newrelic/newrelic-client-go/v2 v2.42.1-0.20240807095203-278e54660b2b/go.mod h1:pDFY24/6iIMEbPIdowTRrRn9YYwkXc3j+B+XpTb4oF4=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/newrelic/resource_newrelic_synthetics_monitor_test.go
+++ b/newrelic/resource_newrelic_synthetics_monitor_test.go
@@ -461,7 +461,7 @@ func TestSyntheticsSimpleBrowserMonitor_PeriodInMinutes(t *testing.T) {
 		AdvancedOptions: synthetics.SyntheticsSimpleBrowserMonitorAdvancedOptionsInput{
 			EnableScreenshotOnFailureAndScript: &tv,
 			ResponseValidationText:             "SUCCESS",
-			CustomHeaders: []synthetics.SyntheticsCustomHeaderInput{
+			CustomHeaders: &[]synthetics.SyntheticsCustomHeaderInput{
 				{
 					Name:  "Monitor",
 					Value: "Synthetics",

--- a/newrelic/structures_newrelic_synthetics_simple_browser_monitor.go
+++ b/newrelic/structures_newrelic_synthetics_simple_browser_monitor.go
@@ -17,9 +17,9 @@ func buildSyntheticsSimpleBrowserMonitor(d *schema.ResourceData) (synthetics.Syn
 		AdvancedOptions: synthetics.SyntheticsSimpleBrowserMonitorAdvancedOptionsInput{},
 	}
 
-	if v, ok := d.GetOk("custom_header"); ok {
-		simpleBrowserMonitorInput.AdvancedOptions.CustomHeaders = expandSyntheticsCustomHeaders(v.(*schema.Set).List())
-	}
+	//NR-296277 Initializing an empty slice of CustomHeader if no custom headers block is provided in TF config.
+	t := expandSyntheticsCustomHeaders(d.Get("custom_header").(*schema.Set).List())
+	simpleBrowserMonitorInput.AdvancedOptions.CustomHeaders = &t
 
 	if v, ok := d.GetOk("uri"); ok {
 		simpleBrowserMonitorInput.Uri = v.(string)
@@ -107,9 +107,9 @@ func buildSyntheticsSimpleBrowserMonitorUpdateStruct(d *schema.ResourceData) (sy
 		AdvancedOptions: synthetics.SyntheticsSimpleBrowserMonitorAdvancedOptionsInput{},
 	}
 
-	if v, ok := d.GetOk("custom_header"); ok {
-		simpleBrowserMonitorUpdateInput.AdvancedOptions.CustomHeaders = expandSyntheticsCustomHeaders(v.(*schema.Set).List())
-	}
+	//NR-296277 Initializing an empty slice of CustomHeader if no custom headers block is provided in TF config.
+	t := expandSyntheticsCustomHeaders(d.Get("custom_header").(*schema.Set).List())
+	simpleBrowserMonitorUpdateInput.AdvancedOptions.CustomHeaders = &t
 
 	if v, ok := d.GetOk("uri"); ok {
 		simpleBrowserMonitorUpdateInput.Uri = v.(string)

--- a/newrelic/structures_newrelic_synthetics_simple_browser_monitor.go
+++ b/newrelic/structures_newrelic_synthetics_simple_browser_monitor.go
@@ -17,7 +17,7 @@ func buildSyntheticsSimpleBrowserMonitor(d *schema.ResourceData) (synthetics.Syn
 		AdvancedOptions: synthetics.SyntheticsSimpleBrowserMonitorAdvancedOptionsInput{},
 	}
 
-	//NR-296277 Initializing an empty slice of CustomHeader if no custom headers block is provided in TF config.
+	//Initializing an empty slice of CustomHeader if no custom headers block is provided in TF config.
 	t := expandSyntheticsCustomHeaders(d.Get("custom_header").(*schema.Set).List())
 	simpleBrowserMonitorInput.AdvancedOptions.CustomHeaders = &t
 
@@ -107,7 +107,7 @@ func buildSyntheticsSimpleBrowserMonitorUpdateStruct(d *schema.ResourceData) (sy
 		AdvancedOptions: synthetics.SyntheticsSimpleBrowserMonitorAdvancedOptionsInput{},
 	}
 
-	//NR-296277 Initializing an empty slice of CustomHeader if no custom headers block is provided in TF config.
+	//Initializing an empty slice of CustomHeader if no custom headers block is provided in TF config.
 	t := expandSyntheticsCustomHeaders(d.Get("custom_header").(*schema.Set).List())
 	simpleBrowserMonitorUpdateInput.AdvancedOptions.CustomHeaders = &t
 

--- a/newrelic/structures_newrelic_synthetics_simple_monitor.go
+++ b/newrelic/structures_newrelic_synthetics_simple_monitor.go
@@ -15,7 +15,7 @@ func buildSyntheticsSimpleMonitor(d *schema.ResourceData) synthetics.SyntheticsC
 	simpleMonitorInput.Status = inputBase.Status
 	simpleMonitorInput.Tags = inputBase.Tags
 
-	//NR-297288 Initializing an empty slice of CustomHeader if no custom headers block is provided in TF config.
+	//Initializing an empty slice of CustomHeader if no custom headers block is provided in TF config.
 	t := expandSyntheticsCustomHeaders(d.Get("custom_header").(*schema.Set).List())
 	simpleMonitorInput.AdvancedOptions.CustomHeaders = &t
 
@@ -63,7 +63,7 @@ func buildSyntheticsSimpleMonitorUpdateStruct(d *schema.ResourceData) synthetics
 	simpleMonitorUpdateInput.Status = inputBase.Status
 	simpleMonitorUpdateInput.Tags = inputBase.Tags
 
-	//NR-297288 Initializing an empty slice of CustomHeader if no custom headers block is provided in TF config.
+	//Initializing an empty slice of CustomHeader if no custom headers block is provided in TF config.
 	t := expandSyntheticsCustomHeaders(d.Get("custom_header").(*schema.Set).List())
 	simpleMonitorUpdateInput.AdvancedOptions.CustomHeaders = &t
 

--- a/newrelic/structures_newrelic_synthetics_simple_monitor.go
+++ b/newrelic/structures_newrelic_synthetics_simple_monitor.go
@@ -15,9 +15,9 @@ func buildSyntheticsSimpleMonitor(d *schema.ResourceData) synthetics.SyntheticsC
 	simpleMonitorInput.Status = inputBase.Status
 	simpleMonitorInput.Tags = inputBase.Tags
 
-	if v, ok := d.GetOk("custom_header"); ok {
-		simpleMonitorInput.AdvancedOptions.CustomHeaders = expandSyntheticsCustomHeaders(v.(*schema.Set).List())
-	}
+	//NR-297288 Initializing an empty slice of CustomHeader if no custom headers block is provided in TF config.
+	t := expandSyntheticsCustomHeaders(d.Get("custom_header").(*schema.Set).List())
+	simpleMonitorInput.AdvancedOptions.CustomHeaders = &t
 
 	if v, ok := d.GetOk("uri"); ok {
 		simpleMonitorInput.Uri = v.(string)
@@ -63,9 +63,9 @@ func buildSyntheticsSimpleMonitorUpdateStruct(d *schema.ResourceData) synthetics
 	simpleMonitorUpdateInput.Status = inputBase.Status
 	simpleMonitorUpdateInput.Tags = inputBase.Tags
 
-	if v, ok := d.GetOk("custom_header"); ok {
-		simpleMonitorUpdateInput.AdvancedOptions.CustomHeaders = expandSyntheticsCustomHeaders(v.(*schema.Set).List())
-	}
+	//NR-297288 Initializing an empty slice of CustomHeader if no custom headers block is provided in TF config.
+	t := expandSyntheticsCustomHeaders(d.Get("custom_header").(*schema.Set).List())
+	simpleMonitorUpdateInput.AdvancedOptions.CustomHeaders = &t
 
 	if v, ok := d.GetOk("uri"); ok {
 		simpleMonitorUpdateInput.Uri = v.(string)


### PR DESCRIPTION
# Description
Added the capability to delete all custom headers for simple/browser synthetic monitors.
Jira: [NR-296277](https://new-relic.atlassian.net/browse/NR-296277)


Please include a summary of the change and which issue is fixed (if relevant).
- passing an empty slice  in custom header for create/update of synthetic monitor when no custom header is provided in the TF config file


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc



[NR-296277]: https://new-relic.atlassian.net/browse/NR-296277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ