### PR TITLE
Add support for metric filters

### DIFF
--- a/examples/modules/cloud-integrations/aws/main.tf
+++ b/examples/modules/cloud-integrations/aws/main.tf
@@ -191,6 +191,24 @@ resource "aws_cloudwatch_metric_stream" "newrelic_metric_stream" {
   role_arn      = aws_iam_role.metric_stream_to_firehose.arn
   firehose_arn  = aws_kinesis_firehose_delivery_stream.newrelic_firehose_stream.arn
   output_format = "opentelemetry0.7"
+
+  dynamic "exclude_filter" {
+    for_each = var.exclude_metric_filters
+
+    content {
+      namespace    = exclude_filter.key
+      metric_names = exclude_filter.value
+    }
+  }
+
+  dynamic "include_filter" {
+    for_each = var.include_metric_filters
+
+    content {
+      namespace    = include_filter.key
+      metric_names = include_filter.value
+    }
+  }
 }
 
 resource "newrelic_cloud_aws_link_account" "newrelic_cloud_integration_pull" {

--- a/examples/modules/cloud-integrations/aws/variables.tf
+++ b/examples/modules/cloud-integrations/aws/variables.tf
@@ -16,3 +16,15 @@ variable "name" {
   type    = string
   default = "production"
 }
+
+variable "exclude_metric_filters" {
+  description = "Map of exclusive metric filters. Use the namespace as the key and the list of metric names as the value."
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "include_metric_filters" {
+  description = "Map of inclusive metric filters. Use the namespace as the key and the list of metric names as the value."
+  type        = map(list(string))
+  default     = {}
+}

--- a/website/docs/guides/cloud_integrations_guide.html.markdown
+++ b/website/docs/guides/cloud_integrations_guide.html.markdown
@@ -60,6 +60,11 @@ module "newrelic-aws-cloud-integrations" {
   newrelic_account_id     = 1234567
   newrelic_account_region = "US"
   name                    = "production"
+
+  include_metric_filters = {
+    "AWS/EC2" = [], # include ALL metrics from the EC2 namespace
+    "AWS/S3" = ["NumberOfObjects"]. # include just a specific metric from the S3 namespace
+  }
 }
 ```
 
@@ -68,10 +73,11 @@ module "newrelic-aws-cloud-integrations" {
 
 Variables:
 
-* newrelic_account_id: The New Relic account you want to link to AWS. This account will receive all the data observability from your AWS environment.
-* newrelic_account_region: The region of your New Relic account, this can be `US` for United States or `EU` for Europe. (Default `US`)
-* name: A unique name used throughout the module to name the resources.
-
+* `newrelic_account_id`: The New Relic account you want to link to AWS. This account will receive all the data observability from your AWS environment.
+* `newrelic_account_region` (Optional): The region of your New Relic account, this can be `US` for United States or `EU` for Europe. (Default `US`)
+* `name` (Optional): A unique name used throughout the module to name the resources. (Default `production`)
+* `exclude_metric_filters` (Optional): a map of namespaces and metric names to exclude from the Cloudwatch metric stream. `Conflicts with include_metric_filters`.
+* `include_metric_filters` (Optional): a map of namespaces and metric names to include in the Cloudwatch metric stream. `Conflicts with exclude_metric_filters`.
 
 ### Azure
 


### PR DESCRIPTION
# Description

Adds support for inclusive and exclusive metric filters

Fixes #2765

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update required

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have performed a self-review of my own code
- [x] I have updated the documentation

## How to test this change?

Add the module using my fork and see what happens

```terraform
module "newrelic" {
  source = "github.com/sjauld/terraform-provider-newrelic//examples/modules/cloud-integrations/aws"

  newrelic_account_id     = "<your account ID>"
  newrelic_account_region = "<your region>"
  name                    = "a prefix for your resources"

  include_metric_filters = {
    "AWS/EC2"    = []
    "AWS/ECS"    = []
    "AWS/Lambda" = []
    "AWS/RDS"    = []
  }
}
```
