### PR TITLE
fix(browseragent): changing cookiesEnabled field to pointer type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,14 +2,12 @@ module github.com/newrelic/terraform-provider-newrelic/v2
 
 go 1.21
 
-replace github.com/newrelic/newrelic-client-go/v2 => github.com/newrelic/newrelic-client-go/v2 v2.42.2-0.20240808135402-bee265ae0a0c
-
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.30.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.42.1
+	github.com/newrelic/newrelic-client-go/v2 v2.43.1
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 )

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/newrelic/terraform-provider-newrelic/v2
 
 go 1.21
 
+replace github.com/newrelic/newrelic-client-go/v2 => github.com/newrelic/newrelic-client-go/v2 v2.42.2-0.20240808135402-bee265ae0a0c
+
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.42.2-0.20240808135402-bee265ae0a0c h1:Da5v7BfgCvFUn6hLIb/7CGf1sFAOFYgkymwHI8krVKI=
-github.com/newrelic/newrelic-client-go/v2 v2.42.2-0.20240808135402-bee265ae0a0c/go.mod h1:pDFY24/6iIMEbPIdowTRrRn9YYwkXc3j+B+XpTb4oF4=
+github.com/newrelic/newrelic-client-go/v2 v2.43.1 h1:ewnyHowf77wq3Of5zlwq7NxY02vzHKENipc6et2y5AA=
+github.com/newrelic/newrelic-client-go/v2 v2.43.1/go.mod h1:pDFY24/6iIMEbPIdowTRrRn9YYwkXc3j+B+XpTb4oF4=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.42.1 h1:IztJJ2coZaU87y1MZfKueGO/setV/zIYC5Yamg7Mxi0=
-github.com/newrelic/newrelic-client-go/v2 v2.42.1/go.mod h1:pDFY24/6iIMEbPIdowTRrRn9YYwkXc3j+B+XpTb4oF4=
+github.com/newrelic/newrelic-client-go/v2 v2.42.2-0.20240808135402-bee265ae0a0c h1:Da5v7BfgCvFUn6hLIb/7CGf1sFAOFYgkymwHI8krVKI=
+github.com/newrelic/newrelic-client-go/v2 v2.42.2-0.20240808135402-bee265ae0a0c/go.mod h1:pDFY24/6iIMEbPIdowTRrRn9YYwkXc3j+B+XpTb4oF4=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/newrelic/resource_newrelic_agent_application_browser.go
+++ b/newrelic/resource_newrelic_agent_application_browser.go
@@ -82,8 +82,9 @@ func resourceNewRelicBrowserApplicationCreate(ctx context.Context, d *schema.Res
 
 	accountID := selectAccountID(providerConfig, d)
 	appName := d.Get("name").(string)
+	cookiesEnabled := d.Get("cookies_enabled").(bool)
 	settingsInput := agentapplications.AgentApplicationBrowserSettingsInput{
-		CookiesEnabled:            d.Get("cookies_enabled").(bool),
+		CookiesEnabled:            &cookiesEnabled,
 		DistributedTracingEnabled: d.Get("distributed_tracing_enabled").(bool),
 		LoaderType:                agentapplications.AgentApplicationBrowserLoader(strings.ToUpper(d.Get("loader_type").(string))),
 	}
@@ -157,13 +158,14 @@ func resourceNewRelicBrowserApplicationUpdate(ctx context.Context, d *schema.Res
 	providerConfig := meta.(*ProviderConfig)
 	client := providerConfig.NewClient
 
+	cookiesEnabled := d.Get("cookies_enabled").(bool)
 	settingsInput := agentapplications.AgentApplicationSettingsUpdateInput{
 		BrowserMonitoring: &agentapplications.AgentApplicationSettingsBrowserMonitoringInput{
 			DistributedTracing: &agentapplications.AgentApplicationSettingsBrowserDistributedTracingInput{
 				Enabled: d.Get("distributed_tracing_enabled").(bool),
 			},
 			Privacy: &agentapplications.AgentApplicationSettingsBrowserPrivacyInput{
-				CookiesEnabled: d.Get("cookies_enabled").(bool),
+				CookiesEnabled: &cookiesEnabled,
 			},
 		},
 	}


### PR DESCRIPTION
# Description

Currently, if user send the value for `cookiesEnabled` as false for browser agent, that is currently being ignored, and the default value of true is being used. Fixed it by changing the boolean field to a pointer. 
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [ ] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Step 1
- Step 2
- etc
