### PR TITLE
fix(dashboard):  changing legend_enabled/legend field to pointer type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.30.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.43.1
+	github.com/newrelic/newrelic-client-go/v2 v2.43.2
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 )

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.43.1 h1:ewnyHowf77wq3Of5zlwq7NxY02vzHKENipc6et2y5AA=
-github.com/newrelic/newrelic-client-go/v2 v2.43.1/go.mod h1:pDFY24/6iIMEbPIdowTRrRn9YYwkXc3j+B+XpTb4oF4=
+github.com/newrelic/newrelic-client-go/v2 v2.43.2 h1:tWcXYxz1oO63kEWoGtiMXGKJ03VyW+l0UJKwOnMAyyU=
+github.com/newrelic/newrelic-client-go/v2 v2.43.2/go.mod h1:pDFY24/6iIMEbPIdowTRrRn9YYwkXc3j+B+XpTb4oF4=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/newrelic/structures_newrelic_one_dashboard.go
+++ b/newrelic/structures_newrelic_one_dashboard.go
@@ -619,7 +619,8 @@ func expandDashboardWidgetInput(w map[string]interface{}, meta interface{}, visu
 
 	if q, ok := w["legend_enabled"]; ok {
 		var l dashboards.DashboardWidgetLegend
-		l.Enabled = q.(bool)
+		qBool, _ := q.(bool)
+		l.Enabled = &qBool
 		cfg.Legend = &l
 	}
 	if q, ok := w["facet_show_other_series"]; ok {


### PR DESCRIPTION
# Description
Currently, if user send the value for legend_enabled as false while creating dashboards, that is currently being ignored, and the default value of true is being used. Fixed it by changing the boolean field to a pointer.

refere to old pr for comments : https://github.com/newrelic/terraform-provider-newrelic/pull/2737 (closed due to branch naming mistake)

Fixes https://github.com/newrelic/terraform-provider-newrelic/issues/2736

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [ ] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Step 1
- Step 2
- etc
