### PR TITLE
docs(notification_channel.html.markdown): fix import example

### DIFF
--- a/website/docs/r/notification_channel.html.markdown
+++ b/website/docs/r/notification_channel.html.markdown
@@ -358,7 +358,7 @@ resource "newrelic_notification_channel" "webhook-channel" {
 Channels can only be used by a single workflow, therefore importing them is not particularly useful, because in the UI channels are created upon workflow creation. 
 Additionally, the channel id isn't available via the UI, and you'd need to look it up with the `channels` query in the NerdGraph API.
 That being said, importing is possible using -
-```terraform import newrelic_notification_destination.foo <destination_id>```
+```terraform import newrelic_notification_channel.foo <id>```
 
 ## Additional Information
 More details about the channels API can be found [here](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-api-notifications-channels).


### PR DESCRIPTION
# Description

Currently the notification_channel import example uses the notification_destination resource, which can lead to errors by the reader. This PR updates the example to match the notification_channel expected import

## Type of change

Please delete options that are not relevant.

- [X] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [X] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation