### PR TITLE
feat(alerts): adds support for signal_seasonality for NRQL baseline conditions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,15 +4,12 @@ go 1.22
 
 toolchain go1.22.6
 
-// For pranav-new-relic/akane0915 : please get rid of the following line after the Go Client is released with the required changes
-replace github.com/newrelic/newrelic-client-go/v2 => github.com/akane0915/newrelic-client-go/v2 v2.0.0-20250414222500-8671fd0bd838
-
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.30.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.57.0
+	github.com/newrelic/newrelic-client-go/v2 v2.58.0
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 )

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,9 @@ go 1.22
 
 toolchain go1.22.6
 
+// For pranav-new-relic/akane0915 : please get rid of the following line after the Go Client is released with the required changes
+replace github.com/newrelic/newrelic-client-go/v2 => github.com/akane0915/newrelic-client-go/v2 v2.0.0-20250414222500-8671fd0bd838
+
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,6 @@ github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/akane0915/newrelic-client-go/v2 v2.0.0-20250414222500-8671fd0bd838 h1:ohg+U+5nkAcSWyh+/iB1wUfNDLcywHMEjTnQsqQBTB0=
-github.com/akane0915/newrelic-client-go/v2 v2.0.0-20250414222500-8671fd0bd838/go.mod h1:+RRjI3nDGWT3kLm9Oi3QxpBm70uu8q1upEHBVWCZFpo=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
@@ -272,6 +270,8 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
+github.com/newrelic/newrelic-client-go/v2 v2.58.0 h1:plkfLvFNrS5b38v2CHQG6j/Axh+aDP05caJSvWMyZ+w=
+github.com/newrelic/newrelic-client-go/v2 v2.58.0/go.mod h1:+RRjI3nDGWT3kLm9Oi3QxpBm70uu8q1upEHBVWCZFpo=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
+github.com/akane0915/newrelic-client-go/v2 v2.0.0-20250414222500-8671fd0bd838 h1:ohg+U+5nkAcSWyh+/iB1wUfNDLcywHMEjTnQsqQBTB0=
+github.com/akane0915/newrelic-client-go/v2 v2.0.0-20250414222500-8671fd0bd838/go.mod h1:+RRjI3nDGWT3kLm9Oi3QxpBm70uu8q1upEHBVWCZFpo=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
@@ -270,8 +272,6 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.57.0 h1:80DIUhk8IvxITO/ocgZvSa8cbNraOoJiCbU5aKOnUT8=
-github.com/newrelic/newrelic-client-go/v2 v2.57.0/go.mod h1:+RRjI3nDGWT3kLm9Oi3QxpBm70uu8q1upEHBVWCZFpo=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -394,10 +394,19 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Description:  "Seasonality under which a condition's signal(s) are evaluated. Valid values are: 'NEW_RELIC_CALCULATION', 'HOURLY', 'DAILY', 'WEEKLY', or 'NONE'. To have New Relic calculate seasonality automatically, set to 'NEW_RELIC_CALCULATION' (default). To turn off seasonality completely, set to 'NONE'.",
-				ValidateFunc: validation.StringInSlice([]string{"NEW_RELIC_CALCULATION", "HOURLY", "DAILY", "WEEKLY", "NONE"}, true),
+				ValidateFunc: validation.StringInSlice(
+					[]string{
+						string(alerts.NrqlSignalSeasonalities.NewRelicCalculation),
+						string(alerts.NrqlSignalSeasonalities.Hourly),
+						string(alerts.NrqlSignalSeasonalities.Daily),
+						string(alerts.NrqlSignalSeasonalities.Weekly),
+						string(alerts.NrqlSignalSeasonalities.None),
+					},
+					true,
+				),
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					// If a value is not provided and the condition uses the default value, don't show a diff. Also case insensitive.
-					return (strings.EqualFold(old, "NEW_RELIC_CALCULATION") && new == "") || strings.EqualFold(old, new)
+					return (strings.EqualFold(old, string(alerts.NrqlSignalSeasonalities.NewRelicCalculation)) && new == "") || strings.EqualFold(old, new)
 				},
 			},
 		},

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -396,7 +396,8 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 				Description:  "Seasonality under which a condition's signal(s) are evaluated. Valid values are: 'NEW_RELIC_CALCULATION', 'HOURLY', 'DAILY', 'WEEKLY', or 'NONE'. To have New Relic calculate seasonality automatically, set to 'NEW_RELIC_CALCULATION' (default). To turn off seasonality completely, set to 'NONE'.",
 				ValidateFunc: validation.StringInSlice([]string{"NEW_RELIC_CALCULATION", "HOURLY", "DAILY", "WEEKLY", "NONE"}, true),
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return strings.EqualFold(old, new) // Case fold this attribute when diffing
+					// If a value is not provided and the condition uses the default value, don't show a diff. Also case insensitive.
+					return (strings.EqualFold(old, "NEW_RELIC_CALCULATION") && new == "") || strings.EqualFold(old, new)
 				},
 			},
 		},

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -391,9 +391,9 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 				},
 			},
 			"signal_seasonality": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Description:  "Seasonality under which a condition's signal(s) are evaluated. Valid values are: 'NEW_RELIC_CALCULATION', 'HOURLY', 'DAILY', 'WEEKLY', or 'NONE'. To have New Relic calculate seasonality automatically, set to 'NEW_RELIC_CALCULATION' (default). To turn off seasonality completely, set to 'NONE'.",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Seasonality under which a condition's signal(s) are evaluated. Valid values are: 'NEW_RELIC_CALCULATION', 'HOURLY', 'DAILY', 'WEEKLY', or 'NONE'. To have New Relic calculate seasonality automatically, set to 'NEW_RELIC_CALCULATION' (default). To turn off seasonality completely, set to 'NONE'.",
 				ValidateFunc: validation.StringInSlice(
 					[]string{
 						string(alerts.NrqlSignalSeasonalities.NewRelicCalculation),

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -389,6 +389,15 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 					return strings.EqualFold(old, new) // Case fold this attribute when diffing
 				},
 			},
+			"signal_seasonality": {
+				Type: 				schema.TypeString,
+				Optional: 		true,
+				Description: 	"Seasonality under which a condition's signal(s) are evaluated. Valid values are: 'HOURLY', 'DAILY', 'WEEKLY', 'NONE', or null. To have New Relic calculate seasonality automatically, set to null (default). To turn off seasonality completely, set to 'NONE'.",
+				ValidateFunc: validation.StringInSlice([]string{"HOURLY", "DAILY", "WEEKLY", "NONE"}, true),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.EqualFold(old, new) // Case fold this attribute when diffing
+				},
+			},
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Second),

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -127,6 +127,7 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceImportStateWithMetadata(2, "type"),
 		},
+		CustomizeDiff: validateNrqlConditionAttributes,
 		Schema: map[string]*schema.Schema{
 			"policy_id": {
 				Type:        schema.TypeInt,

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -390,9 +390,9 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 				},
 			},
 			"signal_seasonality": {
-				Type: 				schema.TypeString,
-				Optional: 		true,
-				Description: 	"Seasonality under which a condition's signal(s) are evaluated. Valid values are: 'HOURLY', 'DAILY', 'WEEKLY', 'NONE', or null. To have New Relic calculate seasonality automatically, set to null (default). To turn off seasonality completely, set to 'NONE'.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "Seasonality under which a condition's signal(s) are evaluated. Valid values are: 'HOURLY', 'DAILY', 'WEEKLY', 'NONE', or null. To have New Relic calculate seasonality automatically, set to null (default). To turn off seasonality completely, set to 'NONE'.",
 				ValidateFunc: validation.StringInSlice([]string{"HOURLY", "DAILY", "WEEKLY", "NONE"}, true),
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					return strings.EqualFold(old, new) // Case fold this attribute when diffing

--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -392,8 +392,8 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 			"signal_seasonality": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Description:  "Seasonality under which a condition's signal(s) are evaluated. Valid values are: 'HOURLY', 'DAILY', 'WEEKLY', 'NONE', or null. To have New Relic calculate seasonality automatically, set to null (default). To turn off seasonality completely, set to 'NONE'.",
-				ValidateFunc: validation.StringInSlice([]string{"HOURLY", "DAILY", "WEEKLY", "NONE"}, true),
+				Description:  "Seasonality under which a condition's signal(s) are evaluated. Valid values are: 'NEW_RELIC_CALCULATION', 'HOURLY', 'DAILY', 'WEEKLY', or 'NONE'. To have New Relic calculate seasonality automatically, set to 'NEW_RELIC_CALCULATION' (default). To turn off seasonality completely, set to 'NONE'.",
+				ValidateFunc: validation.StringInSlice([]string{"NEW_RELIC_CALCULATION", "HOURLY", "DAILY", "WEEKLY", "NONE"}, true),
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					return strings.EqualFold(old, new) // Case fold this attribute when diffing
 				},

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -672,6 +672,7 @@ func TestAccNewRelicNrqlAlertCondition_SignalSeasonality(t *testing.T) {
 	resourceName := "newrelic_nrql_alert_condition.foo"
 	rName := acctest.RandString(5)
 	signalSeasonality := "daily"
+	signalSeasonalityNRCalc := "new_relic_calculation"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckEnvVars(t) },
@@ -688,10 +689,11 @@ func TestAccNewRelicNrqlAlertCondition_SignalSeasonality(t *testing.T) {
 					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),
 				),
 			},
-			// Test: Signal seasonality is nullable
+			// Test: New Relic Calculation is valid value for signal seasonality
 			{
-				Config: testAccNewRelicNrqlAlertConditionNullSignalSeasonality(
+				Config: testAccNewRelicNrqlAlertConditionWithSignalSeasonality(
 					rName,
+					signalSeasonalityNRCalc
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),
@@ -1491,39 +1493,4 @@ resource "newrelic_nrql_alert_condition" "foo" {
 }
 
 	`, name, signalSeasonality)
-}
-
-func testAccNewRelicNrqlAlertConditionNullSignalSeasonality(
-	name string,
-) string {
-	return fmt.Sprintf(`
-resource "newrelic_alert_policy" "foo" {
-	name = "tf-test-%[1]s"
-}
-
-resource "newrelic_nrql_alert_condition" "foo" {
-	policy_id   = newrelic_alert_policy.foo.id
-
-	name                           = "tf-test-%[1]s"
-	type                           = "baseline"
-	enabled                        = false
-	signal_seasonality             = null
-	violation_time_limit_seconds   = 3600
-	baseline_direction						 = "lower_only"
-	aggregation_delay              = 120
-	aggregation_method             = "event_flow"
-
-	nrql {
-		query             = "SELECT uniqueCount(hostname) FROM ComputeSample"
-	}
-
-	critical {
-		operator              = "above"
-		threshold             = 1.0
-		threshold_duration    = 120
-		threshold_occurrences = "ALL"
-	}
-}
-
-	`, name)
 }

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -678,7 +678,7 @@ func TestAccNewRelicNrqlAlertCondition_SignalSeasonality(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
 		Steps: []resource.TestStep{
-			// Test: Create baselin condition with signal seasonality
+			// Test: Create baseline condition with signal seasonality
 			{
 				Config: testAccNewRelicNrqlAlertConditionWithSignalSeasonality(
 					rName,

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -701,7 +701,6 @@ func TestAccNewRelicNrqlAlertCondition_SignalSeasonality(t *testing.T) {
 	})
 }
 
-
 func testAccCheckNewRelicNrqlAlertConditionDestroy(s *terraform.State) error {
 	providerConfig := testAccProvider.Meta().(*ProviderConfig)
 	client := providerConfig.NewClient
@@ -1528,5 +1527,3 @@ resource "newrelic_nrql_alert_condition" "foo" {
 
 	`, name)
 }
-
-

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -693,7 +693,7 @@ func TestAccNewRelicNrqlAlertCondition_SignalSeasonality(t *testing.T) {
 			{
 				Config: testAccNewRelicNrqlAlertConditionWithSignalSeasonality(
 					rName,
-					signalSeasonalityNRCalc
+					signalSeasonalityNRCalc,
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -1484,7 +1484,7 @@ resource "newrelic_nrql_alert_condition" "foo" {
 
 	critical {
 		operator              = "above"
-		threshold             = 0
+		threshold             = 1.0
 		threshold_duration    = 120
 		threshold_occurrences = "ALL"
 	}
@@ -1519,7 +1519,7 @@ resource "newrelic_nrql_alert_condition" "foo" {
 
 	critical {
 		operator              = "above"
-		threshold             = 0
+		threshold             = 1.0
 		threshold_duration    = 120
 		threshold_occurrences = "ALL"
 	}

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -668,6 +668,40 @@ func TestAccNewRelicNrqlAlertCondition_TitleTemplate(t *testing.T) {
 	})
 }
 
+func TestAccNewRelicNrqlAlertCondition_SignalSeasonality(t *testing.T) {
+	resourceName := "newrelic_nrql_alert_condition.foo"
+	rName := acctest.RandString(5)
+	signalSeasonality := "daily"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
+		Steps: []resource.TestStep{
+			// Test: Create baselin condition with signal seasonality
+			{
+				Config: testAccNewRelicNrqlAlertConditionWithSignalSeasonality(
+					rName,
+					signalSeasonality,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),
+				),
+			},
+			// Test: Signal seasonality is nullable
+			{
+				Config: testAccNewRelicNrqlAlertConditionNullSignalSeasonality(
+					rName,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),
+				),
+			},
+		},
+	})
+}
+
+
 func testAccCheckNewRelicNrqlAlertConditionDestroy(s *terraform.State) error {
 	providerConfig := testAccProvider.Meta().(*ProviderConfig)
 	client := providerConfig.NewClient
@@ -1423,3 +1457,76 @@ resource "newrelic_nrql_alert_condition" "foo" {
 }
 `, name, predictBy)
 }
+
+func testAccNewRelicNrqlAlertConditionWithSignalSeasonality(
+	name string,
+	signalSeasonality string,
+) string {
+	return fmt.Sprintf(`
+resource "newrelic_alert_policy" "foo" {
+	name = "tf-test-%[1]s"
+}
+
+resource "newrelic_nrql_alert_condition" "foo" {
+	policy_id   = newrelic_alert_policy.foo.id
+
+	name                           = "tf-test-%[1]s"
+	type                           = "baseline"
+	enabled                        = false
+	signal_seasonality             = "%[2]s"
+	violation_time_limit_seconds   = 3600
+	baseline_direction						 = "lower_only"
+	aggregation_delay              = 120
+	aggregation_method             = "event_flow"
+
+	nrql {
+		query             = "SELECT uniqueCount(hostname) FROM ComputeSample"
+	}
+
+	critical {
+		operator              = "above"
+		threshold             = 0
+		threshold_duration    = 120
+		threshold_occurrences = "ALL"
+	}
+}
+
+	`, name, signalSeasonality)
+}
+
+func testAccNewRelicNrqlAlertConditionNullSignalSeasonality(
+	name string,
+) string {
+	return fmt.Sprintf(`
+resource "newrelic_alert_policy" "foo" {
+	name = "tf-test-%[1]s"
+}
+
+resource "newrelic_nrql_alert_condition" "foo" {
+	policy_id   = newrelic_alert_policy.foo.id
+
+	name                           = "tf-test-%[1]s"
+	type                           = "baseline"
+	enabled                        = false
+	signal_seasonality             = null
+	violation_time_limit_seconds   = 3600
+	baseline_direction						 = "lower_only"
+	aggregation_delay              = 120
+	aggregation_method             = "event_flow"
+
+	nrql {
+		query             = "SELECT uniqueCount(hostname) FROM ComputeSample"
+	}
+
+	critical {
+		operator              = "above"
+		threshold             = 0
+		threshold_duration    = 120
+		threshold_occurrences = "ALL"
+	}
+}
+
+	`, name)
+}
+
+

--- a/newrelic/structures_newrelic_nrql_alert_condition.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition.go
@@ -78,6 +78,10 @@ func expandNrqlAlertConditionCreateInput(d *schema.ResourceData) (*alerts.NrqlCo
 		if attr, ok := d.GetOk("signal_seasonality"); ok {
 			seasonality := alerts.NrqlSignalSeasonality(strings.ToUpper(attr.(string)))
 			input.SignalSeasonality = &seasonality
+		} else {
+			// Null is equivalent to the default value of `NEW_RELIC_CALCULATION` in the API
+			seasonality := alerts.NrqlSignalSeasonalities.NewRelicCalculation
+			input.SignalSeasonality = &seasonality
 		}
 	}
 
@@ -144,6 +148,11 @@ func expandNrqlAlertConditionUpdateInput(d *schema.ResourceData) (*alerts.NrqlCo
 	if conditionType == "baseline" {
 		if attr, ok := d.GetOk("signal_seasonality"); ok {
 			seasonality := alerts.NrqlSignalSeasonality(strings.ToUpper(attr.(string)))
+			input.SignalSeasonality = &seasonality
+		} else {
+			// Null is equivalent to the default value of `NEW_RELIC_CALCULATION` in the API
+			// so this effectively allows the user to null out the signal seasonality on update
+			seasonality := alerts.NrqlSignalSeasonalities.NewRelicCalculation
 			input.SignalSeasonality = &seasonality
 		}
 	}

--- a/newrelic/structures_newrelic_nrql_alert_condition.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition.go
@@ -583,7 +583,10 @@ func flattenNrqlAlertCondition(accountID int, condition *alerts.NrqlAlertConditi
 
 	if conditionType == "baseline" {
 		_ = d.Set("baseline_direction", string(*condition.BaselineDirection))
-		_ = d.Set("signal_seasonality", string(*condition.SignalSeasonality))
+
+		if condition.SignalSeasonality != nil {
+			_ = d.Set("signal_seasonality", string(*condition.SignalSeasonality))
+		}
 	}
 
 	configuredNrql := d.Get("nrql.0").(map[string]interface{})

--- a/newrelic/structures_newrelic_nrql_alert_condition.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition.go
@@ -72,6 +72,13 @@ func expandNrqlAlertConditionCreateInput(d *schema.ResourceData) (*alerts.NrqlCo
 		}
 	}
 
+	if conditionType == "baseline" {
+		if attr, ok := d.GetOk("signal_seasonality"); ok {
+			seasonality := alerts.NrqlSignalSeasonality(strings.ToUpper(attr.(string)))
+			input.SignalSeasonality = &seasonality
+		}
+	}
+
 	if runbookURL, ok := d.GetOk("runbook_url"); ok {
 		input.RunbookURL = runbookURL.(string)
 	}
@@ -129,6 +136,13 @@ func expandNrqlAlertConditionUpdateInput(d *schema.ResourceData) (*alerts.NrqlCo
 			input.BaselineDirection = &direction
 		} else {
 			return nil, fmt.Errorf("attribute `%s` is required for nrql alert conditions of type `%+v`", "baseline_direction", conditionType)
+		}
+	}
+
+	if conditionType == "baseline" {
+		if attr, ok := d.GetOk("signal_seasonality"); ok {
+			seasonality := alerts.NrqlSignalSeasonality(strings.ToUpper(attr.(string)))
+			input.SignalSeasonality = &seasonality
 		}
 	}
 
@@ -569,6 +583,7 @@ func flattenNrqlAlertCondition(accountID int, condition *alerts.NrqlAlertConditi
 
 	if conditionType == "baseline" {
 		_ = d.Set("baseline_direction", string(*condition.BaselineDirection))
+		_ = d.Set("signal_seasonality", string(*condition.SignalSeasonality))
 	}
 
 	configuredNrql := d.Get("nrql.0").(map[string]interface{})

--- a/newrelic/structures_newrelic_nrql_alert_condition.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition.go
@@ -904,8 +904,7 @@ func validateSignalSeasonality(d *schema.ResourceDiff) error {
 	signalSeasonalityIsNotNil := !rawConfiguration.GetAttr("signal_seasonality").IsNull()
 
 	if signalSeasonalityIsNotNil {
-		return fmt.Errorf(`'signal_seasonality' is only valid on baseline conditions. Please remove this field or change the condition type.`)
+		return fmt.Errorf(`'signal_seasonality' is only valid on baseline conditions. Please remove this field or change the condition type`)
 	}
 	return nil
 }
-

--- a/newrelic/structures_newrelic_nrql_alert_condition.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition.go
@@ -1,6 +1,8 @@
 package newrelic
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -874,8 +876,8 @@ func validateNrqlConditionAttributes(ctx context.Context, d *schema.ResourceDiff
 
 	_, conditionType := d.GetChange("type")
 	if conditionType != nil {
-		isStaticCondition := strings.Contains(conditionType.(string), "static")
-		if isStaticCondition {
+		isNotBaselineCondition := !strings.Contains(conditionType.(string), "baseline")
+		if isNotBaselineCondition {
 			err := validateSignalSeasonality(d)
 			if err != nil {
 				errorsList = append(errorsList, err)
@@ -887,7 +889,7 @@ func validateNrqlConditionAttributes(ctx context.Context, d *schema.ResourceDiff
 		return nil
 	}
 
-	errorsString := "the following validation errors have been identified with the configuration of the synthetic monitor: \n"
+	errorsString := "the following validation errors have been identified with the configuration of the nrql alert condition: \n"
 
 	for index, val := range errorsList {
 		errorsString += fmt.Sprintf("(%d): %s\n", index+1, val)
@@ -902,7 +904,7 @@ func validateSignalSeasonality(d *schema.ResourceDiff) error {
 	signalSeasonalityIsNotNil := !rawConfiguration.GetAttr("signal_seasonality").IsNull()
 
 	if signalSeasonalityIsNotNil {
-		return fmt.Errorf(`'signal_seasonality' is not valid for static conditions. Please remove it or change to baseline condition.`)
+		return fmt.Errorf(`'signal_seasonality' is only valid on baseline conditions. Please remove this field or change the condition type.`)
 	}
 	return nil
 }

--- a/newrelic/structures_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition_test.go
@@ -398,6 +398,25 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 				},
 			},
 		},
+		"signal seasonality not nill": {
+			Data: map[string]interface{}{
+				"nrql":           []interface{}{nrql},
+				"signal_seasonality": "daily",
+			},
+			Expanded: &alerts.NrqlConditionCreateInput{
+				NrqlConditionCreateBase: alerts.NrqlConditionCreateBase{},
+				SignalSeasonality: &signalSeasonality,
+			},
+		},
+		"signal seasonality nill": {
+			Data: map[string]interface{}{
+				"nrql":           []interface{}{nrql},
+				"signal_seasonality": nil,
+			},
+			Expanded: &alerts.NrqlConditionCreateInput{
+				NrqlConditionCreateBase: alerts.NrqlConditionCreateBase{},
+			},
+		},
 	}
 
 	r := resourceNewRelicNrqlAlertCondition()

--- a/newrelic/structures_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition_test.go
@@ -695,6 +695,7 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 		switch condition.Type {
 		case alerts.NrqlConditionTypes.Baseline:
 			require.Equal(t, string(alerts.NrqlBaselineDirections.LowerOnly), d.Get("baseline_direction").(string))
+			require.Equal(t, string(alerts.NrqlSignalSeasonalities.Daily), d.Get("signal_seasonality").(string))
 			require.Equal(t, 120, d.Get("expiration_duration").(int))
 			require.True(t, d.Get("open_violation_on_expiration").(bool))
 			require.True(t, d.Get("close_violations_on_expiration").(bool))

--- a/newrelic/structures_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition_test.go
@@ -398,19 +398,19 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 				},
 			},
 		},
-		"signal seasonality not nill": {
+		"signal seasonality not nil": {
 			Data: map[string]interface{}{
-				"nrql":           []interface{}{nrql},
+				"nrql":               []interface{}{nrql},
 				"signal_seasonality": "daily",
 			},
 			Expanded: &alerts.NrqlConditionCreateInput{
 				NrqlConditionCreateBase: alerts.NrqlConditionCreateBase{},
-				SignalSeasonality: &signalSeasonality,
+				SignalSeasonality:       &signalSeasonality,
 			},
 		},
-		"signal seasonality nill": {
+		"signal seasonality nil": {
 			Data: map[string]interface{}{
-				"nrql":           []interface{}{nrql},
+				"nrql":               []interface{}{nrql},
 				"signal_seasonality": nil,
 			},
 			Expanded: &alerts.NrqlConditionCreateInput{

--- a/newrelic/structures_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition_test.go
@@ -51,6 +51,8 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 
 	titleTemplate := "Title {{template}}"
 
+	signalSeasonality := alerts.NrqlSignalSeasonalities.Daily
+
 	cases := map[string]struct {
 		Data         map[string]interface{}
 		ExpectErr    bool
@@ -625,6 +627,7 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 	nrqlConditionBaseline.Type = alerts.NrqlConditionTypes.Baseline
 	nrqlConditionBaseline.BaselineDirection = &alerts.NrqlBaselineDirections.LowerOnly
 	nrqlConditionBaseline.EntityGUID = common.EntityGUID("NDAwMzA0fEFPTkRJVElPTnwxNDMzNjc3")
+	nrqlConditionBaseline.SignalSeasonality = &alerts.NrqlSignalSeasonalities.Daily
 
 	// Static
 	nrqlConditionStatic := nrqlCondition

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -99,7 +99,7 @@ The following arguments are supported:
 - `aggregation_timer` - (Optional) How long we wait after each data point arrives to make sure we've processed the whole batch. Use `aggregation_timer` with the `event_timer` method. The timer value can range from 0 seconds to 1200 seconds (20 minutes); the default is 60 seconds. `aggregation_timer` cannot be set with `nrql.evaluation_offset`.
 - `evaluation_delay` - (Optional) How long we wait until the signal starts evaluating. The maximum delay is 7200 seconds (120 minutes).
 - `slide_by` - (Optional) Gathers data in overlapping time windows to smooth the chart line, making it easier to spot trends. The `slide_by` value is specified in seconds and must be smaller than and a factor of the `aggregation_window`.
-- `signal_seasonality` - (Optional) Seasonality under which a condition's signal(s) are evaluated. Only available for baseline conditions. Valid values are: `HOURLY`, `DAILY`, `WEEKLY`, `NONE`, or `null`. To have New Relic calculate seasonality automatically, set to `null`. To turn off seasonality completely, set to `NONE`.
+- `signal_seasonality` - (Optional) Seasonality under which a condition's signal(s) are evaluated. Only available for baseline conditions. Valid values are: `NEW_RELIC_CALCULATION`, `HOURLY`, `DAILY`, `WEEKLY`, or `NONE`. To have New Relic calculate seasonality automatically, set to `NEW_RELIC_CALCULATION`. To turn off seasonality completely, set to `NONE`.
 
 ## NRQL
 

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -99,6 +99,7 @@ The following arguments are supported:
 - `aggregation_timer` - (Optional) How long we wait after each data point arrives to make sure we've processed the whole batch. Use `aggregation_timer` with the `event_timer` method. The timer value can range from 0 seconds to 1200 seconds (20 minutes); the default is 60 seconds. `aggregation_timer` cannot be set with `nrql.evaluation_offset`.
 - `evaluation_delay` - (Optional) How long we wait until the signal starts evaluating. The maximum delay is 7200 seconds (120 minutes).
 - `slide_by` - (Optional) Gathers data in overlapping time windows to smooth the chart line, making it easier to spot trends. The `slide_by` value is specified in seconds and must be smaller than and a factor of the `aggregation_window`.
+- `signal_seasonality` - (Optional) Seasonality under which a condition's signal(s) are evaluated. Only available for baseline conditions. Valid values are: 'HOURLY', 'DAILY', 'WEEKLY', 'NONE', or null. To have New Relic calculate seasonality automatically, set to null. To turn off seasonality completely, set to 'NONE'.
 
 ## NRQL
 
@@ -180,6 +181,7 @@ resource "newrelic_nrql_alert_condition" "foo" {
 
   # baseline type only
   baseline_direction = "upper_only"
+  signal_seasonality = "none"
 
   nrql {
     query = "SELECT percentile(duration, 95) FROM Transaction WHERE appName = 'ExampleAppName'"

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -99,7 +99,7 @@ The following arguments are supported:
 - `aggregation_timer` - (Optional) How long we wait after each data point arrives to make sure we've processed the whole batch. Use `aggregation_timer` with the `event_timer` method. The timer value can range from 0 seconds to 1200 seconds (20 minutes); the default is 60 seconds. `aggregation_timer` cannot be set with `nrql.evaluation_offset`.
 - `evaluation_delay` - (Optional) How long we wait until the signal starts evaluating. The maximum delay is 7200 seconds (120 minutes).
 - `slide_by` - (Optional) Gathers data in overlapping time windows to smooth the chart line, making it easier to spot trends. The `slide_by` value is specified in seconds and must be smaller than and a factor of the `aggregation_window`.
-- `signal_seasonality` - (Optional) Seasonality under which a condition's signal(s) are evaluated. Only available for baseline conditions. Valid values are: 'HOURLY', 'DAILY', 'WEEKLY', 'NONE', or null. To have New Relic calculate seasonality automatically, set to null. To turn off seasonality completely, set to 'NONE'.
+- `signal_seasonality` - (Optional) Seasonality under which a condition's signal(s) are evaluated. Only available for baseline conditions. Valid values are: `HOURLY`, `DAILY`, `WEEKLY`, `NONE`, or `null`. To have New Relic calculate seasonality automatically, set to `null`. To turn off seasonality completely, set to `NONE`.
 
 ## NRQL
 

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -181,7 +181,7 @@ resource "newrelic_nrql_alert_condition" "foo" {
 
   # baseline type only
   baseline_direction = "upper_only"
-  signal_seasonality = "none"
+  signal_seasonality = "weekly"
 
   nrql {
     query = "SELECT percentile(duration, 95) FROM Transaction WHERE appName = 'ExampleAppName'"


### PR DESCRIPTION
# Description

- Adds support for `signal_seasonality` for baseline NRQL conditions
- See ticket: https://new-relic.atlassian.net/browse/NR-368788

Related to [Go Client PR](https://github.com/newrelic/newrelic-client-go/pull/1291)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Try creating a `newrelic_nrql_alert_condition` of type `baseline`.
- Ensure you can set `signal_seasonality` successfully.
- Try creating a `newrelic_nrql_alert_condition` of type `static` without `signal_seasonality`.

E.g.
```
resource "newrelic_nrql_alert_condition" "baseline_condition" {
  account_id                   = 400304
  policy_id                    = 1514915
  type                         = "baseline"
  name                         = "Baseline Condition from Terraform"
  enabled                      = false
  violation_time_limit_seconds = 3600
  baseline_direction           = "upper_only"
  nrql {
    query = "SELECT average(duration) FROM Transaction"
  }
  critical {
    operator              = "above"
    threshold             = 1
    threshold_duration    = 300
    threshold_occurrences = "all"
  }
  aggregation_window = 60
  aggregation_method = "event_flow"
  aggregation_delay  = 120
  fill_option        = "static"
  fill_value         = 1
  signal_seasonality = "daily"
}
```