### PR TITLE
fix(synthetics): allow new -> legacy runtime downgrade until Oct 22 for simple browser, scripted monitors

### DIFF
--- a/newrelic/structures_newrelic_synthetics_script_api_monitor.go
+++ b/newrelic/structures_newrelic_synthetics_script_api_monitor.go
@@ -27,9 +27,8 @@ func buildSyntheticsScriptAPIMonitorInput(d *schema.ResourceData) synthetics.Syn
 	_, runtimeTypeOk := d.GetOk("runtime_type")
 	_, runtimeVersionOk := d.GetOk("runtime_type_version")
 
+	input.Runtime = &synthetics.SyntheticsRuntimeInput{}
 	if scriptLangOk || runtimeTypeOk || runtimeVersionOk {
-		input.Runtime = &synthetics.SyntheticsRuntimeInput{}
-
 		if v, ok := d.GetOk("script_language"); ok {
 			input.Runtime.ScriptLanguage = v.(string)
 		}
@@ -39,6 +38,9 @@ func buildSyntheticsScriptAPIMonitorInput(d *schema.ResourceData) synthetics.Syn
 		if v, ok := d.GetOk("runtime_type_version"); ok {
 			input.Runtime.RuntimeTypeVersion = synthetics.SemVer(v.(string))
 		}
+	} else {
+		input.Runtime.RuntimeType = ""
+		input.Runtime.RuntimeTypeVersion = ""
 	}
 
 	return input
@@ -66,9 +68,8 @@ func buildSyntheticsScriptAPIMonitorUpdateInput(d *schema.ResourceData) syntheti
 	_, runtimeTypeOk := d.GetOk("runtime_type")
 	_, runtimeVersionOk := d.GetOk("runtime_type_version")
 
+	input.Runtime = &synthetics.SyntheticsRuntimeInput{}
 	if scriptLangOk || runtimeTypeOk || runtimeVersionOk {
-		input.Runtime = &synthetics.SyntheticsRuntimeInput{}
-
 		if v, ok := d.GetOk("script_language"); ok {
 			input.Runtime.ScriptLanguage = v.(string)
 		}
@@ -78,6 +79,9 @@ func buildSyntheticsScriptAPIMonitorUpdateInput(d *schema.ResourceData) syntheti
 		if v, ok := d.GetOk("runtime_type_version"); ok {
 			input.Runtime.RuntimeTypeVersion = synthetics.SemVer(v.(string))
 		}
+	} else {
+		input.Runtime.RuntimeType = ""
+		input.Runtime.RuntimeTypeVersion = ""
 	}
 
 	return input

--- a/newrelic/structures_newrelic_synthetics_script_browser_monitor.go
+++ b/newrelic/structures_newrelic_synthetics_script_browser_monitor.go
@@ -29,9 +29,8 @@ func buildSyntheticsScriptBrowserMonitorInput(d *schema.ResourceData) synthetics
 	runtimeType, runtimeTypeOk := d.GetOk("runtime_type")
 	runtimeTypeVersion, runtimeTypeVersionOk := d.GetOk("runtime_type_version")
 
+	input.Runtime = &synthetics.SyntheticsRuntimeInput{}
 	if scriptLangOk || runtimeTypeOk || runtimeTypeVersionOk {
-		input.Runtime = &synthetics.SyntheticsRuntimeInput{}
-
 		if scriptLangOk {
 			input.Runtime.ScriptLanguage = sciptLang.(string)
 		}
@@ -43,6 +42,9 @@ func buildSyntheticsScriptBrowserMonitorInput(d *schema.ResourceData) synthetics
 		if runtimeTypeVersionOk {
 			input.Runtime.RuntimeTypeVersion = synthetics.SemVer(runtimeTypeVersion.(string))
 		}
+	} else {
+		input.Runtime.RuntimeType = ""
+		input.Runtime.RuntimeTypeVersion = ""
 	}
 
 	enableScreenshot := d.Get("enable_screenshot_on_failure_and_script").(bool)
@@ -90,9 +92,8 @@ func buildSyntheticsScriptBrowserUpdateInput(d *schema.ResourceData) synthetics.
 	sciptLang, scriptLangOk := d.GetOk("script_language")
 	runtimeType, runtimeTypeOk := d.GetOk("runtime_type")
 	runtimeTypeVersion, runtimeTypeVersionOk := d.GetOk("runtime_type_version")
+	input.Runtime = &synthetics.SyntheticsRuntimeInput{}
 	if scriptLangOk || runtimeTypeOk || runtimeTypeVersionOk {
-		input.Runtime = &synthetics.SyntheticsRuntimeInput{}
-
 		if scriptLangOk {
 			input.Runtime.ScriptLanguage = sciptLang.(string)
 		}
@@ -104,6 +105,9 @@ func buildSyntheticsScriptBrowserUpdateInput(d *schema.ResourceData) synthetics.
 		if runtimeTypeVersionOk {
 			input.Runtime.RuntimeTypeVersion = synthetics.SemVer(runtimeTypeVersion.(string))
 		}
+	} else {
+		input.Runtime.RuntimeType = ""
+		input.Runtime.RuntimeTypeVersion = ""
 	}
 
 	enableScreenshot := d.Get("enable_screenshot_on_failure_and_script").(bool)

--- a/newrelic/structures_newrelic_synthetics_simple_browser_monitor.go
+++ b/newrelic/structures_newrelic_synthetics_simple_browser_monitor.go
@@ -152,8 +152,8 @@ func buildSyntheticsSimpleBrowserMonitorRuntimeAndDeviceEmulationUpdateStruct(d 
 	runtimeType, runtimeTypeOk := d.GetOk("runtime_type")
 	runtimeTypeVersion, runtimeTypeVersionOk := d.GetOk("runtime_type_version")
 
-	simpleBrowserMonitorUpdateInput.Runtime = &synthetics.SyntheticsRuntimeInput{}
 	if scriptLangOk || runtimeTypeOk || runtimeTypeVersionOk {
+		simpleBrowserMonitorUpdateInput.Runtime = &synthetics.SyntheticsRuntimeInput{}
 		if scriptLangOk {
 			simpleBrowserMonitorUpdateInput.Runtime.ScriptLanguage = scriptLang.(string)
 		}
@@ -165,9 +165,6 @@ func buildSyntheticsSimpleBrowserMonitorRuntimeAndDeviceEmulationUpdateStruct(d 
 		if runtimeTypeVersionOk {
 			simpleBrowserMonitorUpdateInput.Runtime.RuntimeTypeVersion = synthetics.SemVer(runtimeTypeVersion.(string))
 		}
-	} else {
-		simpleBrowserMonitorUpdateInput.Runtime.RuntimeType = ""
-		simpleBrowserMonitorUpdateInput.Runtime.RuntimeTypeVersion = ""
 	}
 
 	do, doOk := d.GetOk("device_orientation")

--- a/newrelic/structures_newrelic_synthetics_simple_browser_monitor.go
+++ b/newrelic/structures_newrelic_synthetics_simple_browser_monitor.go
@@ -154,6 +154,7 @@ func buildSyntheticsSimpleBrowserMonitorRuntimeAndDeviceEmulationUpdateStruct(d 
 
 	if scriptLangOk || runtimeTypeOk || runtimeTypeVersionOk {
 		simpleBrowserMonitorUpdateInput.Runtime = &synthetics.SyntheticsRuntimeInput{}
+
 		if scriptLangOk {
 			simpleBrowserMonitorUpdateInput.Runtime.ScriptLanguage = scriptLang.(string)
 		}

--- a/newrelic/structures_newrelic_synthetics_simple_browser_monitor.go
+++ b/newrelic/structures_newrelic_synthetics_simple_browser_monitor.go
@@ -60,9 +60,8 @@ func buildSyntheticsSimpleBrowserMonitorRuntimeAndDeviceEmulation(d *schema.Reso
 	runtimeType, runtimeTypeOk := d.GetOk("runtime_type")
 	runtimeTypeVersion, runtimeTypeVersionOk := d.GetOk("runtime_type_version")
 
+	simpleBrowserMonitorInput.Runtime = &synthetics.SyntheticsRuntimeInput{}
 	if scriptLangOk || runtimeTypeOk || runtimeTypeVersionOk {
-		simpleBrowserMonitorInput.Runtime = &synthetics.SyntheticsRuntimeInput{}
-
 		if scriptLangOk {
 			simpleBrowserMonitorInput.Runtime.ScriptLanguage = scriptLang.(string)
 		}
@@ -74,6 +73,9 @@ func buildSyntheticsSimpleBrowserMonitorRuntimeAndDeviceEmulation(d *schema.Reso
 		if runtimeTypeVersionOk {
 			simpleBrowserMonitorInput.Runtime.RuntimeTypeVersion = synthetics.SemVer(runtimeTypeVersion.(string))
 		}
+	} else {
+		simpleBrowserMonitorInput.Runtime.RuntimeType = ""
+		simpleBrowserMonitorInput.Runtime.RuntimeTypeVersion = ""
 	}
 
 	do, doOk := d.GetOk("device_orientation")
@@ -150,9 +152,8 @@ func buildSyntheticsSimpleBrowserMonitorRuntimeAndDeviceEmulationUpdateStruct(d 
 	runtimeType, runtimeTypeOk := d.GetOk("runtime_type")
 	runtimeTypeVersion, runtimeTypeVersionOk := d.GetOk("runtime_type_version")
 
+	simpleBrowserMonitorUpdateInput.Runtime = &synthetics.SyntheticsRuntimeInput{}
 	if scriptLangOk || runtimeTypeOk || runtimeTypeVersionOk {
-		simpleBrowserMonitorUpdateInput.Runtime = &synthetics.SyntheticsRuntimeInput{}
-
 		if scriptLangOk {
 			simpleBrowserMonitorUpdateInput.Runtime.ScriptLanguage = scriptLang.(string)
 		}
@@ -164,6 +165,9 @@ func buildSyntheticsSimpleBrowserMonitorRuntimeAndDeviceEmulationUpdateStruct(d 
 		if runtimeTypeVersionOk {
 			simpleBrowserMonitorUpdateInput.Runtime.RuntimeTypeVersion = synthetics.SemVer(runtimeTypeVersion.(string))
 		}
+	} else {
+		simpleBrowserMonitorUpdateInput.Runtime.RuntimeType = ""
+		simpleBrowserMonitorUpdateInput.Runtime.RuntimeTypeVersion = ""
 	}
 
 	do, doOk := d.GetOk("device_orientation")


### PR DESCRIPTION
The "update" functions of resources which deal in Simple Browser, Scripted Browser and Scripted API monitors in our Terraform Provider do not seem to default to an empty runtime, if no runtime attributes are specified in the configuration, or if they are empty strings. This would cause customers to not be able to downgrade monitors from the new runtime to the legacy runtime (though this is not encouraged, given the context around the Legacy Runtime EOL, customers should be able to do this until the final EOL for new and existing monitors on October 22, 2024; hence this change).

This PR includes a tiny change for update functions to default `runtimeType` and `runtimeTypeVersion` to default to empty strings, if runtime attributes are absent in the configuration, or if they have empty strings as values in the configuration. This would allow the request sent to NerdGraph to pick these attributes up with values as empty strings, as [these attributes do not have an `omitempty` against them in the datatype in Go Client](https://github.com/newrelic/newrelic-client-go/blob/ad6a16dea269ab26a057aab1d8b2c5e87e80d0e3/pkg/synthetics/types.go#L1367-L1374) (since they're mandatory on NerdGraph if the parent field `runtime` is specified).

It may be noted that changes have only been made to
- Scripted Browser
- Scripted API

monitors, and not to
- Broken Links
- Cert Check
- Step

monitors, as they already handle this scenario 

https://github.com/newrelic/terraform-provider-newrelic/blob/2a29b5bf5fca2e67f36ad3d6ce937f4732ef9ae0/newrelic/resource_newrelic_synthetics_cert_check_monitor.go#L395-L398

https://github.com/newrelic/terraform-provider-newrelic/blob/d415d1d057a86efc030245674ff508e4dedc32c9/newrelic/structures_newrelic_synthetics_broken_links_monitor.go#L83-L86

https://github.com/newrelic/terraform-provider-newrelic/blob/d415d1d057a86efc030245674ff508e4dedc32c9/newrelic/structures_newrelic_synthetics_step_monitor.go#L92-L95

and also not to the Simple Browser Monitor, owing to a glitch (see the first resolved comment for more).

