### PR TITLE
feat(application_settings) : Revamp application apm settings to sync with the latest features/functionalities in apm settings in ui

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.30.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.54.1-0.20250304165839-9f2f856f48f7
+	github.com/newrelic/newrelic-client-go/v2 v2.55.0
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 )

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.30.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.54.0
+	github.com/newrelic/newrelic-client-go/v2 v2.54.1-0.20250304100828-114b5a6abef6
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 )

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.30.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.54.1-0.20250304100828-114b5a6abef6
+	github.com/newrelic/newrelic-client-go/v2 v2.54.1-0.20250304165839-9f2f856f48f7
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 )

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.54.1-0.20250304100828-114b5a6abef6 h1:BvMD2tzVwEGdBqy7KcN5kXjIStsVzQXiiUU5S+hGkJQ=
-github.com/newrelic/newrelic-client-go/v2 v2.54.1-0.20250304100828-114b5a6abef6/go.mod h1:+RRjI3nDGWT3kLm9Oi3QxpBm70uu8q1upEHBVWCZFpo=
+github.com/newrelic/newrelic-client-go/v2 v2.54.1-0.20250304165839-9f2f856f48f7 h1:5rY8xXBP6B3tLjwmuiyyv4qf2nFhlCakrYRxausyxUs=
+github.com/newrelic/newrelic-client-go/v2 v2.54.1-0.20250304165839-9f2f856f48f7/go.mod h1:+RRjI3nDGWT3kLm9Oi3QxpBm70uu8q1upEHBVWCZFpo=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,11 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.54.0 h1:d4rKYO/souvIMmsA58DfL17TR8clCt6ZNUoPfzjIKng=
+github.com/newrelic/newrelic-client-go/v2 v2.52.1-0.20250304085509-74cbd078c697 h1:rSG4vFvdRHocLWzBanujVP17AQO563lzPkIUDSyJWLA=
+github.com/newrelic/newrelic-client-go/v2 v2.52.1-0.20250304085509-74cbd078c697/go.mod h1:+RRjI3nDGWT3kLm9Oi3QxpBm70uu8q1upEHBVWCZFpo=
 github.com/newrelic/newrelic-client-go/v2 v2.54.0/go.mod h1:+RRjI3nDGWT3kLm9Oi3QxpBm70uu8q1upEHBVWCZFpo=
+github.com/newrelic/newrelic-client-go/v2 v2.54.1-0.20250304100828-114b5a6abef6 h1:BvMD2tzVwEGdBqy7KcN5kXjIStsVzQXiiUU5S+hGkJQ=
+github.com/newrelic/newrelic-client-go/v2 v2.54.1-0.20250304100828-114b5a6abef6/go.mod h1:+RRjI3nDGWT3kLm9Oi3QxpBm70uu8q1upEHBVWCZFpo=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.54.1-0.20250304165839-9f2f856f48f7 h1:5rY8xXBP6B3tLjwmuiyyv4qf2nFhlCakrYRxausyxUs=
-github.com/newrelic/newrelic-client-go/v2 v2.54.1-0.20250304165839-9f2f856f48f7/go.mod h1:+RRjI3nDGWT3kLm9Oi3QxpBm70uu8q1upEHBVWCZFpo=
+github.com/newrelic/newrelic-client-go/v2 v2.55.0 h1:H/lu9fz92/i2Z+RQGtWPYrREpWGECRIUtKhjUqsB62A=
+github.com/newrelic/newrelic-client-go/v2 v2.55.0/go.mod h1:+RRjI3nDGWT3kLm9Oi3QxpBm70uu8q1upEHBVWCZFpo=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/go.sum
+++ b/go.sum
@@ -270,9 +270,6 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.52.1-0.20250304085509-74cbd078c697 h1:rSG4vFvdRHocLWzBanujVP17AQO563lzPkIUDSyJWLA=
-github.com/newrelic/newrelic-client-go/v2 v2.52.1-0.20250304085509-74cbd078c697/go.mod h1:+RRjI3nDGWT3kLm9Oi3QxpBm70uu8q1upEHBVWCZFpo=
-github.com/newrelic/newrelic-client-go/v2 v2.54.0/go.mod h1:+RRjI3nDGWT3kLm9Oi3QxpBm70uu8q1upEHBVWCZFpo=
 github.com/newrelic/newrelic-client-go/v2 v2.54.1-0.20250304100828-114b5a6abef6 h1:BvMD2tzVwEGdBqy7KcN5kXjIStsVzQXiiUU5S+hGkJQ=
 github.com/newrelic/newrelic-client-go/v2 v2.54.1-0.20250304100828-114b5a6abef6/go.mod h1:+RRjI3nDGWT3kLm9Oi3QxpBm70uu8q1upEHBVWCZFpo=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=

--- a/newrelic/helpers.go
+++ b/newrelic/helpers.go
@@ -164,3 +164,25 @@ func revertEscapedSingleQuote(name string) string {
 func fetchAttributeValueFromResourceConfig(d *schema.ResourceData, key string) (interface{}, bool) {
 	return d.GetOk(key)
 }
+
+func getBoolPointer(value bool) *bool {
+	return &value
+}
+
+func getFloatPointer(value float64) *float64 {
+	return &value
+}
+
+func getStringPointer(value string) *string {
+	return &value
+}
+
+func convertInterfaceToStringSlice(v interface{}) []string {
+	var result []string
+	for _, item := range v.([]interface{}) {
+		if str, ok := item.(string); ok {
+			result = append(result, str)
+		}
+	}
+	return result
+}

--- a/newrelic/helpers.go
+++ b/newrelic/helpers.go
@@ -173,10 +173,6 @@ func getFloatPointer(value float64) *float64 {
 	return &value
 }
 
-func getStringPointer(value string) *string {
-	return &value
-}
-
 func convertInterfaceToStringSlice(v interface{}) []string {
 	var result []string
 	for _, item := range v.([]interface{}) {

--- a/newrelic/resource_helpers_application_settings.go
+++ b/newrelic/resource_helpers_application_settings.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"regexp"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/newrelic/resource_helpers_application_settings.go
+++ b/newrelic/resource_helpers_application_settings.go
@@ -1,0 +1,290 @@
+package newrelic
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func applicationSettingCommonSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"guid": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			ForceNew:    true,
+			Computed:    true,
+			Description: "The GUID of the application in New Relic.",
+		},
+		"is_imported": {
+			Type:     schema.TypeBool,
+			Computed: true,
+			Default:  nil,
+		},
+	}
+}
+
+func apmApplicationSettingsSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "The name of the application in New Relic.",
+		},
+		"app_apdex_threshold": {
+			Type:        schema.TypeFloat,
+			Optional:    true,
+			Description: "The response time threshold value for Apdex score calculation.",
+		},
+		"end_user_apdex_threshold": {
+			Type:        schema.TypeFloat,
+			Optional:    true,
+			Description: "Dummy field to support backward compatibility of previous version.should be removed with next major version.",
+		},
+		"enable_real_user_monitoring": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Dummy field to support backward compatibility of previous version.should be removed with next major version.",
+		},
+		"use_server_side_config": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable or disable server side monitoring.",
+		},
+		"transaction_tracer": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Configuration for transaction tracing.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"transaction_threshold_type": {
+						Type:         schema.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringInSlice([]string{"APDEX_F", "VALUE"}, false),
+						Description:  "The type of threshold for transaction tracing, either 'APDEX_F' or 'VALUE'.",
+					},
+					"transaction_threshold_value": {
+						Type:        schema.TypeFloat,
+						Optional:    true,
+						Description: "The threshold value for transaction tracing when 'transaction_threshold_type' is 'VALUE'.",
+					},
+					"sql": {
+						Type:        schema.TypeList,
+						Optional:    true,
+						MinItems:    1,
+						MaxItems:    1,
+						Description: "Configuration for SQL tracing.",
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"record_sql": {
+									Type:         schema.TypeString,
+									Required:     true,
+									ValidateFunc: validation.StringInSlice([]string{"OBFUSCATED", "OFF", "RAW"}, true),
+									Description:  "The level of SQL recording, either 'OBFUSCATED', 'OFF', or 'RAW'.",
+								},
+							},
+						},
+					},
+					"stack_trace_threshold_value": {
+						Type:        schema.TypeFloat,
+						Optional:    true,
+						Description: "The response time threshold value for capturing stack traces of SQL queries.",
+					},
+					"explain_query_plans": {
+						Type:        schema.TypeList,
+						Optional:    true,
+						Description: "Configuration for explain plans of slow SQL queries.",
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"query_plan_threshold_type": {
+									Type:         schema.TypeString,
+									Optional:     true,
+									ValidateFunc: validation.StringInSlice([]string{"APDEX_F", "VALUE"}, false),
+									Description:  "The type of threshold for explain plans, either 'APDEX_F' or 'VALUE'.",
+								},
+								"query_plan_threshold_value": {
+									Type:        schema.TypeFloat,
+									Optional:    true,
+									Description: "The threshold value for explain plans when 'query_plan_threshold_type' is 'VALUE'.",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"error_collector": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Configuration for error collection.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"expected_error_classes": {
+						Type:        schema.TypeList,
+						Elem:        &schema.Schema{Type: schema.TypeString},
+						Optional:    true,
+						Description: "A list of error classes that are expected and should not trigger alerts.",
+					},
+					"expected_error_codes": {
+						Type:        schema.TypeList,
+						Elem:        &schema.Schema{Type: schema.TypeString},
+						Optional:    true,
+						Description: "A list of error codes that are expected and should not trigger alerts.",
+					},
+					"ignored_error_classes": {
+						Type:        schema.TypeList,
+						Elem:        &schema.Schema{Type: schema.TypeString},
+						Optional:    true,
+						Description: "A list of error classes that should be ignored.",
+					},
+					"ignored_error_codes": {
+						Type:        schema.TypeList,
+						Elem:        &schema.Schema{Type: schema.TypeString},
+						Optional:    true,
+						Description: "A list of error codes that should be ignored.",
+					},
+				},
+			},
+		},
+		"enable_slow_sql": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Samples and reports the slowest database queries in your traces.",
+		},
+		"tracer_type": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice([]string{"CROSS_APPLICATION_TRACER", "DISTRIBUTED_TRACING", "NONE", "OPT_OUT"}, true),
+			Description:  "The type of tracer to use, either 'CROSS_APPLICATION_TRACER', 'DISTRIBUTED_TRACING', 'NONE', or 'OPT_OUT'.",
+		},
+		"enable_thread_profiler": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable or disable the thread profiler.",
+		},
+	}
+}
+
+func validateErrorCollector(d *schema.ResourceDiff, errorsList *[]string) {
+	if excodes, ok := d.GetOk("error_collector.0.expected_error_codes"); ok {
+		for _, excode := range excodes.([]interface{}) {
+			excodeStr, ok := excode.(string)
+			if !ok {
+				*errorsList = append(*errorsList, fmt.Sprintf("expected_error_codes '%v' is not a string", excode))
+			} else if !regexp.MustCompile(`^[1-9][0-9]{2}$`).MatchString(excodeStr) { // Validate the expected_error_codes against the regex pattern
+				*errorsList = append(*errorsList, fmt.Sprintf("expected_error_codes '%s' must be a valid status code between 100 and 900", excodeStr))
+			}
+		}
+	}
+	if excodes, ok := d.GetOk("error_collector.0.ignored_error_codes"); ok {
+		for _, excode := range excodes.([]interface{}) {
+			excodeStr, ok := excode.(string)
+			if !ok {
+				*errorsList = append(*errorsList, fmt.Sprintf("ignored_error_codes '%v' is not a string", excode))
+			} else if !regexp.MustCompile(`^[1-9][0-9]{2}$`).MatchString(excodeStr) { // Validate the expected_error_codes against the regex pattern
+				*errorsList = append(*errorsList, fmt.Sprintf("ignored_error_codes '%s' must be a valid status code between 100 and 900", excodeStr))
+			}
+		}
+	}
+}
+
+func validateThresholds(d *schema.ResourceDiff, errorsList *[]string) {
+	_, tracerExists := d.GetOk("transaction_tracer")
+	if tracerExists {
+		_, queryPlanExists := d.GetOk("transaction_tracer.0.explain_query_plans")
+		thresholdType, typeExists := d.GetOk("transaction_tracer.0.explain_query_plans.0.query_plan_threshold_type")
+		_, valueExists := d.GetOk("transaction_tracer.0.explain_query_plans.0.query_plan_threshold_value")
+		_, stackTraceExists := d.GetOk("transaction_tracer.0.stack_trace_threshold_value")
+
+		if queryPlanExists && !typeExists && !valueExists {
+			*errorsList = append(*errorsList, "at least one of `query_plan_threshold_type` or `query_plan_threshold_value` must be provided when `explain_query_plans` is set")
+		}
+
+		if typeExists && thresholdType == "VALUE" && !valueExists {
+			*errorsList = append(*errorsList, "`query_plan_threshold_value` must be set when `query_plan_threshold_type` is 'VALUE'")
+		}
+
+		if valueExists && (!typeExists || thresholdType != "VALUE") {
+			*errorsList = append(*errorsList, "`query_plan_threshold_type` must be set to 'VALUE' when `query_plan_threshold_value` is provided")
+		}
+
+		if typeExists && thresholdType == "APDEX_F" && valueExists {
+			*errorsList = append(*errorsList, "`query_plan_threshold_value` should not be set when `query_plan_threshold_type` is 'APDEX_F'")
+		}
+
+		if !stackTraceExists {
+			*errorsList = append(*errorsList, "stack_trace_threshold_value must be provided when `transaction_tracer` is set")
+		}
+
+		validateTransactionThresholds(d, errorsList)
+	}
+}
+
+func validateTransactionThresholds(d *schema.ResourceDiff, errorsList *[]string) {
+	transactionThresholdType, transactionTypeExists := d.GetOk("transaction_tracer.0.transaction_threshold_type")
+	_, transactionValueExists := d.GetOk("transaction_tracer.0.transaction_threshold_value")
+
+	if !transactionTypeExists && !transactionValueExists {
+		*errorsList = append(*errorsList, "at least one of `transaction_threshold_type` or `transaction_threshold_value` must be provided when `transaction_tracer` is set")
+	}
+
+	if transactionTypeExists && transactionThresholdType == "VALUE" && !transactionValueExists {
+		*errorsList = append(*errorsList, "`transaction_threshold_value` must be set when `transaction_threshold_type` is 'VALUE'")
+	}
+
+	if transactionValueExists && (!transactionTypeExists || transactionThresholdType != "VALUE") {
+		*errorsList = append(*errorsList, "`transaction_threshold_type` must be set to 'VALUE' when `transaction_threshold_value` is provided")
+	}
+
+	if transactionTypeExists && transactionThresholdType == "APDEX_F" && transactionValueExists {
+		*errorsList = append(*errorsList, "`transaction_threshold_value` should not be set when `transaction_threshold_type` is 'APDEX_F'")
+	}
+}
+
+func validateServerSideConfig(d *schema.ResourceDiff, errorsList *[]string) {
+	ServerSideConfig := d.Get("use_server_side_config").(bool)
+
+	attrList := []string{"transaction_tracer", "error_collector", "tracer_type", "enable_thread_profiler", "enable_slow_sql"}
+	var finalList []string
+	for _, value := range attrList {
+		_, valueBool := d.GetOk(value)
+		if valueBool && !ServerSideConfig {
+			finalList = append(finalList, value)
+		}
+	}
+
+	if len(finalList) > 0 {
+		*errorsList = append(*errorsList, fmt.Sprintf("use_server_side_config must be set to true when %s is configured", strings.Join(finalList, ", ")))
+	}
+}
+
+// Custom validator that ensures fields are validated correctly
+func validateApplicationSettingsInput(ctx context.Context, d *schema.ResourceDiff, v interface{}) error {
+	var errorsList []string
+
+	_, nameExists := d.GetOk("name")
+	_, guidExists := d.GetOk("guid")
+
+	if !guidExists && !nameExists {
+		return fmt.Errorf("at least one of `name` or `guid` must be provided")
+	}
+
+	validateServerSideConfig(d, &errorsList)
+	validateThresholds(d, &errorsList)
+	validateErrorCollector(d, &errorsList)
+
+	if len(errorsList) == 0 {
+		return nil
+	}
+
+	errorsString := "the following validation errors have been identified: \n"
+	for index, val := range errorsList {
+		errorsString += fmt.Sprintf("(%d): %s\n", index+1, val)
+	}
+	return errors.New(errorsString)
+}

--- a/newrelic/resource_newrelic_application_settings.go
+++ b/newrelic/resource_newrelic_application_settings.go
@@ -106,7 +106,7 @@ func validateTransactionThresholds(d *schema.ResourceDiff, errorsList *[]string)
 func validateServerSideConfig(d *schema.ResourceDiff, errorsList *[]string) {
 	ServerSideConfig := d.Get("use_server_side_config").(bool)
 
-	attrList := []string{"transaction_tracer", "error_collector", "tracer_type", "enable_thread_profiler"}
+	attrList := []string{"transaction_tracer", "error_collector", "tracer_type", "enable_thread_profiler", "enable_slow_sql"}
 	var finalList []string
 	for _, value := range attrList {
 		_, valueBool := d.GetOk(value)

--- a/newrelic/resource_newrelic_application_settings.go
+++ b/newrelic/resource_newrelic_application_settings.go
@@ -2,13 +2,9 @@ package newrelic
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/agentapplications"
 	"log"
-	"regexp"
-	"strings"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -30,278 +26,6 @@ func resourceNewRelicApplicationSettings() *schema.Resource {
 			apmApplicationSettingsSchema(),
 		),
 		CustomizeDiff: validateApplicationSettingsInput,
-	}
-}
-
-func validateErrorCollector(d *schema.ResourceDiff, errorsList *[]string) {
-	if excodes, ok := d.GetOk("error_collector.0.expected_error_codes"); ok {
-		for _, excode := range excodes.([]interface{}) {
-			excodeStr, ok := excode.(string)
-			if !ok {
-				*errorsList = append(*errorsList, fmt.Sprintf("expected_error_codes '%v' is not a string", excode))
-			} else if !regexp.MustCompile(`^[1-9][0-9]{2}$`).MatchString(excodeStr) { // Validate the expected_error_codes against the regex pattern
-				*errorsList = append(*errorsList, fmt.Sprintf("expected_error_codes '%s' must be a valid status code between 100 and 900", excodeStr))
-			}
-		}
-	}
-	if excodes, ok := d.GetOk("error_collector.0.ignored_error_codes"); ok {
-		for _, excode := range excodes.([]interface{}) {
-			excodeStr, ok := excode.(string)
-			if !ok {
-				*errorsList = append(*errorsList, fmt.Sprintf("ignored_error_codes '%v' is not a string", excode))
-			} else if !regexp.MustCompile(`^[1-9][0-9]{2}$`).MatchString(excodeStr) { // Validate the expected_error_codes against the regex pattern
-				*errorsList = append(*errorsList, fmt.Sprintf("ignored_error_codes '%s' must be a valid status code between 100 and 900", excodeStr))
-			}
-		}
-	}
-}
-
-func validateThresholds(d *schema.ResourceDiff, errorsList *[]string) {
-	_, tracerExists := d.GetOk("transaction_tracer")
-	if tracerExists {
-		_, queryPlanExists := d.GetOk("transaction_tracer.0.explain_query_plans")
-		thresholdType, typeExists := d.GetOk("transaction_tracer.0.explain_query_plans.0.query_plan_threshold_type")
-		_, valueExists := d.GetOk("transaction_tracer.0.explain_query_plans.0.query_plan_threshold_value")
-
-		if queryPlanExists && !typeExists && !valueExists {
-			*errorsList = append(*errorsList, "at least one of `query_plan_threshold_type` or `query_plan_threshold_value` must be provided when `explain_query_plans` is set")
-		}
-
-		if typeExists && thresholdType == "VALUE" && !valueExists {
-			*errorsList = append(*errorsList, "`query_plan_threshold_value` must be set when `query_plan_threshold_type` is 'VALUE'")
-		}
-
-		if valueExists && (!typeExists || thresholdType != "VALUE") {
-			*errorsList = append(*errorsList, "`query_plan_threshold_type` must be set to 'VALUE' when `query_plan_threshold_value` is provided")
-		}
-
-		if typeExists && thresholdType == "APDEX_F" && valueExists {
-			*errorsList = append(*errorsList, "`query_plan_threshold_value` should not be set when `query_plan_threshold_type` is 'APDEX_F'")
-		}
-		validateTransactionThresholds(d, errorsList)
-	}
-}
-
-func validateTransactionThresholds(d *schema.ResourceDiff, errorsList *[]string) {
-	transactionThresholdType, transactionTypeExists := d.GetOk("transaction_tracer.0.transaction_threshold_type")
-	_, transactionValueExists := d.GetOk("transaction_tracer.0.transaction_threshold_value")
-
-	if !transactionTypeExists && !transactionValueExists {
-		*errorsList = append(*errorsList, "at least one of `transaction_threshold_type` or `transaction_threshold_value` must be provided when `transaction_tracer` is set")
-	}
-
-	if transactionTypeExists && transactionThresholdType == "VALUE" && !transactionValueExists {
-		*errorsList = append(*errorsList, "`transaction_threshold_value` must be set when `transaction_threshold_type` is 'VALUE'")
-	}
-
-	if transactionValueExists && (!transactionTypeExists || transactionThresholdType != "VALUE") {
-		*errorsList = append(*errorsList, "`transaction_threshold_type` must be set to 'VALUE' when `transaction_threshold_value` is provided")
-	}
-
-	if transactionTypeExists && transactionThresholdType == "APDEX_F" && transactionValueExists {
-		*errorsList = append(*errorsList, "`transaction_threshold_value` should not be set when `transaction_threshold_type` is 'APDEX_F'")
-	}
-}
-
-func validateServerSideConfig(d *schema.ResourceDiff, errorsList *[]string) {
-	ServerSideConfig := d.Get("use_server_side_config").(bool)
-
-	attrList := []string{"transaction_tracer", "error_collector", "tracer_type", "enable_thread_profiler", "enable_slow_sql"}
-	var finalList []string
-	for _, value := range attrList {
-		_, valueBool := d.GetOk(value)
-		if valueBool && !ServerSideConfig {
-			finalList = append(finalList, value)
-		}
-	}
-
-	if len(finalList) > 0 {
-		*errorsList = append(*errorsList, fmt.Sprintf("use_server_side_config must be set to true when %v is configured", finalList))
-	}
-}
-
-// Custom validator that ensures fields are validated correctly
-func validateApplicationSettingsInput(ctx context.Context, d *schema.ResourceDiff, v interface{}) error {
-	var errorsList []string
-
-	_, nameExists := d.GetOk("name")
-	_, guidExists := d.GetOk("guid")
-
-	if !guidExists && !nameExists {
-		return fmt.Errorf("at least one of `name` or `guid` must be provided")
-	}
-
-	validateServerSideConfig(d, &errorsList)
-	validateThresholds(d, &errorsList)
-	validateErrorCollector(d, &errorsList)
-
-	if len(errorsList) == 0 {
-		return nil
-	}
-
-	errorsString := "the following validation errors have been identified: \n"
-	for index, val := range errorsList {
-		errorsString += fmt.Sprintf("(%d): %s\n", index+1, val)
-	}
-	return errors.New(errorsString)
-}
-
-func applicationSettingCommonSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"guid": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			ForceNew:    true,
-			Computed:    true,
-			Description: "The GUID of the application in New Relic.",
-		},
-		"is_imported": {
-			Type:     schema.TypeBool,
-			Computed: true,
-			Default:  nil,
-		},
-	}
-}
-
-func apmApplicationSettingsSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"name": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Computed:    true,
-			Description: "The name of the application in New Relic.",
-		},
-		"app_apdex_threshold": {
-			Type:        schema.TypeFloat,
-			Optional:    true,
-			Description: "The response time threshold value for Apdex score calculation.",
-		},
-		"end_user_apdex_threshold": {
-			Type:        schema.TypeFloat,
-			Optional:    true,
-			Description: "Dummy field to support backward compatibility of previous version.should be removed with next major version.",
-		},
-		"enable_real_user_monitoring": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Description: "Dummy field to support backward compatibility of previous version.should be removed with next major version.",
-		},
-		"use_server_side_config": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Description: "Enable or disable server side monitoring.",
-		},
-		"transaction_tracer": {
-			Type:        schema.TypeList,
-			Optional:    true,
-			Description: "Configuration for transaction tracing.",
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"transaction_threshold_type": {
-						Type:         schema.TypeString,
-						Optional:     true,
-						ValidateFunc: validation.StringInSlice([]string{"APDEX_F", "VALUE"}, false),
-						Description:  "The type of threshold for transaction tracing, either 'APDEX_F' or 'VALUE'.",
-					},
-					"transaction_threshold_value": {
-						Type:        schema.TypeFloat,
-						Optional:    true,
-						Description: "The threshold value for transaction tracing when 'transaction_threshold_type' is 'VALUE'.",
-					},
-					"sql": {
-						Type:        schema.TypeList,
-						Optional:    true,
-						MinItems:    1,
-						MaxItems:    1,
-						Description: "Configuration for SQL tracing.",
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"record_sql": {
-									Type:         schema.TypeString,
-									Required:     true,
-									ValidateFunc: validation.StringInSlice([]string{"OBFUSCATED", "OFF", "RAW"}, true),
-									Description:  "The level of SQL recording, either 'OBFUSCATED', 'OFF', or 'RAW'.",
-								},
-							},
-						},
-					},
-					"stack_trace_threshold_value": {
-						Type:        schema.TypeFloat,
-						Required:    true,
-						Description: "The response time threshold value for capturing stack traces of SQL queries.",
-					},
-					"explain_query_plans": {
-						Type:        schema.TypeList,
-						Optional:    true,
-						Description: "Configuration for explain plans of slow SQL queries.",
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"query_plan_threshold_type": {
-									Type:         schema.TypeString,
-									Optional:     true,
-									ValidateFunc: validation.StringInSlice([]string{"APDEX_F", "VALUE"}, false),
-									Description:  "The type of threshold for explain plans, either 'APDEX_F' or 'VALUE'.",
-								},
-								"query_plan_threshold_value": {
-									Type:        schema.TypeFloat,
-									Optional:    true,
-									Description: "The threshold value for explain plans when 'query_plan_threshold_type' is 'VALUE'.",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"error_collector": {
-			Type:        schema.TypeList,
-			Optional:    true,
-			Description: "Configuration for error collection.",
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"expected_error_classes": {
-						Type:        schema.TypeList,
-						Elem:        &schema.Schema{Type: schema.TypeString},
-						Optional:    true,
-						Description: "A list of error classes that are expected and should not trigger alerts.",
-					},
-					"expected_error_codes": {
-						Type:        schema.TypeList,
-						Elem:        &schema.Schema{Type: schema.TypeString},
-						Optional:    true,
-						Description: "A list of error codes that are expected and should not trigger alerts.",
-					},
-					"ignored_error_classes": {
-						Type:        schema.TypeList,
-						Elem:        &schema.Schema{Type: schema.TypeString},
-						Optional:    true,
-						Description: "A list of error classes that should be ignored.",
-					},
-					"ignored_error_codes": {
-						Type:        schema.TypeList,
-						Elem:        &schema.Schema{Type: schema.TypeString},
-						Optional:    true,
-						Description: "A list of error codes that should be ignored.",
-					},
-				},
-			},
-		},
-		"enable_slow_sql": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Description: "Samples and reports the slowest database queries in your traces.",
-		},
-		"tracer_type": {
-			Type:         schema.TypeString,
-			Optional:     true,
-			ValidateFunc: validation.StringInSlice([]string{"CROSS_APPLICATION_TRACER", "DISTRIBUTED_TRACING", "NONE", "OPT_OUT"}, true),
-			Description:  "The type of tracer to use, either 'CROSS_APPLICATION_TRACER', 'DISTRIBUTED_TRACING', 'NONE', or 'OPT_OUT'.",
-		},
-		"enable_thread_profiler": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Description: "Enable or disable the thread profiler.",
-		},
 	}
 }
 
@@ -380,59 +104,54 @@ func resourceNewRelicApplicationSettingsUpdate(ctx context.Context, d *schema.Re
 }
 
 func resourceNewRelicApplicationSettingsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	// You can only delete applications and not application settings which not might be provisioned by this resource
 	var diags diag.Diagnostics
-	diags = append(diags, diag.Diagnostic{
-		Severity: diag.Warning,
-		Summary:  "Deleting the settings of an APM Application is not supported by this resource. https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/application_settings",
-	})
-	return diags
-}
-
-func getEntityDetailsFromName(ctx context.Context, d *schema.ResourceData, meta interface{}) (*entities.EntityOutlineInterface, error) {
-	log.Printf("[INFO] Reading New Relic entities")
-
 	client := meta.(*ProviderConfig).NewClient
-	name := d.Get("name").(string)
-	name = escapeSingleQuote(name)
-	entityType := "APPLICATION"
-	domain := "APM"
+	guid := d.Get("guid").(string)
+	falseValue := false
 
-	query := buildEntitySearchQuery(name, domain, entityType, []interface{}{})
-
-	entityResults, err := client.Entities.GetEntitySearchByQueryWithContext(ctx,
-		entities.EntitySearchOptions{
-			CaseSensitiveTagMatching: true,
+	agentApplicationSettingResult, err := client.AgentApplications.AgentApplicationSettingsUpdate(
+		common.EntityGUID(guid),
+		agentapplications.AgentApplicationSettingsUpdateInput{
+			ApmConfig: &agentapplications.AgentApplicationSettingsApmConfigInput{
+				UseServerSideConfig: &falseValue,
+				ApdexTarget:         0.5,
+			},
+			ErrorCollector: &agentapplications.AgentApplicationSettingsErrorCollectorInput{
+				Enabled: &falseValue,
+			},
+			TransactionTracer: &agentapplications.AgentApplicationSettingsTransactionTracerInput{
+				Enabled:        &falseValue,
+				ExplainEnabled: &falseValue,
+				RecordSql:      agentapplications.AgentApplicationSettingsRecordSqlEnumTypes.OFF,
+			},
+			TracerType: &agentapplications.AgentApplicationSettingsTracerTypeInput{
+				// choosing "NONE" instead of "OPT_OUT", as OPT_OUT is not available as a type in the Go Client
+				// since OPT_OUT is not a recognized enum value by NerdGraph
+				Value: agentapplications.AgentApplicationSettingsTracerTypes.NONE,
+			},
+			ThreadProfiler: &agentapplications.AgentApplicationSettingsThreadProfilerInput{
+				Enabled: &falseValue,
+			},
+			SlowSql: &agentapplications.AgentApplicationSettingsSlowSqlInput{
+				Enabled: &falseValue,
+			},
 		},
-		query,
-		[]entities.EntitySearchSortCriteria{},
 	)
 
 	if err != nil {
-		return nil, err
+		return diag.FromErr(err)
 	}
 
-	if entityResults == nil {
-		return nil, fmt.Errorf("GetEntitySearchByQuery response was nil")
+	if agentApplicationSettingResult == nil {
+		return diag.FromErr(fmt.Errorf("something went wrong while clearing the settings of the application"))
 	}
 
-	var entity *entities.EntityOutlineInterface
-	for _, e := range entityResults.Results.Entities {
-		// Conditional on case-sensitive match
-		str := e.GetName()
-		str = strings.TrimSpace(str)
+	// this function should not be removed, this exists in every delete function to "clear" Terraform state
+	d.SetId("")
 
-		name = revertEscapedSingleQuote(name)
-		if strings.Compare(str, name) == 0 || (strings.EqualFold(str, name)) {
-			entity = &e
-			break
-		}
-	}
-
-	if entity == nil {
-		return nil, fmt.Errorf("no entities found with the provided name, please ensure your name is valid")
-	}
-
-	return entity, nil
-
+	diags = append(diags, diag.Diagnostic{
+		Severity: diag.Warning,
+		Summary:  "\nSince the `newrelic_application_settings` resource does not support deletion via NerdGraph, the resource has been reset to its initial state and cleared of most settings.\nYou would still find some settings of this APM entity in the New Relic UI (such as the Apdex Threshold) which cannot be cleared.",
+	})
+	return diags
 }

--- a/newrelic/resource_newrelic_application_settings.go
+++ b/newrelic/resource_newrelic_application_settings.go
@@ -2,13 +2,19 @@ package newrelic
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log"
-	"strconv"
+	"regexp"
+	"strings"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/newrelic/newrelic-client-go/v2/pkg/apm"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/entities"
 )
 
 func resourceNewRelicApplicationSettings() *schema.Resource {
@@ -20,99 +26,412 @@ func resourceNewRelicApplicationSettings() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+		Schema: mergeSchemas(
+			applicationSettingCommonSchema(),
+			apmApplicationSettingsSchema(),
+		),
+		CustomizeDiff: validateApplicationSettingsInput,
+	}
+}
+
+func validateErrorCollector(d *schema.ResourceDiff, errorsList *[]string) {
+	if excodes, ok := d.GetOk("error_collector.0.expected_error_codes"); ok {
+		for _, excode := range excodes.([]interface{}) {
+			excodeStr, ok := excode.(string)
+			if !ok {
+				*errorsList = append(*errorsList, fmt.Sprintf("expected_error_codes '%v' is not a string", excode))
+			} else if !regexp.MustCompile(`^[1-9][0-9]{2}$`).MatchString(excodeStr) { // Validate the expected_error_codes against the regex pattern
+				*errorsList = append(*errorsList, fmt.Sprintf("expected_error_codes '%s' must be a valid status code between 100 and 900", excodeStr))
+			}
+		}
+	}
+	if excodes, ok := d.GetOk("error_collector.0.ignored_error_codes"); ok {
+		for _, excode := range excodes.([]interface{}) {
+			excodeStr, ok := excode.(string)
+			if !ok {
+				*errorsList = append(*errorsList, fmt.Sprintf("ignored_error_codes '%v' is not a string", excode))
+			} else if !regexp.MustCompile(`^[1-9][0-9]{2}$`).MatchString(excodeStr) { // Validate the expected_error_codes against the regex pattern
+				*errorsList = append(*errorsList, fmt.Sprintf("ignored_error_codes '%s' must be a valid status code between 100 and 900", excodeStr))
+			}
+		}
+	}
+}
+
+func validateThresholds(d *schema.ResourceDiff, errorsList *[]string) {
+
+	_, tracerExists := d.GetOk("transaction_tracer")
+	if tracerExists {
+		_, queryPlanExists := d.GetOk("transaction_tracer.0.explain_query_plans")
+		thresholdType, typeExists := d.GetOk("transaction_tracer.0.explain_query_plans.0.query_plan_threshold_type")
+		_, valueExists := d.GetOk("transaction_tracer.0.explain_query_plans.0.query_plan_threshold_value")
+
+		if queryPlanExists && !typeExists && !valueExists {
+			*errorsList = append(*errorsList, "at least one of `query_plan_threshold_type` or `query_plan_threshold_value` must be provided when `explain_query_plans` is set")
+		}
+
+		if typeExists && thresholdType == "VALUE" && !valueExists {
+			*errorsList = append(*errorsList, "`query_plan_threshold_value` must be set when `query_plan_threshold_type` is 'VALUE'")
+		}
+
+		if valueExists && (!typeExists || thresholdType != "VALUE") {
+			*errorsList = append(*errorsList, "`query_plan_threshold_type` must be set to 'VALUE' when `query_plan_threshold_value` is provided")
+		}
+
+		if typeExists && thresholdType == "APDEX_F" && valueExists {
+			*errorsList = append(*errorsList, "`query_plan_threshold_value` should not be set when `query_plan_threshold_type` is 'APDEX_F'")
+		}
+
+		transactionThresholdType, transactionTypeExists := d.GetOk("transaction_tracer.0.transaction_threshold_type")
+		_, transactionValueExists := d.GetOk("transaction_tracer.0.transaction_threshold_value")
+
+		if !transactionTypeExists && !transactionValueExists {
+			*errorsList = append(*errorsList, "at least one of `transaction_threshold_type` or `transaction_threshold_value` must be provided when `transaction_tracer` is set")
+		}
+
+		if transactionTypeExists && transactionThresholdType == "VALUE" && !transactionValueExists {
+			*errorsList = append(*errorsList, "`transaction_threshold_value` must be set when `transaction_threshold_type` is 'VALUE'")
+		}
+
+		if transactionValueExists && (!transactionTypeExists || transactionThresholdType != "VALUE") {
+			*errorsList = append(*errorsList, "`transaction_threshold_type` must be set to 'VALUE' when `transaction_threshold_value` is provided")
+		}
+
+		if transactionTypeExists && transactionThresholdType == "APDEX_F" && transactionValueExists {
+			*errorsList = append(*errorsList, "`transaction_threshold_value` should not be set when `transaction_threshold_type` is 'APDEX_F'")
+		}
+	}
+}
+
+func validateServerSideConfig(d *schema.ResourceDiff, errorsList *[]string) {
+	ServerSideConfig := d.Get("use_server_side_config").(bool)
+
+	attrList := []string{"transaction_tracer", "error_collector", "tracer_type", "enable_thread_profiler"}
+	var finalList []string
+	for _, value := range attrList {
+		_, valueBool := d.GetOk(value)
+		if valueBool && !ServerSideConfig {
+			finalList = append(finalList, value)
+		}
+	}
+
+	if len(finalList) > 0 {
+		*errorsList = append(*errorsList, fmt.Sprintf("use_server_side_config must be set to true when %v is configured", finalList))
+	}
+}
+
+// Custom validator that ensures fields are validated correctly
+func validateApplicationSettingsInput(ctx context.Context, d *schema.ResourceDiff, v interface{}) error {
+	var errorsList []string
+
+	_, nameExists := d.GetOk("name")
+	_, guidExists := d.GetOk("guid")
+
+	if !guidExists && !nameExists {
+		return fmt.Errorf("at least one of `name` or `guid` must be provided")
+	}
+
+	validateServerSideConfig(d, &errorsList)
+	validateThresholds(d, &errorsList)
+	validateErrorCollector(d, &errorsList)
+
+	if len(errorsList) == 0 {
+		return nil
+	}
+
+	errorsString := "the following validation errors have been identified: \n"
+	for index, val := range errorsList {
+		errorsString += fmt.Sprintf("(%d): %s\n", index+1, val)
+	}
+	return errors.New(errorsString)
+}
+
+func applicationSettingCommonSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"guid": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			ForceNew:    true,
+			Computed:    true,
+			Description: "The GUID of the application in New Relic.",
+		},
+		"is_imported": {
+			Type:     schema.TypeBool,
+			Computed: true,
+			Default:  nil,
+		},
+	}
+}
+
+func apmApplicationSettingsSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "The name of the application in New Relic.",
+		},
+		"app_apdex_threshold": {
+			Type:        schema.TypeFloat,
+			Optional:    true,
+			Description: "The response time threshold value for Apdex score calculation.",
+		},
+		"end_user_apdex_threshold": {
+			Type:        schema.TypeFloat,
+			Optional:    true,
+			Description: "Dummy field to support backward compatability of previous version.should be removed with next major version.",
+		},
+		"enable_real_user_monitoring": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Dummy field to support backward compatability of previous version.should be removed with next major version.",
+		},
+		"use_server_side_config": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable or disable server side monitoring.",
+		},
+		"transaction_tracer": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Configuration for transaction tracing.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"transaction_threshold_type": {
+						Type:         schema.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringInSlice([]string{"APDEX_F", "VALUE"}, false),
+						Description:  "The type of threshold for transaction tracing, either 'APDEX_F' or 'VALUE'.",
+					},
+					"transaction_threshold_value": {
+						Type:        schema.TypeFloat,
+						Optional:    true,
+						Description: "The threshold value for transaction tracing when 'transaction_threshold_type' is 'VALUE'.",
+					},
+					"sql": {
+						Type:        schema.TypeList,
+						Optional:    true,
+						MinItems:    1,
+						MaxItems:    1,
+						Description: "Configuration for SQL tracing.",
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"record_sql": {
+									Type:         schema.TypeString,
+									Required:     true,
+									ValidateFunc: validation.StringInSlice([]string{"OBFUSCATED", "OFF", "RAW"}, true),
+									Description:  "The level of SQL recording, either 'OBFUSCATED', 'OFF', or 'RAW'.",
+								},
+							},
+						},
+					},
+					"stack_trace_threshold_value": {
+						Type:        schema.TypeFloat,
+						Required:    true,
+						Description: "The response time threshold value for capturing stack traces of SQL queries.",
+					},
+					"explain_query_plans": {
+						Type:        schema.TypeList,
+						Optional:    true,
+						Description: "Configuration for explain plans of slow SQL queries.",
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"query_plan_threshold_type": {
+									Type:         schema.TypeString,
+									Optional:     true,
+									ValidateFunc: validation.StringInSlice([]string{"APDEX_F", "VALUE"}, false),
+									Description:  "The type of threshold for explain plans, either 'APDEX_F' or 'VALUE'.",
+								},
+								"query_plan_threshold_value": {
+									Type:        schema.TypeFloat,
+									Optional:    true,
+									Description: "The threshold value for explain plans when 'query_plan_threshold_type' is 'VALUE'.",
+								},
+							},
+						},
+					},
+				},
 			},
-			"app_apdex_threshold": {
-				Type:     schema.TypeFloat,
-				Required: true,
+		},
+		"error_collector": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Configuration for error collection.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"expected_error_classes": {
+						Type:        schema.TypeList,
+						Elem:        &schema.Schema{Type: schema.TypeString},
+						Optional:    true,
+						Description: "A list of error classes that are expected and should not trigger alerts.",
+					},
+					"expected_error_codes": {
+						Type:        schema.TypeList,
+						Elem:        &schema.Schema{Type: schema.TypeString},
+						Optional:    true,
+						Description: "A list of error codes that are expected and should not trigger alerts.",
+					},
+					"ignored_error_classes": {
+						Type:        schema.TypeList,
+						Elem:        &schema.Schema{Type: schema.TypeString},
+						Optional:    true,
+						Description: "A list of error classes that should be ignored.",
+					},
+					"ignored_error_codes": {
+						Type:        schema.TypeList,
+						Elem:        &schema.Schema{Type: schema.TypeString},
+						Optional:    true,
+						Description: "A list of error codes that should be ignored.",
+					},
+				},
 			},
-			"end_user_apdex_threshold": {
-				Type:     schema.TypeFloat,
-				Required: true,
-			},
-			"enable_real_user_monitoring": {
-				Type:     schema.TypeBool,
-				Required: true,
-			},
+		},
+		"enable_slow_sql": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Samples and reports the slowest database queries in your traces.",
+		},
+		"tracer_type": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice([]string{"CROSS_APPLICATION_TRACER", "DISTRIBUTED_TRACING", "NONE", "OPT_OUT"}, true),
+			Description:  "The type of tracer to use, either 'CROSS_APPLICATION_TRACER', 'DISTRIBUTED_TRACING', 'NONE', or 'OPT_OUT'.",
+		},
+		"enable_thread_profiler": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Enable or disable the thread profiler.",
 		},
 	}
 }
 
 func resourceNewRelicApplicationSettingsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*ProviderConfig).NewClient
 
-	userApp := expandApplication(d)
-
-	listParams := apm.ListApplicationsParams{
-		Name: userApp.Name,
-	}
-
-	result, err := client.APM.ListApplicationsWithContext(ctx, &listParams)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	var app *apm.Application
-
-	for _, a := range result {
-		if a.Name == userApp.Name {
-			app = a
-			break
-		}
-	}
-
-	if app == nil {
-		return diag.Errorf("the name '%s' does not match any New Relic applications", userApp.Name)
-	}
-
-	d.SetId(strconv.Itoa(app.ID))
-
-	log.Printf("[INFO] Importing New Relic application %v", userApp.Name)
 	return resourceNewRelicApplicationSettingsUpdate(ctx, d, meta)
 }
 
 func resourceNewRelicApplicationSettingsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*ProviderConfig).NewClient
 
-	userApp := expandApplication(d)
-	log.Printf("[INFO] Reading New Relic application %+v", userApp)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
 
-	app, err := client.APM.GetApplicationWithContext(ctx, userApp.ID)
+	log.Printf("[INFO] Reading New Relic application %+v", d.Id())
+
+	resp, err := client.Entities.GetEntityWithContext(ctx, common.EntityGUID(d.Id()))
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	log.Printf("[INFO] Read found New Relic application %+v\n\n\n", app)
+	if resp == nil {
+		d.SetId("")
+		return diag.FromErr(fmt.Errorf("no New Relic application found with given guid %s", d.Id()))
+	}
 
-	return diag.FromErr(flattenApplication(app, d))
+	var dig diag.Diagnostics
+	switch (*resp).(type) {
+	case *entities.ApmApplicationEntity:
+		entity := (*resp).(*entities.ApmApplicationEntity)
+		d.SetId(string(entity.GUID))
+		_ = d.Set("guid", string(entity.GUID))
+		dig = diag.FromErr(setAPMApplicationValues(d, entity.ApmSettings))
+	default:
+		dig = diag.FromErr(fmt.Errorf("problem in retrieving application with GUID %s", d.Id()))
+	}
+	return dig
 }
 
 func resourceNewRelicApplicationSettingsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderConfig).NewClient
 
-	userApp := expandApplication(d)
-
-	updateParams := apm.UpdateApplicationParams{
-		Name:     userApp.Name,
-		Settings: userApp.Settings,
+	_, guidExists := d.GetOk("guid")
+	_, nameExists := d.GetOk("name")
+	if nameExists && !guidExists {
+		entityRes, err := getEntityDetailsFromName(ctx, d, meta)
+		if entityRes != nil {
+			err = d.Set("guid", string((*entityRes).GetGUID()))
+		} else {
+			return diag.FromErr(err)
+		}
 	}
 
-	log.Printf("[INFO] Updating New Relic application %+v with params: %+v", userApp, updateParams)
+	updateApplicationParams := expandApplication(d)
 
-	app, err := client.APM.UpdateApplicationWithContext(ctx, userApp.ID, updateParams)
+	guid := d.Get("guid").(string)
+	log.Printf("[INFO] Updating New Relic application %+v with params: %+v", guid, updateApplicationParams)
+
+	agentApplicationSettingResult, err := client.AgentApplications.AgentApplicationSettingsUpdate(common.EntityGUID(guid), *updateApplicationParams)
+
 	if err != nil {
 		return diag.FromErr(err)
+	}
+	if agentApplicationSettingResult == nil {
+		return diag.FromErr(fmt.Errorf("something went wrong while Updating New Relic application"))
 	}
 
 	time.Sleep(2 * time.Second)
 
-	return diag.FromErr(flattenApplication(app, d))
+	d.SetId(string(agentApplicationSettingResult.GUID))
+	err = d.Set("is_imported", true)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceNewRelicApplicationSettingsRead(ctx, d, meta)
 }
 
 func resourceNewRelicApplicationSettingsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	// You can not delete application settings
-	return nil
+	// You can only delete applications and not application settings which not might be provisioned by this resource
+	var diags diag.Diagnostics
+	diags = append(diags, diag.Diagnostic{
+		Severity: diag.Warning,
+		Summary:  "Only browser, mobile, or APM applications that are not actively reporting data can be deleted via terraform and not just application settings. https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/application_settings",
+	})
+	return diags
+}
+
+func getEntityDetailsFromName(ctx context.Context, d *schema.ResourceData, meta interface{}) (*entities.EntityOutlineInterface, error) {
+	log.Printf("[INFO] Reading New Relic entities")
+
+	client := meta.(*ProviderConfig).NewClient
+	name := d.Get("name").(string)
+	name = escapeSingleQuote(name)
+	entityType := "APPLICATION"
+	domain := "APM"
+
+	query := buildEntitySearchQuery(name, domain, entityType, []interface{}{})
+
+	entityResults, err := client.Entities.GetEntitySearchByQueryWithContext(ctx,
+		entities.EntitySearchOptions{
+			CaseSensitiveTagMatching: true,
+		},
+		query,
+		[]entities.EntitySearchSortCriteria{},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if entityResults == nil {
+		return nil, fmt.Errorf("GetEntitySearchByQuery response was nil")
+	}
+
+	var entity *entities.EntityOutlineInterface
+	for _, e := range entityResults.Results.Entities {
+		// Conditional on case-sensitive match
+		str := e.GetName()
+		str = strings.TrimSpace(str)
+
+		name = revertEscapedSingleQuote(name)
+		if strings.Compare(str, name) == 0 || (strings.EqualFold(str, name)) {
+			entity = &e
+			break
+		}
+	}
+
+	if entity == nil {
+		return nil, fmt.Errorf("no entities found with the provided name, please ensure your name is valid")
+	}
+
+	return entity, nil
+
 }

--- a/newrelic/resource_newrelic_application_settings.go
+++ b/newrelic/resource_newrelic_application_settings.go
@@ -3,8 +3,9 @@ package newrelic
 import (
 	"context"
 	"fmt"
-	"github.com/newrelic/newrelic-client-go/v2/pkg/agentapplications"
 	"log"
+
+	"github.com/newrelic/newrelic-client-go/v2/pkg/agentapplications"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/newrelic/resource_newrelic_application_settings_test.go
+++ b/newrelic/resource_newrelic_application_settings_test.go
@@ -6,24 +6,26 @@ package newrelic
 import (
 	"fmt"
 	"os"
-	"strconv"
+	"regexp"
 	"testing"
 	"time"
+
+	"github.com/newrelic/newrelic-client-go/v2/pkg/entities"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
 )
 
 var (
 	testExpectedApplicationName string
+	testApplicationGUID         = "Mzk1NzUyNHxBUE18QVBQTElDQVRJT058NTc4ODU1MzYx"
 )
 
 func TestAccNewRelicApplicationSettings_Basic(t *testing.T) {
 	resourceName := "newrelic_application_settings.app"
-	testExpectedApplicationName = fmt.Sprintf("tf_test_%s", acctest.RandString(10))
-
+	testExpectedApplicationName = fmt.Sprintf("dummy_app_pro_test_%s", acctest.RandString(10))
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testPreCheck(t) },
 		Providers:    testAccProviders,
@@ -44,9 +46,41 @@ func TestAccNewRelicApplicationSettings_Basic(t *testing.T) {
 			},
 			// Test: Import
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: false,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateId:           testApplicationGUID,
+				ImportStateVerifyIgnore: []string{"is_imported"},
+			},
+		},
+	})
+}
+
+func TestAccNewRelicApplicationSettings_UserMonitoringValidation(t *testing.T) {
+	expectedMsg, _ := regexp.Compile("use_server_side_config must be set to true when transaction_tracer is configured")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccNewRelicApplicationConfigUserMonitoringValidation(testExpectedApplicationName),
+				ExpectError: expectedMsg,
+			},
+		},
+	})
+}
+
+func TestAccNewRelicApplicationSettings_TransactionTracerValidation(t *testing.T) {
+	expectedMsg, _ := regexp.Compile("`transaction_threshold_value` must be set when `transaction_threshold_type` is 'VALUE'")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccNewRelicApplicationConfigTransactionTracerValidation(testExpectedApplicationName),
+				ExpectError: expectedMsg,
 			},
 		},
 	})
@@ -57,50 +91,135 @@ func testAccCheckNewRelicApplicationDestroy(s *terraform.State) error {
 	return nil
 }
 
-// The test application for this data source is created in provider_test.go
 func testAccNewRelicApplicationConfig() string {
 	return fmt.Sprintf(`
-resource "newrelic_application_settings" "app" {
-	name = "%s"
-	app_apdex_threshold = "0.9"
-	end_user_apdex_threshold = "0.8"
-	enable_real_user_monitoring = true
-}
-`, testExpectedApplicationName)
+		resource "newrelic_application_settings" "app" {
+			guid = "%[2]s"
+			name = "%[1]s"
+			app_apdex_threshold = "0.5"
+			use_server_side_config = true
+			transaction_tracer{
+			   explain_query_plans{
+				 query_plan_threshold_value = "0.5"
+				 query_plan_threshold_type = "VALUE"
+			   }
+			   stack_trace_threshold_value = "0.5"
+			   transaction_threshold_value = "0.5"
+			   transaction_threshold_type = "VALUE"
+			   sql{
+				 record_sql = "RAW"
+			   }
+			}
+			error_collector{
+			  expected_error_classes = []
+			  expected_error_codes = []
+			  ignored_error_classes = []
+			  ignored_error_codes = []
+			}
+			tracer_type = "OPT_OUT"
+			enable_thread_profiler = false
+		}`, testExpectedApplicationName, testApplicationGUID)
 }
 
 func testAccNewRelicApplicationConfigUpdated(name string) string {
 	return fmt.Sprintf(`
-resource "newrelic_application_settings" "app" {
-	name = "%s-updated"
-	app_apdex_threshold = "0.8"
-	end_user_apdex_threshold = "0.7"
-	enable_real_user_monitoring = false
-}
-`, name)
+		resource "newrelic_application_settings" "app" {
+			guid = "%[2]s"
+			name = "%[1]s-updated"
+			app_apdex_threshold = "0.5"
+			use_server_side_config = true
+			transaction_tracer{
+			   explain_query_plans{
+				 query_plan_threshold_value = "0.5"
+				 query_plan_threshold_type = "VALUE"
+			   }
+			   stack_trace_threshold_value = "0.5"
+			   transaction_threshold_value = "0.5"
+			   transaction_threshold_type = "VALUE"
+			   sql{
+				 record_sql = "RAW"
+			   }
+			}
+			error_collector{
+			  expected_error_classes = []
+			  expected_error_codes = []
+			  ignored_error_classes = []
+			  ignored_error_codes = []
+			}
+			tracer_type = "OPT_OUT"
+			enable_thread_profiler = false
+		}`, name, testApplicationGUID)
 }
 
-func testAccCheckNewRelicApplicationExists(n string) resource.TestCheckFunc {
+func testAccNewRelicApplicationConfigUserMonitoringValidation(name string) string {
+	return fmt.Sprintf(`
+		resource "newrelic_application_settings" "app" {
+			guid = "%[2]s"
+			name = "%[1]s-updated"
+			app_apdex_threshold = "0.5"
+			use_server_side_config = false
+			transaction_tracer{
+			   explain_query_plans{
+				 query_plan_threshold_value = "0.5"
+				 query_plan_threshold_type = "VALUE"
+			   }
+			   stack_trace_threshold_value = "0.5"
+			   transaction_threshold_value = "0.5"
+			   transaction_threshold_type = "VALUE"
+			   sql{
+				 record_sql = "RAW"
+			   }
+			}
+		}`, name, testApplicationGUID)
+}
+
+func testAccNewRelicApplicationConfigTransactionTracerValidation(name string) string {
+	return fmt.Sprintf(`
+		resource "newrelic_application_settings" "app" {
+			guid = "%[2]s"
+			name = "%[1]s-updated"
+			app_apdex_threshold = "0.5"
+			use_server_side_config = true
+			transaction_tracer{
+			   explain_query_plans{
+				 query_plan_threshold_value = "0.5"
+				 query_plan_threshold_type = "VALUE"
+			   }
+			   stack_trace_threshold_value = "0.5"
+			   transaction_threshold_type = "VALUE"
+			   sql{
+				 record_sql = "RAW"
+			   }
+			}
+		}`, name, testApplicationGUID)
+}
+
+func testAccCheckNewRelicApplicationExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("not found: %s", n)
-		}
+		rs, ok := s.RootModule().Resources[resourceName]
 
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no application ID is set")
 		}
 
-		id, err := strconv.ParseInt(rs.Primary.ID, 10, 32)
+		client := testAccProvider.Meta().(*ProviderConfig).NewClient
+
+		time.Sleep(2 * time.Second)
+		found, err := client.Entities.GetEntity(common.EntityGUID(rs.Primary.ID))
 		if err != nil {
-			return nil
+			return fmt.Errorf(err.Error())
 		}
 
-		client := testAccProvider.Meta().(*ProviderConfig).NewClient
-		_, err = client.APM.GetApplication(int(id))
-		if err != nil {
-			return err
+		res, foundOk := (*found).(*entities.ApmApplicationEntity)
+		if !foundOk {
+			return fmt.Errorf("no application found")
+		}
+		if res.GUID != common.EntityGUID(rs.Primary.ID) {
+			return fmt.Errorf("no application found")
 		}
 
 		return nil
@@ -115,26 +234,4 @@ func testPreCheck(t *testing.T) {
 	if v := os.Getenv("NEW_RELIC_LICENSE_KEY"); v == "" {
 		t.Skipf("NEW_RELIC_LICENSE_KEY must be set for acceptance tests")
 	}
-
-	testCreateApplication(t)
-
-	time.Sleep(5 * time.Second)
-}
-
-func testCreateApplication(t *testing.T) {
-	app, err := newrelic.NewApplication(
-		newrelic.ConfigAppName(testExpectedApplicationName),
-		newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
-	)
-
-	if err != nil {
-		t.Fatalf("Error setting up New Relic application: %s", err)
-	}
-
-	if err := app.WaitForConnection(30 * time.Second); err != nil {
-		t.Fatalf("Unable to setup New Relic application connection: %s", err)
-	}
-
-	app.RecordCustomEvent("terraform test", nil)
-	app.Shutdown(30 * time.Second)
 }

--- a/newrelic/structures_newrelic_application_settings.go
+++ b/newrelic/structures_newrelic_application_settings.go
@@ -3,15 +3,16 @@ package newrelic
 import (
 	"context"
 	"fmt"
-	"github.com/newrelic/newrelic-client-go/v2/pkg/agentapplications"
-	"github.com/newrelic/newrelic-client-go/v2/pkg/entities"
 	"log"
 	"strings"
+
+	"github.com/newrelic/newrelic-client-go/v2/pkg/agentapplications"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/entities"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// Getting the entity details from the name using entity search query to find out the linked GUID to support backward compatability of existing users
+// Getting the entity details from the name using entity search query to find out the linked GUID to support backward compatibility of existing users
 // NOTE : Revisit on this approach to support the name based application settings update in future as it introduces additional query call to fetch entity details. Instead, we can force customers to provide GUID
 func getEntityDetailsFromName(ctx context.Context, d *schema.ResourceData, meta interface{}) (*entities.EntityOutlineInterface, error) {
 	log.Printf("[INFO] Reading New Relic entities")

--- a/newrelic/structures_newrelic_application_settings.go
+++ b/newrelic/structures_newrelic_application_settings.go
@@ -1,55 +1,311 @@
 package newrelic
 
 import (
-	"log"
-	"strconv"
+	"fmt"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/agentapplications"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/entities"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/newrelic/newrelic-client-go/v2/pkg/apm"
 )
 
-func expandApplication(d *schema.ResourceData) *apm.Application {
-	a := apm.Application{
-		Name: d.Get("name").(string),
-	}
+func expandApmConfigValues(d *schema.ResourceData) *agentapplications.AgentApplicationSettingsApmConfigInput {
 
-	id, err := strconv.Atoi(d.Id())
-	if err != nil {
-		log.Printf("[ERROR] expanding application, id %s", err)
+	apmConfig := agentapplications.AgentApplicationSettingsApmConfigInput{}
+	if v, ok := d.GetOk("app_apdex_threshold"); ok {
+		apmConfig.ApdexTarget = v.(float64)
+	}
+	apmConfig.UseServerSideConfig = getBoolPointer(d.Get("use_server_side_config").(bool))
+	if apmConfig == (agentapplications.AgentApplicationSettingsApmConfigInput{}) {
+		return nil
+	}
+	return &apmConfig
+}
+
+func expandTransactionTracerValues(d *schema.ResourceData) *agentapplications.AgentApplicationSettingsTransactionTracerInput {
+
+	tracer := agentapplications.AgentApplicationSettingsTransactionTracerInput{}
+
+	if _, ok := d.GetOk("transaction_tracer"); ok {
+		flag := true
+		tracer.Enabled = &flag
 	} else {
-		a.ID = id
+		flag := false
+		tracer.Enabled = &flag
+	}
+	if v, ok := d.GetOk("transaction_tracer.0.transaction_threshold_type"); ok {
+		tracer.TransactionThresholdType = agentapplications.AgentApplicationSettingsThresholdTypeEnum(v.(string))
+	}
+	if v, ok := d.GetOk("transaction_tracer.0.transaction_threshold_value"); ok {
+		tracer.TransactionThresholdValue = getFloatPointer(v.(float64))
+	}
+	if _, ok := d.GetOk("transaction_tracer.0.explain_query_plans"); ok {
+		flag := true
+		tracer.ExplainEnabled = &flag
+	} else {
+		flag := false
+		tracer.ExplainEnabled = &flag
+	}
+	if v, ok := d.GetOk("transaction_tracer.0.explain_query_plans.0.query_plan_threshold_value"); ok {
+		tracer.ExplainThresholdValue = getFloatPointer(v.(float64))
+	}
+	if v, ok := d.GetOk("transaction_tracer.0.explain_query_plans.0.query_plan_threshold_type"); ok {
+		tracer.ExplainThresholdType = agentapplications.AgentApplicationSettingsThresholdTypeEnum(v.(string))
+	}
+	if _, ok := d.GetOk("transaction_tracer.0.sql"); ok {
+		flag := true
+		tracer.LogSql = &flag
+	} else {
+		flag := false
+		tracer.LogSql = &flag
+	}
+	if v, ok := d.GetOk("transaction_tracer.0.sql.0.record_sql"); ok {
+		tracer.RecordSql = agentapplications.AgentApplicationSettingsRecordSqlEnum(v.(string))
+	}
+	if v, ok := d.GetOk("transaction_tracer.0.stack_trace_threshold_value"); ok {
+		tracer.StackTraceThreshold = getFloatPointer(v.(float64))
 	}
 
-	a.Settings.AppApdexThreshold = d.Get("app_apdex_threshold").(float64)
-	a.Settings.EndUserApdexThreshold = d.Get("end_user_apdex_threshold").(float64)
-	a.Settings.EnableRealUserMonitoring = d.Get("enable_real_user_monitoring").(bool)
+	if tracer == (agentapplications.AgentApplicationSettingsTransactionTracerInput{}) {
+		return nil
+	}
+
+	return &tracer
+}
+
+func expandErrorCollectorValues(d *schema.ResourceData) *agentapplications.AgentApplicationSettingsErrorCollectorInput {
+
+	collector := agentapplications.AgentApplicationSettingsErrorCollectorInput{}
+
+	if _, ok := d.GetOk("error_collector"); ok {
+		flag := true
+		collector.Enabled = &flag
+	} else {
+		flag := false
+		collector.Enabled = &flag
+	}
+	if v, ok := d.GetOk("error_collector.0.expected_error_classes"); ok {
+		collector.ExpectedErrorClasses = convertInterfaceToStringSlice(v)
+	}
+	if v, ok := d.GetOk("error_collector.0.expected_error_codes"); ok {
+		strSlice := convertInterfaceToStringSlice(v)
+		var httpStatusSlice []agentapplications.AgentApplicationSettingsErrorCollectorHttpStatus
+		for _, str := range strSlice {
+			httpStatusSlice = append(httpStatusSlice, agentapplications.AgentApplicationSettingsErrorCollectorHttpStatus(str))
+		}
+		collector.ExpectedErrorCodes = httpStatusSlice
+	}
+	if v, ok := d.GetOk("error_collector.0.ignored_error_classes"); ok {
+		collector.IgnoredErrorClasses = convertInterfaceToStringSlice(v)
+	}
+	if v, ok := d.GetOk("error_collector.0.ignored_error_codes"); ok {
+		strSlice := convertInterfaceToStringSlice(v)
+		var httpStatusSlice []agentapplications.AgentApplicationSettingsErrorCollectorHttpStatus
+		for _, str := range strSlice {
+			httpStatusSlice = append(httpStatusSlice, agentapplications.AgentApplicationSettingsErrorCollectorHttpStatus(str))
+		}
+		collector.IgnoredErrorCodes = httpStatusSlice
+	}
+
+	if collector.Enabled == nil && len(collector.ExpectedErrorClasses) == 0 && len(collector.ExpectedErrorCodes) == 0 && len(collector.IgnoredErrorClasses) == 0 && len(collector.IgnoredErrorCodes) == 0 {
+		return nil
+	}
+
+	return &collector
+}
+
+func expandApplication(d *schema.ResourceData) *agentapplications.AgentApplicationSettingsUpdateInput {
+
+	a := agentapplications.AgentApplicationSettingsUpdateInput{}
+
+	if v, ok := d.GetOk("name"); ok { // alias
+		a.Alias = getStringPointer(v.(string))
+	}
+
+	slowSQL := &agentapplications.AgentApplicationSettingsSlowSqlInput{}
+	slowSQL.Enabled = getBoolPointer(d.Get("enable_slow_sql").(bool))
+	a.SlowSql = slowSQL
+
+	TracerType := &agentapplications.AgentApplicationSettingsTracerTypeInput{}
+	TracerType.Value = "NONE"
+	a.TracerType = TracerType
+	if v, ok := d.GetOk("tracer_type"); ok { // tracer type
+		TracerType.Value = agentapplications.AgentApplicationSettingsTracer(v.(string))
+		a.TracerType = TracerType
+	}
+
+	ThreadProfiler := &agentapplications.AgentApplicationSettingsThreadProfilerInput{}
+	ThreadProfiler.Enabled = getBoolPointer(d.Get("enable_thread_profiler").(bool))
+	a.ThreadProfiler = ThreadProfiler
+
+	// apm settings
+	a.ApmConfig = expandApmConfigValues(d) // APM config
+
+	a.TransactionTracer = expandTransactionTracerValues(d) // transaction_tracing
+
+	a.ErrorCollector = expandErrorCollectorValues(d) // error_collector
 
 	return &a
 }
 
-func flattenApplication(a *apm.Application, d *schema.ResourceData) error {
-	d.SetId(strconv.Itoa(a.ID))
+// setting APM values
+func setAPMApplicationValues(d *schema.ResourceData, ApmSettings entities.AgentApplicationSettingsApmBase) error {
 	var err error
+	isImported := d.Get("is_imported").(bool)
 
-	err = d.Set("name", a.Name)
-	if err != nil {
+	if err = setBasicAPMValues(d, ApmSettings, isImported); err != nil {
 		return err
 	}
-
-	err = d.Set("app_apdex_threshold", a.Settings.AppApdexThreshold)
-	if err != nil {
+	if err = setTransactionTracerValues(d, ApmSettings, isImported); err != nil {
 		return err
 	}
-
-	err = d.Set("end_user_apdex_threshold", a.Settings.EndUserApdexThreshold)
-	if err != nil {
-		return err
-	}
-
-	err = d.Set("enable_real_user_monitoring", a.Settings.EnableRealUserMonitoring)
-	if err != nil {
+	if err = setErrorCollectorValues(d, ApmSettings, isImported); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func setBasicAPMValues(d *schema.ResourceData, ApmSettings entities.AgentApplicationSettingsApmBase, isImported bool) error {
+	var err error
+	if _, ok := d.GetOk("name"); ok || !isImported {
+		if err = d.Set("name", ApmSettings.Alias); err != nil {
+			return err
+		}
+	}
+	if _, ok := d.GetOk("app_apdex_threshold"); ok || !isImported {
+		if err = d.Set("app_apdex_threshold", ApmSettings.ApmConfig.ApdexTarget); err != nil {
+			return fmt.Errorf("[DEBUG] Error setting app_apdex_threshold value : %#v", err)
+		}
+	}
+	if _, ok := d.GetOk("use_server_side_config"); ok || !isImported {
+		if err = d.Set("use_server_side_config", ApmSettings.ApmConfig.UseServerSideConfig); err != nil {
+			return fmt.Errorf("[DEBUG] Error setting use_server_side_config value : %#v", err)
+		}
+	}
+	if _, ok := d.GetOk("enable_slow_sql"); ok || !isImported {
+		if err = d.Set("enable_slow_sql", ApmSettings.SlowSql.Enabled); err != nil {
+			return fmt.Errorf("[DEBUG] Error setting enable_slow_sql value : %#v", err)
+		}
+	}
+	if _, ok := d.GetOk("enable_thread_profiler"); ok || !isImported {
+		if err = d.Set("enable_thread_profiler", ApmSettings.ThreadProfiler.Enabled); err != nil {
+			return fmt.Errorf("[DEBUG] Error setting thread profiler value : %#v", err)
+		}
+	}
+	if _, ok := d.GetOk("tracer_type"); ok || !isImported {
+		if err = d.Set("tracer_type", ApmSettings.TracerType); err != nil {
+			return fmt.Errorf("[DEBUG] Error setting tracer type value : %#v", err)
+		}
+	}
+	return nil
+}
+
+func setTransactionTracerValues(d *schema.ResourceData, ApmSettings entities.AgentApplicationSettingsApmBase, isImported bool) error {
+	if _, ok := d.GetOk("transaction_tracer"); ok || !isImported {
+		if err := flattenTransactionTracingValues(d, ApmSettings.TransactionTracer); err != nil {
+			return fmt.Errorf("[DEBUG] Error setting transaction tracer values : %#v", err)
+		}
+	}
+	return nil
+}
+
+func setErrorCollectorValues(d *schema.ResourceData, ApmSettings entities.AgentApplicationSettingsApmBase, isImported bool) error {
+	if _, ok := d.GetOk("error_collector"); ok || !isImported {
+		if err := flattenErrorCollectorValues(d, ApmSettings.ErrorCollector); err != nil {
+			return fmt.Errorf("[DEBUG] Error setting error collector values : %#v", err)
+		}
+	}
+	return nil
+}
+
+func flattenTransactionTracingValues(d *schema.ResourceData, in entities.AgentApplicationSettingsTransactionTracer) error {
+	isImported := d.Get("is_imported").(bool)
+	var err error
+	transactionTracingValues := map[string]interface{}{
+		"stack_trace_threshold_value": 0,
+		"transaction_threshold_value": 0,
+		"explain_query_plans":         make([]interface{}, 0),
+		"sql":                         make([]interface{}, 0),
+	}
+
+	_, ok := d.GetOk("transaction_tracer")
+	if (in.Enabled && ok) || !isImported {
+		transactionTracingValues["stack_trace_threshold_value"] = in.StackTraceThreshold
+		transactionTracingValues["transaction_threshold_type"] = in.TransactionThresholdType
+		transactionTracingValues["transaction_threshold_value"] = in.TransactionThresholdValue
+
+		if in.ExplainEnabled || !isImported {
+			explainQueryPlans := map[string]interface{}{}
+			explainQueryPlans["query_plan_threshold_value"] = in.ExplainThresholdValue
+			explainQueryPlans["query_plan_threshold_type"] = in.ExplainThresholdType
+			transactionTracingValues["explain_query_plans"] = []interface{}{explainQueryPlans}
+		}
+
+		if in.LogSql || !isImported {
+			logSQLValues := map[string]interface{}{}
+			logSQLValues["record_sql"] = in.RecordSql
+			transactionTracingValues["sql"] = []interface{}{logSQLValues}
+		}
+		err = d.Set("transaction_tracer", []interface{}{transactionTracingValues})
+	} else {
+		err = d.Set("transaction_tracer", nil)
+	}
+
+	return err
+}
+
+func flattenErrorCollectorValues(d *schema.ResourceData, in entities.AgentApplicationSettingsErrorCollector) error {
+	isImported := d.Get("is_imported").(bool)
+	var err error
+	errorCollectorValues := map[string]interface{}{
+		"expected_error_classes": in.ExpectedErrorClasses,
+		"expected_error_codes":   in.ExpectedErrorCodes,
+		"ignored_error_classes":  in.IgnoredErrorClasses,
+		"ignored_error_codes":    in.IgnoredErrorCodes,
+	}
+
+	_, ok := d.GetOk("error_collector")
+	if (in.Enabled && ok) || !isImported {
+		var expectedErrorClasses []string
+		var expectedErrorCodes []string
+		var ignoredErrorClasses []string
+		var ignoredErrorCodes []string
+		if _, ok := d.GetOk("expected_error_classes"); ok || !isImported {
+			for _, code := range in.ExpectedErrorClasses {
+				expectedErrorClasses = append(expectedErrorClasses, code)
+			}
+			errorCollectorValues["expected_error_classes"] = expectedErrorClasses
+		} else {
+			errorCollectorValues["expected_error_classes"] = []string{}
+		}
+		if _, ok := d.GetOk("expected_error_codes"); ok || !isImported {
+			for _, code := range in.ExpectedErrorCodes {
+				expectedErrorCodes = append(expectedErrorCodes, string(code))
+			}
+			errorCollectorValues["expected_error_codes"] = expectedErrorCodes
+		} else {
+			errorCollectorValues["expected_error_codes"] = []string{}
+		}
+		if _, ok := d.GetOk("ignored_error_classes"); ok || !isImported {
+			for _, code := range in.IgnoredErrorClasses {
+				ignoredErrorClasses = append(ignoredErrorClasses, code)
+			}
+			errorCollectorValues["ignored_error_classes"] = ignoredErrorClasses
+		} else {
+			errorCollectorValues["ignored_error_classes"] = []string{}
+		}
+		if _, ok := d.GetOk("ignored_error_codes"); ok || !isImported {
+			for _, code := range in.IgnoredErrorCodes {
+				ignoredErrorCodes = append(ignoredErrorCodes, string(code))
+			}
+			errorCollectorValues["ignored_error_codes"] = ignoredErrorCodes
+		} else {
+			errorCollectorValues["ignored_error_classes"] = []string{}
+		}
+
+		err = d.Set("error_collector", []interface{}{errorCollectorValues})
+	} else {
+		err = d.Set("error_collector", nil)
+	}
+	return err
 }

--- a/newrelic/structures_newrelic_application_settings.go
+++ b/newrelic/structures_newrelic_application_settings.go
@@ -2,6 +2,7 @@ package newrelic
 
 import (
 	"fmt"
+
 	"github.com/newrelic/newrelic-client-go/v2/pkg/agentapplications"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/entities"
 
@@ -271,9 +272,7 @@ func flattenErrorCollectorValues(d *schema.ResourceData, in entities.AgentApplic
 		var ignoredErrorClasses []string
 		var ignoredErrorCodes []string
 		if _, ok := d.GetOk("expected_error_classes"); ok || !isImported {
-			for _, code := range in.ExpectedErrorClasses {
-				expectedErrorClasses = append(expectedErrorClasses, code)
-			}
+			expectedErrorClasses = append(expectedErrorClasses, in.ExpectedErrorClasses...)
 			errorCollectorValues["expected_error_classes"] = expectedErrorClasses
 		} else {
 			errorCollectorValues["expected_error_classes"] = []string{}
@@ -287,9 +286,7 @@ func flattenErrorCollectorValues(d *schema.ResourceData, in entities.AgentApplic
 			errorCollectorValues["expected_error_codes"] = []string{}
 		}
 		if _, ok := d.GetOk("ignored_error_classes"); ok || !isImported {
-			for _, code := range in.IgnoredErrorClasses {
-				ignoredErrorClasses = append(ignoredErrorClasses, code)
-			}
+			ignoredErrorClasses = append(ignoredErrorClasses, in.IgnoredErrorClasses...)
 			errorCollectorValues["ignored_error_classes"] = ignoredErrorClasses
 		} else {
 			errorCollectorValues["ignored_error_classes"] = []string{}

--- a/newrelic/structures_newrelic_application_settings.go
+++ b/newrelic/structures_newrelic_application_settings.go
@@ -271,13 +271,13 @@ func flattenErrorCollectorValues(d *schema.ResourceData, in entities.AgentApplic
 		var expectedErrorCodes []string
 		var ignoredErrorClasses []string
 		var ignoredErrorCodes []string
-		if _, ok := d.GetOk("expected_error_classes"); ok || !isImported {
+		if _, ok := d.GetOk("error_collector.0.expected_error_classes"); ok || !isImported {
 			expectedErrorClasses = append(expectedErrorClasses, in.ExpectedErrorClasses...)
 			errorCollectorValues["expected_error_classes"] = expectedErrorClasses
 		} else {
 			errorCollectorValues["expected_error_classes"] = []string{}
 		}
-		if _, ok := d.GetOk("expected_error_codes"); ok || !isImported {
+		if _, ok := d.GetOk("error_collector.0.expected_error_codes"); ok || !isImported {
 			for _, code := range in.ExpectedErrorCodes {
 				expectedErrorCodes = append(expectedErrorCodes, string(code))
 			}
@@ -285,13 +285,13 @@ func flattenErrorCollectorValues(d *schema.ResourceData, in entities.AgentApplic
 		} else {
 			errorCollectorValues["expected_error_codes"] = []string{}
 		}
-		if _, ok := d.GetOk("ignored_error_classes"); ok || !isImported {
+		if _, ok := d.GetOk("error_collector.0.ignored_error_classes"); ok || !isImported {
 			ignoredErrorClasses = append(ignoredErrorClasses, in.IgnoredErrorClasses...)
 			errorCollectorValues["ignored_error_classes"] = ignoredErrorClasses
 		} else {
 			errorCollectorValues["ignored_error_classes"] = []string{}
 		}
-		if _, ok := d.GetOk("ignored_error_codes"); ok || !isImported {
+		if _, ok := d.GetOk("error_collector.0.ignored_error_codes"); ok || !isImported {
 			for _, code := range in.IgnoredErrorCodes {
 				ignoredErrorCodes = append(ignoredErrorCodes, string(code))
 			}

--- a/testing/newrelic.tf
+++ b/testing/newrelic.tf
@@ -9,3 +9,4 @@ terraform {
 provider "newrelic" {
   region = "US" # US or EU
 }
+

--- a/website/docs/r/application_settings.html.markdown
+++ b/website/docs/r/application_settings.html.markdown
@@ -14,29 +14,62 @@ a reporting agent.
 Use this resource to manage configuration for an application that already
 exists in New Relic.
 
+~> **WARNING:** We encourage you to  use this resource to manage all application settings together not just a few to avoid potential issues like incompatibility or unexpected behavior.
+
 ## Example Usage
 
 ```hcl
 resource "newrelic_application_settings" "app" {
+  guid = "rhbwkguhfjkewqre4r9"
   name = "my-app"
   app_apdex_threshold = "0.7"
-  end_user_apdex_threshold = "0.8"
-  enable_real_user_monitoring = false
+  use_server_side_config = true
+  transaction_tracer {
+    explain_query_plans {
+      query_plan_threshold_type  = "VALUE"
+      query_plan_threshold_value = "0.5"
+    }
+    sql {
+      record_sql = "RAW"
+    }
+    stack_trace_threshold_value = "0.5"
+    transaction_threshold_type = "VALUE"
+    transaction_threshold_value = "0.5"
+  }
+  error_collector {
+    expected_error_classes = []
+    expected_error_codes = []
+    ignored_error_classes = []
+    ignored_error_codes = []
+  }
+  tracer_type = "NONE"
+  enable_thread_profiler = true
 }
 ```
-
 ## Argument Reference
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the application in New Relic APM.
-* `app_apdex_threshold` - (Required) The apdex threshold for the New Relic application.
-* `end_user_apdex_threshold` - (Required) The user's apdex threshold for the New Relic application.
-* `enable_real_user_monitoring` - (Required) Enable or disable real user monitoring for the New Relic application.
-
-```
-Warning: This resource will use the account ID linked to your API key. At the moment it is not possible to dynamically set the account ID.
-```
+* `guid` - (Required) The GUID of the application in New Relic APM.
+* `name` - (Optional) A custom name or alias you can give the application in New Relic APM.
+* `app_apdex_threshold` - (Optional) The acceptable response time limit (Apdex threshold) for the application.
+* `use_server_side_config` - (Optional) Enable or disable server side monitoring for the New Relic application.
+* `transaction_tracer` - (Optional) Configuration block for transaction tracer. Providing this block enables transaction tracing. The following arguments are supported:
+  * `stack_trace_threshold_value` - (Optional) The response time threshold for collecting stack traces.
+  * `transaction_threshold_type` - (Optional) The type of threshold for transactions. Valid values are `VALUE`,`APDEX_F`(4 times your apdex target)
+  * `transaction_threshold_value` - (Optional) The threshold value for transactions(in seconds).
+  * `explain_query_plans` - (Optional) Configuration block for query plans. Including this block enables the capture of query plans. The following arguments are supported:
+    * `query_plan_threshold_value` - (Optional) The response time threshold for capturing query plans(in seconds).
+    * `query_plan_threshold_type` - (Optional) The type of threshold for query plans. Valid values are `VALUE`,`APDEX_F`(4 times your apdex target)
+  * `sql` - (Optional) Configuration block for SQL logging.  Including this block enables SQL logging. The following arguments are supported:
+    * `record_sql` - (Required) The level of SQL recording. Valid values ar `OBFUSCATED`,`OFF`,`RAW` (Mandatory attribute when `sql` block is provided).
+* `error_collector` - (Optional) Configuration block for error collection. Including this block enables the error collector. The following arguments are supported:
+  * `expected_error_classes` - (Optional) A list of expected error classes.
+  * `expected_error_codes` - (Optional) A list of expected error codes(any status code between 100-900).
+  * `ignored_error_classes` - (Optional) A list of ignored error classes.
+  * `ignored_error_codes` - (Optional) A list of ignored error codes(any status code between 100-900).
+* `tracer_type` - (Optional) Configures the type of tracer used. Valid values are `CROSS_APPLICATION_TRACER`, `DISTRIBUTED_TRACING`, `NONE`, `OPT_OUT`.
+* `enable_thread_profiler` - (Optional) Enable or disable the collection of thread profiling data.
 
 ## Attributes Reference
 
@@ -46,10 +79,10 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Applications can be imported using notation `application_id`, e.g.
+Applications can be imported using notation `application_guid`, e.g.
 
 ```
-$ terraform import newrelic_application_settings.main 6789012345
+$ terraform import newrelic_application_settings.main Mzk1NzUyNHQVRJNTxBUE18QVBQTElDc4ODU1MzYx
 ```
 
 ## Notes

--- a/website/docs/r/application_settings.html.markdown
+++ b/website/docs/r/application_settings.html.markdown
@@ -42,6 +42,7 @@ resource "newrelic_application_settings" "app" {
     ignored_error_classes = []
     ignored_error_codes = []
   }
+  enable_slow_sql = true
   tracer_type = "NONE"
   enable_thread_profiler = true
 }
@@ -68,6 +69,7 @@ The following arguments are supported:
   * `expected_error_codes` - (Optional) A list of expected error codes(any status code between 100-900).
   * `ignored_error_classes` - (Optional) A list of ignored error classes.
   * `ignored_error_codes` - (Optional) A list of ignored error codes(any status code between 100-900).
+* `enable_slow_sql` - (Optional) Enable or disable the collection of slowest database queries in your traces.
 * `tracer_type` - (Optional) Configures the type of tracer used. Valid values are `CROSS_APPLICATION_TRACER`, `DISTRIBUTED_TRACING`, `NONE`, `OPT_OUT`.
 * `enable_thread_profiler` - (Optional) Enable or disable the collection of thread profiling data.
 
@@ -87,5 +89,4 @@ $ terraform import newrelic_application_settings.main Mzk1NzUyNHQVRJNTxBUE18QVBQ
 
 ## Notes
 
--> **NOTE:** Applications that have reported data in the last twelve hours
-cannot be deleted.
+-> **NOTE:** The `newrelic_application_settings` resource cannot be deleted directly via Terraform. It can only reset application settings to their initial state.


### PR DESCRIPTION
**_Right now, this TF resource only supports a subset of the application settings available on the APM UI .
This PR concludes the changes required for `newrelic_application_settings` resource to add the missing set of configuration settings that are available on the UI_**

#### Test Configuration
```hcl
resource "newrelic_application_settings" "app" {
  guid                   = "Mxxxxxxxxxxxxxxxxxxxx"
  name                   = "XXXXXXXXXXXXXX"
  app_apdex_threshold    = "0.8"
  use_server_side_config = true
  transaction_tracer {
    explain_query_plans {
      query_plan_threshold_type  = "VALUE"
      query_plan_threshold_value = "0.8"
    }
    sql {
      record_sql = "OBFUSCATED"
    }
    stack_trace_threshold_value = "0.3"
    transaction_threshold_type  = "VALUE"
    transaction_threshold_value = "0.9"
  }
  error_collector {
    expected_error_classes = ["StandardError"]
    expected_error_codes   = ["403"]
    ignored_error_classes  = ["HTTPError"]
    ignored_error_codes    = ["407"]
  }

  tracer_type            = "DISTRIBUTED_TRACING"
  enable_thread_profiler = true
  enable_slow_sql        = true
}
```