### PR TITLE
fix(key transaction): Migrate key transaction data source from Rest api to NerdGraph

### DIFF
--- a/newrelic/data_source_newrelic_key_transaction.go
+++ b/newrelic/data_source_newrelic_key_transaction.go
@@ -65,7 +65,7 @@ func dataSourceNewRelicKeyTransactionRead(ctx context.Context, d *schema.Resourc
 	}
 
 	if transaction == nil || len(transaction.Results.Entities) == 0 {
-		return diag.FromErr(fmt.Errorf("the name '%s' does not match any New Relic key transaction", name))
+		return diag.FromErr(fmt.Errorf("no key transaction that matches the specified parameters is found in New Relic"))
 	}
 
 	flattenKeyTransaction(transaction, d)

--- a/newrelic/data_source_newrelic_key_transaction.go
+++ b/newrelic/data_source_newrelic_key_transaction.go
@@ -24,7 +24,7 @@ func dataSourceNewRelicKeyTransaction() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				Description: "guid of the key transaction in New Relic.",
+				Description: "GUID of the key transaction in New Relic.",
 			},
 			"domain": {
 				Type:        schema.TypeString,
@@ -59,16 +59,16 @@ func dataSourceNewRelicKeyTransactionRead(ctx context.Context, d *schema.Resourc
 		query = fmt.Sprintf("%s AND id = '%s'", query, guid)
 	}
 
-	transaction, err := client.Entities.GetEntitySearchByQueryWithContext(ctx, entities.EntitySearchOptions{}, query, []entities.EntitySearchSortCriteria{})
+	keyTransactionsFound, err := client.Entities.GetEntitySearchByQueryWithContext(ctx, entities.EntitySearchOptions{}, query, []entities.EntitySearchSortCriteria{})
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	if transaction == nil || len(transaction.Results.Entities) == 0 {
+	if keyTransactionsFound == nil || len(keyTransactionsFound.Results.Entities) == 0 {
 		return diag.FromErr(fmt.Errorf("no key transaction that matches the specified parameters is found in New Relic"))
 	}
 
-	flattenKeyTransaction(transaction, d)
+	flattenKeyTransaction(keyTransactionsFound, d)
 
 	return nil
 }

--- a/website/docs/d/key_transaction.html.markdown
+++ b/website/docs/d/key_transaction.html.markdown
@@ -45,12 +45,20 @@ resource "newrelic_alert_condition" "foo" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the key transaction in New Relic.
+* `guid` - (Optional) GUID of the key transaction in New Relic.
+
+## Note
+If two or more key transactions have the same name, the datasource fetch only one key transaction. To differentiate between them, use the GUID of the key transaction.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the application.
+* `guid` - GUID of the key transaction in New Relic.
+* `domain` - Domain of the key transaction in New Relic.
+* `type` - Type of the key transaction in New Relic.
+* `name` - Name of the key Transation in New Relic.
 
 ```
 Warning: This data source will use the account ID linked to your API key. At the moment it is not possible to dynamically set the account ID.

--- a/website/docs/d/key_transaction.html.markdown
+++ b/website/docs/d/key_transaction.html.markdown
@@ -47,8 +47,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the key transaction in New Relic.
 * `guid` - (Optional) GUID of the key transaction in New Relic.
 
-## Note
-If two or more key transactions have the same name, the datasource fetch only one key transaction. To differentiate between them, use the GUID of the key transaction.
+-> **NOTE** If the `name` specified in the configuration matches the names of multiple key transaction in the account, the data source will return the first match from the list of all matching key transaction retrieved from the API. However, when using the `guid` argument as the search criterion, only the key transaction with that particular guid is returned, as each key transaction has a unique guid.
 
 ## Attributes Reference
 

--- a/website/docs/d/key_transaction.html.markdown
+++ b/website/docs/d/key_transaction.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the key transaction in New Relic.
 * `guid` - (Optional) GUID of the key transaction in New Relic.
 
--> **NOTE** If the `name` specified in the configuration matches the names of multiple key transaction in the account, the data source will return the first match from the list of all matching key transaction retrieved from the API. However, when using the `guid` argument as the search criterion, only the key transaction with that particular guid is returned, as each key transaction has a unique guid.
+-> **NOTE** If the `name` specified in the configuration matches the names of multiple key transactions in the account, the data source will return the first match from the list of all matching key transactions retrieved from the API. However, when using the `guid` argument as the search criterion, only the key transaction with that particular GUID is returned, as each key transaction has a unique GUID.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Updated the key transaction data source to migrate from lagacy Rest Api to NerdGraph Api.
Added some featured as part of the update
* Added additional capability of filtering of the key transaction on the basis of guid id multiple key transaction have same same. 



Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

* add newrelic_key_transaction data block in Config file
* perform terraform apply
* key transaction details should be visible in the state file
