### PR TITLE
fix: get the linked account if already linked

### DIFF
--- a/newrelic/resource_newrelic_cloud_aws_govcloud_link_account.go
+++ b/newrelic/resource_newrelic_cloud_aws_govcloud_link_account.go
@@ -74,7 +74,7 @@ func resourceNewRelicAwsGovCloudLinkAccountCreate(ctx context.Context, d *schema
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	
+
 	if cloudLinkAccountPayload == nil {
 		return diag.FromErr(fmt.Errorf("[ERROR] cloudLinkAccountPayload was nil"))
 	}

--- a/newrelic/resource_newrelic_cloud_gcp_link_account.go
+++ b/newrelic/resource_newrelic_cloud_gcp_link_account.go
@@ -47,6 +47,8 @@ func resourceNewRelicCloudGcpLinkAccountCreate(ctx context.Context, d *schema.Re
 	providerConfig := meta.(*ProviderConfig)
 	client := providerConfig.NewClient
 	accountID := selectAccountID(providerConfig, d)
+	provider := d.Get("cloud_provider").(string)
+	name := d.Get("name").(string)
 
 	linkAccountInput := expandGcpCloudLinkAccountInput(d)
 
@@ -66,10 +68,37 @@ func resourceNewRelicCloudGcpLinkAccountCreate(ctx context.Context, d *schema.Re
 
 	if len(cloudLinkAccountPayload.Errors) > 0 {
 		for _, err := range cloudLinkAccountPayload.Errors {
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  err.Type + " " + err.Message,
-			})
+			if(string(err.Type) == "ERR_INVALID_DATA" && err.LinkedAccountId == 0) {
+				accounts, getLinkedAccountsErr := client.Cloud.GetLinkedAccounts(provider)
+				if(getLinkedAccountsErr != nil){
+					diags = append(diags, diag.Diagnostic{
+						Severity: diag.Error,
+						Summary:  err.Type + " " + err.Message + " " + getLinkedAccountsErr.Error(),
+					})
+				}
+
+				var account *cloud.CloudLinkedAccount
+
+				for _, a := range *accounts {
+					if a.NrAccountId == accountID && strings.EqualFold(a.Name, name) {
+						account = &a
+						break
+					}
+				}
+			
+				if account == nil {
+					return diag.FromErr(fmt.Errorf("the name '%s' does not match any account for provider '%s", name, provider))
+				}
+
+				d.SetId(strconv.Itoa(account.ID))
+			} else if(err.LinkedAccountId != 0) {
+				d.SetId(strconv.Itoa(err.LinkedAccountId))
+			} else {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Error,
+					Summary:  err.Type + " " + err.Message,
+				})
+			}
 		}
 	}
 

--- a/newrelic/resource_newrelic_cloud_gcp_link_account.go
+++ b/newrelic/resource_newrelic_cloud_gcp_link_account.go
@@ -68,9 +68,9 @@ func resourceNewRelicCloudGcpLinkAccountCreate(ctx context.Context, d *schema.Re
 
 	if len(cloudLinkAccountPayload.Errors) > 0 {
 		for _, err := range cloudLinkAccountPayload.Errors {
-			if(string(err.Type) == "ERR_INVALID_DATA" && err.LinkedAccountId == 0) {
+			if string(err.Type) == "ERR_INVALID_DATA" && err.LinkedAccountId == 0 {
 				accounts, getLinkedAccountsErr := client.Cloud.GetLinkedAccounts(provider)
-				if(getLinkedAccountsErr != nil){
+				if getLinkedAccountsErr != nil {
 					diags = append(diags, diag.Diagnostic{
 						Severity: diag.Error,
 						Summary:  err.Type + " " + err.Message + " " + getLinkedAccountsErr.Error(),
@@ -85,13 +85,13 @@ func resourceNewRelicCloudGcpLinkAccountCreate(ctx context.Context, d *schema.Re
 						break
 					}
 				}
-			
+
 				if account == nil {
 					return diag.FromErr(fmt.Errorf("the name '%s' does not match any account for provider '%s", name, provider))
 				}
 
 				d.SetId(strconv.Itoa(account.ID))
-			} else if(err.LinkedAccountId != 0) {
+			} else if err.LinkedAccountId != 0 {
 				d.SetId(strconv.Itoa(err.LinkedAccountId))
 			} else {
 				diags = append(diags, diag.Diagnostic{


### PR DESCRIPTION
# Description

This is my first time working on a "Go" project, terraform provider, and the new relic api.  Please review my work and feel free to improve it and/or suggest improvements from me.

Uses `client.Cloud.GetLinkedAccounts` to get the _already_ linked account if `ERR_INVALID_DATA` is the response from `client.Cloud.CloudLinkAccountWithContext`.  

```HCL
resource "newrelic_cloud_gcp_link_account" "example" {
  account_id      = var.nr_account_id
  project_id      = var.project_id
  name            = "chmoder"
}

resource "newrelic_cloud_gcp_integrations" "example" {
  account_id        = var.nr_account_id
  linked_account_id = newrelic_cloud_gcp_link_account.example.id
}
```

Fixes #2733

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Step 1

Try to link an already linked account using `newrelic_cloud_gcp_link_account` and reference the output `id` field in another resource.

