### PR TITLE
feat(alert_muting_rule): Add `action_on_muting_rule_window_ended` attribute in `newrelic_alert_muting_rule` Terraform Resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.22
 
 toolchain go1.22.6
 
+replace github.com/newrelic/newrelic-client-go/v2 => github.com/newrelic/newrelic-client-go/v2 v2.51.4-0.20241217120708-22dfc1bcd16c
+
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.51.3 h1:Bu/cUs6nfMjQMPBcxxHt4Xm30tKDT7ttYy/XRDsWP6Y=
-github.com/newrelic/newrelic-client-go/v2 v2.51.3/go.mod h1:+RRjI3nDGWT3kLm9Oi3QxpBm70uu8q1upEHBVWCZFpo=
+github.com/newrelic/newrelic-client-go/v2 v2.51.4-0.20241217120708-22dfc1bcd16c h1:U4xKoQkH6OJQqAXxD0eLHO6rzVcIS19fSIsI0DSdzXE=
+github.com/newrelic/newrelic-client-go/v2 v2.51.4-0.20241217120708-22dfc1bcd16c/go.mod h1:+RRjI3nDGWT3kLm9Oi3QxpBm70uu8q1upEHBVWCZFpo=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/newrelic/resource_newrelic_alert_muting_rule.go
+++ b/newrelic/resource_newrelic_alert_muting_rule.go
@@ -187,6 +187,7 @@ func resourceNewRelicAlertMutingRule() *schema.Resource {
 			"action_on_muting_rule_window_ended": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The action when the muting rule window is ended or disabled.",
 				ValidateFunc: validation.StringInSlice(
 					[]string{

--- a/newrelic/resource_newrelic_alert_muting_rule.go
+++ b/newrelic/resource_newrelic_alert_muting_rule.go
@@ -3,6 +3,7 @@ package newrelic
 import (
 	"context"
 	"fmt"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/alerts"
 	"log"
 	"regexp"
 	"time"
@@ -183,11 +184,17 @@ func resourceNewRelicAlertMutingRule() *schema.Resource {
 				Elem:        scheduleSchema(),
 				Description: "The time window when the MutingRule should actively mute incidents.",
 			},
-			"end_behaviour": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Description:  "The action when the muting rule window is ended or disabled.",
-				ValidateFunc: validation.StringInSlice([]string{"CLOSE_ISSUES_ON_INACTIVE", "DO_NOTHING"}, false),
+			"action_on_muting_rule_window_ended": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The action when the muting rule window is ended or disabled.",
+				ValidateFunc: validation.StringInSlice(
+					[]string{
+						string(alerts.AlertsActionOnMutingRuleWindowEndedTypes.CLOSE_ISSUES_ON_INACTIVE),
+						string(alerts.AlertsActionOnMutingRuleWindowEndedTypes.DO_NOTHING),
+					},
+					false,
+				),
 			},
 		},
 	}

--- a/newrelic/resource_newrelic_alert_muting_rule.go
+++ b/newrelic/resource_newrelic_alert_muting_rule.go
@@ -183,6 +183,12 @@ func resourceNewRelicAlertMutingRule() *schema.Resource {
 				Elem:        scheduleSchema(),
 				Description: "The time window when the MutingRule should actively mute incidents.",
 			},
+			"end_behaviour": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "The action when the muting rule window is ended or disabled.",
+				ValidateFunc: validation.StringInSlice([]string{"CLOSE_ISSUES_ON_INACTIVE", "DO_NOTHING"}, false),
+			},
 		},
 	}
 }

--- a/newrelic/resource_newrelic_alert_muting_rule_test.go
+++ b/newrelic/resource_newrelic_alert_muting_rule_test.go
@@ -78,14 +78,46 @@ func TestAccNewRelicAlertMutingRule_Basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test: Create
 			{
-				Config: testAccNewRelicAlertMutingRuleBasic(rName, "new muting rule", "product", "EQUALS", "APM", "CLOSE_ISSUES_ON_INACTIVE"),
+				Config: testAccNewRelicAlertMutingRuleBasic(rName, "new muting rule", "product", "EQUALS", "APM"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicAlertMutingRuleExists(resourceName),
 				),
 			},
 			// Test: Update
 			{
-				Config: testAccNewRelicAlertMutingRuleBasic(rName, "second muting rule", "conditionType", "NOT_EQUALS", "baseline", "CLOSE_ISSUES_ON_INACTIVE"),
+				Config: testAccNewRelicAlertMutingRuleBasic(rName, "second muting rule", "conditionType", "NOT_EQUALS", "baseline"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicAlertMutingRuleExists(resourceName),
+				),
+			},
+			// // Test: Import
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true},
+		},
+	})
+}
+
+func TestAccNewRelicAlertMutingRule_EndBehaviourInput(t *testing.T) {
+	resourceName := "newrelic_alert_muting_rule.foo"
+	rName := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertMutingRuleDestroy,
+		Steps: []resource.TestStep{
+			// Test: Create
+			{
+				Config: testAccNewRelicAlertMutingRuleEndBehaviourInput(rName, "new muting rule", "product", "EQUALS", "APM", "CLOSE_ISSUES_ON_INACTIVE"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicAlertMutingRuleExists(resourceName),
+				),
+			},
+			// Test: Update
+			{
+				Config: testAccNewRelicAlertMutingRuleEndBehaviourInput(rName, "second muting rule", "conditionType", "NOT_EQUALS", "baseline", "CLOSE_ISSUES_ON_INACTIVE"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicAlertMutingRuleExists(resourceName),
 				),
@@ -154,7 +186,6 @@ func TestAccNewRelicAlertMutingRule_WithSchedule(t *testing.T) {
 					"conditionName",
 					"EQUALS",
 					"My cool condition",
-					"CLOSE_ISSUES_ON_INACTIVE",
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicAlertMutingRuleExists(resourceName),
@@ -211,6 +242,36 @@ func TestAccNewRelicAlertMutingRule_WithSchedule(t *testing.T) {
 }
 
 func testAccNewRelicAlertMutingRuleBasic(
+	name string,
+	description string,
+	attribute string,
+	operator string,
+	values string,
+) string {
+	return fmt.Sprintf(`
+
+resource "newrelic_alert_muting_rule" "foo" {
+	name = "tf-test-%[1]s"
+	enabled = true
+	description = "%[2]s"
+	condition {
+		conditions {
+			attribute 	= "%[3]s"
+			operator 	= "EQUALS"
+			values 		= ["%[5]s"]
+		}
+		conditions {
+			attribute 	= "conditionType"
+			operator 	= "%[4]s"
+			values 		= ["static"]
+		}
+		operator = "AND"
+	}
+}
+`, name, description, attribute, operator, values)
+}
+
+func testAccNewRelicAlertMutingRuleEndBehaviourInput(
 	name string,
 	description string,
 	attribute string,

--- a/newrelic/resource_newrelic_alert_muting_rule_test.go
+++ b/newrelic/resource_newrelic_alert_muting_rule_test.go
@@ -78,14 +78,14 @@ func TestAccNewRelicAlertMutingRule_Basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test: Create
 			{
-				Config: testAccNewRelicAlertMutingRuleBasic(rName, "new muting rule", "product", "EQUALS", "APM"),
+				Config: testAccNewRelicAlertMutingRuleBasic(rName, "new muting rule", "product", "EQUALS", "APM", "CLOSE_ISSUES_ON_INACTIVE"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicAlertMutingRuleExists(resourceName),
 				),
 			},
 			// Test: Update
 			{
-				Config: testAccNewRelicAlertMutingRuleBasic(rName, "second muting rule", "conditionType", "NOT_EQUALS", "baseline"),
+				Config: testAccNewRelicAlertMutingRuleBasic(rName, "second muting rule", "conditionType", "NOT_EQUALS", "baseline", "CLOSE_ISSUES_ON_INACTIVE"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicAlertMutingRuleExists(resourceName),
 				),
@@ -154,6 +154,7 @@ func TestAccNewRelicAlertMutingRule_WithSchedule(t *testing.T) {
 					"conditionName",
 					"EQUALS",
 					"My cool condition",
+					"CLOSE_ISSUES_ON_INACTIVE",
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicAlertMutingRuleExists(resourceName),
@@ -215,6 +216,7 @@ func testAccNewRelicAlertMutingRuleBasic(
 	attribute string,
 	operator string,
 	values string,
+	actionOnMutingRuleWindowEnded string,
 ) string {
 	return fmt.Sprintf(`
 
@@ -235,6 +237,7 @@ resource "newrelic_alert_muting_rule" "foo" {
 		}
 		operator = "AND"
 	}
+	action_on_muting_rule_window_ended = "%[6]%"
 }
 `, name, description, attribute, operator, values)
 }

--- a/newrelic/resource_newrelic_alert_muting_rule_test.go
+++ b/newrelic/resource_newrelic_alert_muting_rule_test.go
@@ -237,9 +237,9 @@ resource "newrelic_alert_muting_rule" "foo" {
 		}
 		operator = "AND"
 	}
-	action_on_muting_rule_window_ended = "%[6]%"
+	action_on_muting_rule_window_ended = "%[6]s"
 }
-`, name, description, attribute, operator, values)
+`, name, description, attribute, operator, values, actionOnMutingRuleWindowEnded)
 }
 
 func testAccNewRelicAlertMutingRuleBadInput(

--- a/newrelic/structures_newrelic_alert_muting_rule.go
+++ b/newrelic/structures_newrelic_alert_muting_rule.go
@@ -18,8 +18,8 @@ func expandMutingRuleCreateInput(d *schema.ResourceData) (alerts.MutingRuleCreat
 		Description: d.Get("description").(string),
 	}
 
-	if endBehaviour, ok := d.GetOk("end_behaviour"); ok {
-		createInput.ActionOnMutingRuleWindowEnded = expandMutingRuleEndBehaviour(endBehaviour.(string))
+	if actionOnMutingRuleWindowEnded, ok := d.GetOk("action_on_muting_rule_window_ended"); ok {
+		createInput.ActionOnMutingRuleWindowEnded = alerts.AlertsActionOnMutingRuleWindowEnded(actionOnMutingRuleWindowEnded.(string))
 	}
 
 	if e, ok := d.GetOk("condition"); ok {
@@ -35,17 +35,6 @@ func expandMutingRuleCreateInput(d *schema.ResourceData) (alerts.MutingRuleCreat
 	}
 
 	return createInput, nil
-}
-
-func expandMutingRuleEndBehaviour(endBehaviour string) alerts.AlertsActionOnMutingRuleWindowEnded {
-	switch endBehaviour {
-	case string(alerts.AlertsActionOnMutingRuleWindowEndedTypes.CLOSE_ISSUES_ON_INACTIVE):
-		return alerts.AlertsActionOnMutingRuleWindowEndedTypes.CLOSE_ISSUES_ON_INACTIVE
-	case string(alerts.AlertsActionOnMutingRuleWindowEndedTypes.DO_NOTHING):
-		return alerts.AlertsActionOnMutingRuleWindowEndedTypes.DO_NOTHING
-	default:
-		return alerts.AlertsActionOnMutingRuleWindowEndedTypes.CLOSE_ISSUES_ON_INACTIVE
-	}
 }
 
 func expandMutingRuleCreateSchedule(cfg map[string]interface{}) (alerts.MutingRuleScheduleCreateInput, error) {
@@ -214,8 +203,8 @@ func expandMutingRuleUpdateInput(d *schema.ResourceData) (alerts.MutingRuleUpdat
 		Description: d.Get("description").(string),
 	}
 
-	if endBehaviour, ok := d.GetOk("end_behaviour"); ok {
-		updateInput.ActionOnMutingRuleWindowEnded = expandMutingRuleEndBehaviour(endBehaviour.(string))
+	if actionOnMutingRuleWindowEnded, ok := d.GetOk("action_on_muting_rule_window_ended"); ok {
+		updateInput.ActionOnMutingRuleWindowEnded = alerts.AlertsActionOnMutingRuleWindowEnded(actionOnMutingRuleWindowEnded.(string))
 	}
 
 	if e, ok := d.GetOk("condition"); ok {
@@ -289,7 +278,7 @@ func flattenMutingRule(mutingRule *alerts.MutingRule, d *schema.ResourceData) er
 	configuredCondition := x.([]interface{})
 
 	_ = d.Set("enabled", mutingRule.Enabled)
-	_ = d.Set("end_behaviour", mutingRule.ActionOnMutingRuleWindowEnded)
+	_ = d.Set("action_on_muting_rule_window_ended", mutingRule.ActionOnMutingRuleWindowEnded)
 	err := d.Set("condition", flattenMutingRuleConditionGroup(mutingRule.Condition, configuredCondition))
 	if err != nil {
 		return nil

--- a/newrelic/structures_newrelic_alert_muting_rule.go
+++ b/newrelic/structures_newrelic_alert_muting_rule.go
@@ -278,10 +278,7 @@ func flattenMutingRule(mutingRule *alerts.MutingRule, d *schema.ResourceData) er
 	configuredCondition := x.([]interface{})
 
 	_ = d.Set("enabled", mutingRule.Enabled)
-
-	if _, ok := d.GetOk("action_on_muting_rule_window_ended"); ok {
-		_ = d.Set("action_on_muting_rule_window_ended", mutingRule.ActionOnMutingRuleWindowEnded)
-	}
+	_ = d.Set("action_on_muting_rule_window_ended", mutingRule.ActionOnMutingRuleWindowEnded)
 
 	err := d.Set("condition", flattenMutingRuleConditionGroup(mutingRule.Condition, configuredCondition))
 	if err != nil {

--- a/newrelic/structures_newrelic_alert_muting_rule.go
+++ b/newrelic/structures_newrelic_alert_muting_rule.go
@@ -18,6 +18,10 @@ func expandMutingRuleCreateInput(d *schema.ResourceData) (alerts.MutingRuleCreat
 		Description: d.Get("description").(string),
 	}
 
+	if endBehaviour, ok := d.GetOk("end_behaviour"); ok {
+		createInput.ActionOnMutingRuleWindowEnded = expandMutingRuleEndBehaviour(endBehaviour.(string))
+	}
+
 	if e, ok := d.GetOk("condition"); ok {
 		createInput.Condition = expandMutingRuleConditionGroup(e.([]interface{})[0].(map[string]interface{}))
 	}
@@ -31,6 +35,17 @@ func expandMutingRuleCreateInput(d *schema.ResourceData) (alerts.MutingRuleCreat
 	}
 
 	return createInput, nil
+}
+
+func expandMutingRuleEndBehaviour(endBehaviour string) alerts.AlertsActionOnMutingRuleWindowEnded {
+	switch endBehaviour {
+	case string(alerts.AlertsActionOnMutingRuleWindowEndedTypes.CLOSE_ISSUES_ON_INACTIVE):
+		return alerts.AlertsActionOnMutingRuleWindowEndedTypes.CLOSE_ISSUES_ON_INACTIVE
+	case string(alerts.AlertsActionOnMutingRuleWindowEndedTypes.DO_NOTHING):
+		return alerts.AlertsActionOnMutingRuleWindowEndedTypes.DO_NOTHING
+	default:
+		return alerts.AlertsActionOnMutingRuleWindowEndedTypes.CLOSE_ISSUES_ON_INACTIVE
+	}
 }
 
 func expandMutingRuleCreateSchedule(cfg map[string]interface{}) (alerts.MutingRuleScheduleCreateInput, error) {
@@ -199,6 +214,10 @@ func expandMutingRuleUpdateInput(d *schema.ResourceData) (alerts.MutingRuleUpdat
 		Description: d.Get("description").(string),
 	}
 
+	if endBehaviour, ok := d.GetOk("end_behaviour"); ok {
+		updateInput.ActionOnMutingRuleWindowEnded = expandMutingRuleEndBehaviour(endBehaviour.(string))
+	}
+
 	if e, ok := d.GetOk("condition"); ok {
 		x := expandMutingRuleConditionGroup(e.([]interface{})[0].(map[string]interface{}))
 
@@ -270,6 +289,7 @@ func flattenMutingRule(mutingRule *alerts.MutingRule, d *schema.ResourceData) er
 	configuredCondition := x.([]interface{})
 
 	_ = d.Set("enabled", mutingRule.Enabled)
+	_ = d.Set("end_behaviour", mutingRule.ActionOnMutingRuleWindowEnded)
 	err := d.Set("condition", flattenMutingRuleConditionGroup(mutingRule.Condition, configuredCondition))
 	if err != nil {
 		return nil

--- a/newrelic/structures_newrelic_alert_muting_rule.go
+++ b/newrelic/structures_newrelic_alert_muting_rule.go
@@ -278,7 +278,11 @@ func flattenMutingRule(mutingRule *alerts.MutingRule, d *schema.ResourceData) er
 	configuredCondition := x.([]interface{})
 
 	_ = d.Set("enabled", mutingRule.Enabled)
-	_ = d.Set("action_on_muting_rule_window_ended", mutingRule.ActionOnMutingRuleWindowEnded)
+
+	if _, ok := d.GetOk("action_on_muting_rule_window_ended"); ok {
+		_ = d.Set("action_on_muting_rule_window_ended", mutingRule.ActionOnMutingRuleWindowEnded)
+	}
+
 	err := d.Set("condition", flattenMutingRuleConditionGroup(mutingRule.Condition, configuredCondition))
 	if err != nil {
 		return nil

--- a/website/docs/r/alert_muting_rule.html.markdown
+++ b/website/docs/r/alert_muting_rule.html.markdown
@@ -42,6 +42,7 @@ resource "newrelic_alert_muting_rule" "foo" {
       weekly_repeat_days = ["MONDAY", "WEDNESDAY", "FRIDAY"]
       repeat_count = 42
     }
+    action_on_muting_rule_window_ended = "CLOSE_ISSUES_ON_INACTIVE"
 }
 ```
 

--- a/website/docs/r/alert_muting_rule.html.markdown
+++ b/website/docs/r/alert_muting_rule.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
   * `name` - The name of the MutingRule.
   * `description` - The description of the MutingRule.
   * `schedule` - (Optional) Specify a schedule for enabling the MutingRule. See [Schedule](#schedule) below for details
-
+  * `action_on_muting_rule_window_ended` - (Optional) The action when the muting rule window is ended or disabled. Valid values are `CLOSE_ISSUES_ON_INACTIVE`, `DO_NOTHING`
 
 ### Nested `condition` blocks
 


### PR DESCRIPTION
# Description
- The addition of the `action_on_muting_rule_window_ended` attribute in the `newrelic_alert_muting_rule` Terraform resource aims to enhance the functionality of muting rules within New Relic's alerting system using terraform.
- The attribute `action_on_muting_rule_window_ended` is added to MutingRule Schema Resource and handler methods.
- Link to GitHub Issue: https://github.com/newrelic/terraform-provider-newrelic/issues/2774

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.
