### PR TITLE
fix(aws_govcloud): define a working AWS GovCloud module for cloud integration prerequisites

### DIFF
--- a/examples/modules/cloud-integrations/aws-govcloud/README.md
+++ b/examples/modules/cloud-integrations/aws-govcloud/README.md
@@ -1,0 +1,54 @@
+# AWS GovCloud Integration Module
+
+This Terraform module links an AWS GovCloud account to New Relic. It sets up the necessary IAM roles, policies, and configurations to enable metric collection from AWS GovCloud to New Relic.
+
+## Prerequisites
+
+- An AWS GovCloud account.
+- A New Relic account with the necessary permissions to create and manage cloud integrations.
+
+## How the Module Works
+
+This module creates several AWS resources, including IAM roles, policies, S3 buckets, and Kinesis Firehose delivery streams, to facilitate the integration between AWS GovCloud and New Relic. It also configures CloudWatch metric streams to send metrics to New Relic.
+
+It then uses the following resources based on cloud integrations from the New Relic Terraform Provider (the ARN used with the New Relic Terraform Provider's cloud integrations resources comes from the AWS resources deployed by the module, as stated above):
+
+- `newrelic_cloud_aws_govcloud_link_account`: Links the AWS GovCloud account to New Relic.
+- `newrelic_cloud_aws_govcloud_integrations`: Configures various AWS (GovCloud) services (e.g., EC2, S3, RDS) to send metrics to New Relic.
+
+## Usage
+
+> **Note:** Using this module requires a minimum version of `3.56.0` of the New Relic Terraform Provider.
+
+```hcl
+module "newrelic-aws-govcloud-integrations" {
+  source                  = "github.com/newrelic/terraform-provider-newrelic//examples/modules/cloud-integrations/aws-govcloud"
+  newrelic_account_id     = 1234321
+  name                    = "Test AWS GovCloud Integrations"
+
+  include_metric_filters = {
+    # "AWS/EC2" = [], # include ALL metrics from the EC2 namespace
+  }
+}
+```
+
+> **Note:** If you have cloned this repo and would like to deploy this configuration in `main.tf` in the `testing` folder, use the following path as the value of the `source` argument:
+
+```hcl
+  source                  = "../examples/modules/cloud-integrations/aws-govcloud"
+```
+
+### A Note on 'Applying' the Module :warning:
+
+When applying this module, please use reduced parallelism (ideally `--parallelism=1`) with the `terraform apply` command. The volume of resources in the module sometimes leads to a race condition where AWS resources are applied and the ARN is made available for the `newrelic_aws_govcloud_link_account` resource, but not yet updated on the AWS backend. This could sometimes lead to validation issues with the ARN. To avoid this, reduced parallelism can keep the apply operation streamlined and ensure adequate time for the ARN to be available and valid on the AWS backend.
+
+```sh
+terraform apply --parallelism=1
+```
+
+## Variables
+
+- `newrelic_account_id` - (Required) The New Relic account ID.
+- `name` - (Required) The name/identifier for the integration.
+- `exclude_metric_filters` - (Optional) A map of metric namespaces and metric names to exclude from the metric stream.
+- `include_metric_filters` - (Optional) A map of metric namespaces and metric names to include in the metric stream.

--- a/examples/modules/cloud-integrations/aws-govcloud/main.tf
+++ b/examples/modules/cloud-integrations/aws-govcloud/main.tf
@@ -4,8 +4,8 @@ data "aws_iam_policy_document" "newrelic_assume_policy" {
 
     principals {
       type = "AWS"
-      // This is the unique identifier for New Relic account on AWS, there is no need to change this
-      identifiers = [var.new_relic_aws_govcloud_account_id]
+      // This is the unique identifier for New Relic account on AWS GovCloud, there is no need to change this
+      identifiers = [266471868085]
     }
 
     condition {
@@ -67,14 +67,17 @@ resource "aws_iam_role_policy_attachment" "newrelic_aws_policy_attach" {
   policy_arn = aws_iam_policy.newrelic_aws_permissions.arn
 }
 
+resource "aws_iam_role_policy_attachment" "readonly_access_policy_attach" {
+  role       = aws_iam_role.newrelic_aws_role.name
+  policy_arn = "arn:aws-us-gov:iam::aws:policy/ReadOnlyAccess"
+}
+
 resource "newrelic_cloud_aws_govcloud_link_account" "newrelic_cloud_integration_push" {
   account_id             = var.newrelic_account_id
+  arn                    = aws_iam_role.newrelic_aws_role.arn
   metric_collection_mode = "PUSH"
   name                   = "${var.name} metric stream"
-  depends_on             = [aws_iam_role_policy_attachment.newrelic_aws_policy_attach]
-  access_key_id          = newrelic_api_access_key.newrelic_aws_access_key.key
-  secret_access_key      = newrelic_api_access_key.newrelic_aws_access_key.key
-  aws_account_id         = var.new_relic_aws_govcloud_account_id
+  depends_on             = [aws_iam_role_policy_attachment.newrelic_aws_policy_attach, aws_iam_role_policy_attachment.readonly_access_policy_attach]
 }
 
 resource "newrelic_api_access_key" "newrelic_aws_access_key" {
@@ -103,6 +106,11 @@ resource "aws_iam_role" "firehose_newrelic_role" {
   ]
 }
 EOF
+}
+
+resource "aws_iam_role_policy_attachment" "readonly_access_policy_attach_2" {
+  role       = aws_iam_role.firehose_newrelic_role.name
+  policy_arn = "arn:aws-us-gov:iam::aws:policy/ReadOnlyAccess"
 }
 
 resource "random_string" "s3-bucket-name" {
@@ -215,12 +223,10 @@ resource "aws_cloudwatch_metric_stream" "newrelic_metric_stream" {
 
 resource "newrelic_cloud_aws_govcloud_link_account" "newrelic_cloud_integration_pull" {
   account_id             = var.newrelic_account_id
+  arn                    = aws_iam_role.newrelic_aws_role.arn
   metric_collection_mode = "PULL"
   name                   = "${var.name} pull"
-  depends_on             = [aws_iam_role_policy_attachment.newrelic_aws_policy_attach]
-  access_key_id          = newrelic_api_access_key.newrelic_aws_access_key.key
-  secret_access_key      = newrelic_api_access_key.newrelic_aws_access_key.key
-  aws_account_id         = var.new_relic_aws_govcloud_account_id
+  depends_on             = [aws_iam_role_policy_attachment.newrelic_aws_policy_attach, aws_iam_role_policy_attachment.readonly_access_policy_attach]
 }
 
 resource "newrelic_cloud_aws_govcloud_integrations" "newrelic_cloud_integration_pull" {
@@ -297,7 +303,7 @@ POLICY
 
 resource "aws_iam_role_policy_attachment" "newrelic_configuration_recorder" {
   role       = aws_iam_role.newrelic_configuration_recorder.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWS_ConfigRole"
+  policy_arn = "arn:aws-us-gov:iam::aws:policy/service-role/AWS_ConfigRole"
 }
 
 resource "aws_config_configuration_recorder" "newrelic_recorder" {

--- a/examples/modules/cloud-integrations/aws-govcloud/providers.tf
+++ b/examples/modules/cloud-integrations/aws-govcloud/providers.tf
@@ -5,6 +5,8 @@ terraform {
     }
     newrelic = {
       source = "newrelic/newrelic"
+      version = ">= 3.56.0"
+      # Using this module requires a minimum version of `3.56.0` of the New Relic Terraform Provider.
     }
   }
 }

--- a/examples/modules/cloud-integrations/aws-govcloud/variables.tf
+++ b/examples/modules/cloud-integrations/aws-govcloud/variables.tf
@@ -18,8 +18,3 @@ variable "include_metric_filters" {
   type        = map(list(string))
   default     = {}
 }
-
-variable "new_relic_aws_govcloud_account_id" {
-  type    = string
-  default = "266471868085"
-}


### PR DESCRIPTION
Original Author: @vivek-tech-exp (#2807, #2811)

### Background

With the AWS GovCloud Link Account resource that was recently fixed with v3.56.0 of the New Relic Terraform Provider (#2809), as a follow up, the objective of this PR is to convert the AWS GovCloud module into a working module that can help customers set up AWS GovCloud infrastructure needed to exchange metrics with New Relic, and leverage `newrelic_cloud_aws_govcloud_link_account` and `newrelic_cloud_aws_govcloud_integrations` to set up AWS GovCloud monitoring.