### PR TITLE
feat(resource-import-script): script to automate import of existing users into groups as terraform resource 

### DIFF
--- a/examples/script/main.go
+++ b/examples/script/main.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/machinebox/graphql"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/usermanagement"
+	"golang.org/x/exp/maps"
+)
+
+type authenticationDomainsResponse struct {
+	Actor usermanagement.Actor `json:"actor"`
+}
+
+type ResourceUser struct {
+	id                       string
+	name                     string
+	email_id                 string
+	authentication_domain_id string
+	user_type                string
+}
+
+type ResourceGroup struct {
+	id                       string
+	name                     string
+	authentication_domain_id string
+	user_ids                 []string
+}
+
+var userTier = map[string]string{
+	"Basic":         "BASIC_USER_TIER",
+	"Core":          "CORE_USER_TIER",
+	"Full platform": "FULL_USER_TIER",
+}
+
+func main() {
+
+	args := os.Args
+
+	client := graphql.NewClient("https://api.newrelic.com/graphql")
+	queryData(client, args[1], args[2], args[3])
+
+}
+
+// *UserManagementAuthenticationDomains
+func queryData(client *graphql.Client, groupId string, apiKey string, path string) {
+
+	query := `
+	query(
+		$groupId: [ID!]
+	){
+		actor {
+			organization {
+				userManagement {
+					authenticationDomains {
+					nextCursor
+						authenticationDomains {
+							name
+							id
+							groups(id: $groupId) {
+								groups {
+									id
+									displayName
+									users {
+										users {
+											email
+											id
+											name
+											timeZone
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	`
+
+	request := graphql.NewRequest(query)
+	request.Var("groupId", groupId)
+	request.Header.Set("Api-Key", apiKey)
+
+	response := authenticationDomainsResponse{}
+	err := client.Run(context.Background(), request, &response)
+	if err != nil {
+		panic(err)
+	}
+
+	var resourceGroup ResourceGroup
+	var resourceUserById map[string]ResourceUser = make(map[string]ResourceUser)
+
+	if len(response.Actor.Organization.UserManagement.AuthenticationDomains.AuthenticationDomains) > 0 {
+
+		authDomains := response.Actor.Organization.UserManagement.AuthenticationDomains.AuthenticationDomains
+
+		for _, authDomain := range authDomains {
+			if len(authDomain.Groups.Groups) > 0 {
+				for _, group := range authDomain.Groups.Groups {
+
+					// Create Resource Group
+					resourceGroup.id = group.ID
+					resourceGroup.name = group.DisplayName
+					resourceGroup.authentication_domain_id = authDomain.ID
+
+					for _, user := range group.Users.Users {
+
+						var resourceUser ResourceUser
+						resourceUser.id = user.ID
+						resourceUser.name = user.Name
+						resourceUser.email_id = user.Email
+						resourceUser.authentication_domain_id = authDomain.ID
+
+						resourceUserById[user.ID] = resourceUser
+						resourceGroup.user_ids = append(resourceGroup.user_ids, user.ID)
+
+					}
+
+				}
+			}
+		}
+
+	}
+
+	query = `query(
+		$userId: [ID!]
+	){
+		actor {
+			organization {
+				userManagement {
+					authenticationDomains {
+						nextCursor
+						authenticationDomains {
+							name
+							id
+							users(id: $userId) {
+								users {
+									email
+									id
+									name
+									type {
+										displayName
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}`
+
+	request = graphql.NewRequest(query)
+	request.Var("userId", maps.Keys(resourceUserById))
+	request.Header.Set("Api-Key", apiKey)
+
+	response = authenticationDomainsResponse{}
+	err = client.Run(context.Background(), request, &response)
+	if err != nil {
+		panic(err)
+	}
+
+	if len(response.Actor.Organization.UserManagement.AuthenticationDomains.AuthenticationDomains) > 0 {
+
+		authDomains := response.Actor.Organization.UserManagement.AuthenticationDomains.AuthenticationDomains
+
+		for _, authDomain := range authDomains {
+
+			if len(authDomain.Users.Users) > 0 {
+				for _, user := range authDomain.Users.Users {
+
+					val, ok := resourceUserById[user.ID]
+					if ok {
+						val.user_type = userTier[user.Type.DisplayName]
+						resourceUserById[user.ID] = val
+					}
+
+				}
+			}
+		}
+
+	}
+
+	var fileContent string
+
+	str := `resource "newrelic_group" "%s" {
+			name                     = "%s"
+			authentication_domain_id = "%s"
+			user_ids                 = %s
+		}`
+
+	var userIdList string = "["
+
+	resourceName := resourceGroup.name
+	resourceName = strings.ReplaceAll(resourceName, " ", "-")
+
+	importCommand := "terraform import newrelic_group." + resourceName + " " + resourceGroup.id + " && "
+
+	for _, user := range resourceUserById {
+
+		str := `resource "newrelic_user" "%s" {
+				name                     = "%s"
+				email_id                 = "%s"
+				authentication_domain_id = "%s"
+				user_type = "%s"
+			}`
+
+		importCommand += "terraform import newrelic_user." + user.name + " " + user.id + " && "
+
+		userIdList += ("newrelic_user." + user.name + ".id,")
+
+		resourceName := user.name
+		resourceName = strings.ReplaceAll(resourceName, " ", "-")
+
+		fileContent += fmt.Sprintf(str, resourceName, user.name, user.email_id, user.authentication_domain_id, user.user_type)
+		fileContent += "\n\n"
+
+	}
+
+	importCommand = importCommand[:len(importCommand)-4]
+
+	userIdList = userIdList[:len(userIdList)-1]
+	userIdList += "]"
+
+	fileContent += fmt.Sprintf(str, resourceName, resourceGroup.name, resourceGroup.authentication_domain_id, userIdList)
+	fileContent += "\n\n"
+
+	createTerraformFile(fileContent, path)
+
+	importTerraformResource(importCommand, path)
+
+}
+
+func createTerraformFile(content string, path string) {
+
+	file, err := os.Create("../../" + path + "/generated.tf")
+	if err != nil {
+		fmt.Println("Error while creating file: ", err)
+		return
+	}
+
+	defer file.Close()
+
+	_, err = io.WriteString(file, content)
+	if err != nil {
+		fmt.Println("Error while writing file: ", err)
+		return
+	}
+
+}
+
+func importTerraformResource(command string, path string) {
+
+	cmd := exec.Command("bash", "-c", "cd ../.. && cd "+path+" && "+command)
+
+	// Run the command and capture output
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Printf("Error executing command: %s\n", err)
+		return
+	}
+
+	// Print the output of the command
+	fmt.Printf("Output:\n%s\n", output)
+}

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
+	github.com/machinebox/graphql v0.2.2 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
@@ -51,6 +52,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.0.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 // indirect

--- a/go.sum
+++ b/go.sum
@@ -227,6 +227,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
+github.com/machinebox/graphql v0.2.2 h1:dWKpJligYKhYKO5A2gvNhkJdQMNZeChZYyBbrZkBZfo=
+github.com/machinebox/graphql v0.2.2/go.mod h1:F+kbVMHuwrQ5tYgU9JXlnskM8nOaFxCAEolaQybkjWA=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/matoous/godox v0.0.0-20190911065817-5d6d842e92eb/go.mod h1:1BELzlh859Sh1c6+90blK8lbYy0kwQf1bYlBhBysy1s=
@@ -285,6 +287,7 @@ github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtP
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
# Description

This feature builds a Golang script that automates the importation of existing users into Terraform and their addition to specified groups. The script will streamline the process for customers who wish to transition from UI-based management to Terraform.

- The script retrieves existing users and groups using the NerdGraph API.
- The script will manage file operations necessary for generating and updating Terraform configuration files.
- The generated configuration will ensure that all imported users are correctly referenced in their respective group.
- The script automatically runs terraform import command to import the generated configuration.

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [ ] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

- go run main.go groupId apiKey path
