### PR TITLE
fix(synthetics): export monitor ID in all synthetic monitor resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.30.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.55.3
+	github.com/newrelic/newrelic-client-go/v2 v2.56.1
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 )

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.55.3 h1:7oFmlW7g2eNflm4IxvXv2C0fpe1FViAichRsdhJStBQ=
-github.com/newrelic/newrelic-client-go/v2 v2.55.3/go.mod h1:+RRjI3nDGWT3kLm9Oi3QxpBm70uu8q1upEHBVWCZFpo=
+github.com/newrelic/newrelic-client-go/v2 v2.56.1 h1:KeGS6/NM7gyIkvjuFXW6y2+WhdRm0d/Mb1V1UkQc2sE=
+github.com/newrelic/newrelic-client-go/v2 v2.56.1/go.mod h1:+RRjI3nDGWT3kLm9Oi3QxpBm70uu8q1upEHBVWCZFpo=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/newrelic/helpers_synthetics.go
+++ b/newrelic/helpers_synthetics.go
@@ -29,6 +29,11 @@ func syntheticsMonitorCommonSchema() map[string]*schema.Schema {
 			Computed:    true,
 			Description: "The unique entity identifier of the monitor in New Relic.",
 		},
+		"monitor_id": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "ID of the monitor",
+		},
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,

--- a/newrelic/resource_newrelic_synthetics_broken_links_monitor.go
+++ b/newrelic/resource_newrelic_synthetics_broken_links_monitor.go
@@ -66,11 +66,12 @@ func resourceNewRelicSyntheticsBrokenLinksMonitorCreate(ctx context.Context, d *
 	_ = d.Set("period_in_minutes", syntheticsMonitorPeriodInMinutesValueMap[resp.Monitor.Period])
 
 	err = setSyntheticsMonitorAttributes(d, map[string]string{
-		"guid":   string(resp.Monitor.GUID),
-		"name":   resp.Monitor.Name,
-		"period": string(resp.Monitor.Period),
-		"status": string(resp.Monitor.Status),
-		"uri":    resp.Monitor.Uri,
+		"guid":       string(resp.Monitor.GUID),
+		"name":       resp.Monitor.Name,
+		"period":     string(resp.Monitor.Period),
+		"status":     string(resp.Monitor.Status),
+		"uri":        resp.Monitor.Uri,
+		"monitor_id": resp.Monitor.ID,
 	})
 
 	respRuntimeType := resp.Monitor.Runtime.RuntimeType
@@ -115,11 +116,12 @@ func resourceNewRelicSyntheticsBrokenLinksMonitorRead(ctx context.Context, d *sc
 		_ = d.Set("period_in_minutes", int(entity.GetPeriod()))
 
 		err = setSyntheticsMonitorAttributes(d, map[string]string{
-			"guid":   string(e.GUID),
-			"name":   entity.Name,
-			"period": string(syntheticsMonitorPeriodValueMap[int(entity.GetPeriod())]),
-			"status": string(entity.MonitorSummary.Status),
-			"uri":    entity.MonitoredURL,
+			"guid":       string(e.GUID),
+			"name":       entity.Name,
+			"period":     string(syntheticsMonitorPeriodValueMap[int(entity.GetPeriod())]),
+			"status":     string(entity.MonitorSummary.Status),
+			"uri":        entity.MonitoredURL,
+			"monitor_id": entity.MonitorId,
 		})
 
 		runtimeType, runtimeTypeVersion := getRuntimeValuesFromEntityTags(entity.GetTags())

--- a/newrelic/resource_newrelic_synthetics_broken_links_monitor_test.go
+++ b/newrelic/resource_newrelic_synthetics_broken_links_monitor_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/entities"
 )
 
 func TestAccNewRelicSyntheticsBrokenLinksMonitor(t *testing.T) {
@@ -105,6 +106,10 @@ func testAccCheckNewRelicSyntheticsMonitorEntityExists(n string) resource.TestCh
 		}
 		if string((*result).GetGUID()) != rs.Primary.ID {
 			return fmt.Errorf("the monitor is not found %v - %v", (*result).GetGUID(), rs.Primary.ID)
+		}
+
+		if rs.Primary.Attributes["monitor_id"] != string((*result).(*entities.SyntheticMonitorEntity).MonitorId) {
+			return fmt.Errorf("the monitor id doesnot match, expected: %v", rs.Primary.Attributes["monitor_id"])
 		}
 
 		if rs.Primary.Attributes["runtime_type"] != "" && rs.Primary.Attributes["runtime_type_version"] != "" {

--- a/newrelic/resource_newrelic_synthetics_cert_check_monitor.go
+++ b/newrelic/resource_newrelic_synthetics_cert_check_monitor.go
@@ -29,6 +29,11 @@ func resourceNewRelicSyntheticsCertCheckMonitor() *schema.Resource {
 				Computed:    true,
 				Optional:    true,
 			},
+			"monitor_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "ID of the monitor",
+			},
 			"name": {
 				Type:        schema.TypeString,
 				Description: "name of the cert check monitor",
@@ -167,10 +172,11 @@ func resourceNewRelicSyntheticsCertCheckMonitorCreate(ctx context.Context, d *sc
 	}
 
 	err = setSyntheticsMonitorAttributes(d, map[string]string{
-		"domain": resp.Monitor.Domain,
-		"name":   resp.Monitor.Name,
-		"period": string(resp.Monitor.Period),
-		"status": string(resp.Monitor.Status),
+		"domain":     resp.Monitor.Domain,
+		"name":       resp.Monitor.Name,
+		"period":     string(resp.Monitor.Period),
+		"status":     string(resp.Monitor.Status),
+		"monitor_id": resp.Monitor.ID,
 	})
 
 	if err != nil {
@@ -211,9 +217,10 @@ func resourceNewRelicSyntheticsCertCheckMonitorRead(ctx context.Context, d *sche
 		_ = d.Set("period_in_minutes", int(entity.GetPeriod()))
 
 		err = setSyntheticsMonitorAttributes(d, map[string]string{
-			"name":   e.Name,
-			"period": string(syntheticsMonitorPeriodValueMap[int(entity.GetPeriod())]),
-			"status": string(entity.MonitorSummary.Status),
+			"name":       e.Name,
+			"period":     string(syntheticsMonitorPeriodValueMap[int(entity.GetPeriod())]),
+			"status":     string(entity.MonitorSummary.Status),
+			"monitor_id": entity.MonitorId,
 		})
 
 		runtimeType, runtimeTypeVersion := getRuntimeValuesFromEntityTags(entity.GetTags())

--- a/newrelic/resource_newrelic_synthetics_cert_check_monitor_test.go
+++ b/newrelic/resource_newrelic_synthetics_cert_check_monitor_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/entities"
 )
 
 func TestAccNewRelicSyntheticsCertCheckMonitor(t *testing.T) {
@@ -128,6 +129,10 @@ func testAccNewRelicSyntheticsCertCheckMonitorExists(name string) resource.TestC
 		}
 		if string((*result).GetGUID()) != rs.Primary.ID {
 			return fmt.Errorf("the monitor is not found %v - %v", (*result).GetGUID(), rs.Primary.ID)
+		}
+
+		if rs.Primary.Attributes["monitor_id"] != string((*result).(*entities.SyntheticMonitorEntity).MonitorId) {
+			return fmt.Errorf("the monitor id doesnot match, expected: %v", rs.Primary.Attributes["monitor_id"])
 		}
 
 		if rs.Primary.Attributes["runtime_type"] != "" && rs.Primary.Attributes["runtime_type_version"] != "" {

--- a/newrelic/resource_newrelic_synthetics_monitor.go
+++ b/newrelic/resource_newrelic_synthetics_monitor.go
@@ -39,6 +39,11 @@ func resourceNewRelicSyntheticsMonitor() *schema.Resource {
 				Description:  "The monitor type. Valid values are SIMPLE AND BROWSER.",
 				ValidateFunc: validation.StringInSlice([]string{"SIMPLE", "BROWSER"}, false),
 			},
+			"monitor_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "ID of the monitor",
+			},
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -248,6 +253,7 @@ func setAttributesFromCreate(res *synthetics.SyntheticsSimpleBrowserMonitorCreat
 	_ = d.Set("locations_private", res.Monitor.Locations.Private)
 	_ = d.Set("device_orientation", res.Monitor.AdvancedOptions.DeviceEmulation.DeviceOrientation)
 	_ = d.Set("device_type", res.Monitor.AdvancedOptions.DeviceEmulation.DeviceType)
+	_ = d.Set("monitor_id", res.Monitor.ID)
 
 	if res.Monitor.Runtime.RuntimeType != "" {
 		_ = d.Set("runtime_type", res.Monitor.Runtime.RuntimeType)
@@ -298,11 +304,12 @@ func setCommonSyntheticsMonitorAttributes(v *entities.EntityInterface, d *schema
 	switch e := (*v).(type) {
 	case *entities.SyntheticMonitorEntity:
 		err := setSyntheticsMonitorAttributes(d, map[string]string{
-			"name":   e.Name,
-			"type":   string(e.MonitorType),
-			"uri":    e.MonitoredURL,
-			"period": string(syntheticsMonitorPeriodValueMap[int(e.GetPeriod())]),
-			"status": string(e.MonitorSummary.Status),
+			"name":       e.Name,
+			"type":       string(e.MonitorType),
+			"uri":        e.MonitoredURL,
+			"period":     string(syntheticsMonitorPeriodValueMap[int(e.GetPeriod())]),
+			"status":     string(e.MonitorSummary.Status),
+			"monitor_id": e.MonitorId,
 		})
 
 		_ = d.Set("period_in_minutes", e.GetPeriod())

--- a/newrelic/resource_newrelic_synthetics_monitor_test.go
+++ b/newrelic/resource_newrelic_synthetics_monitor_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/entities"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/synthetics"
 	mock "github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
 	"github.com/stretchr/testify/require"
@@ -379,6 +380,10 @@ func testAccCheckNewRelicSyntheticsMonitorExists(n string) resource.TestCheckFun
 
 		if string((*found).GetGUID()) != rs.Primary.ID {
 			return fmt.Errorf("the monitor is not found %v - %v", (*found).GetGUID(), rs.Primary.ID)
+		}
+
+		if rs.Primary.Attributes["monitor_id"] != string((*found).(*entities.SyntheticMonitorEntity).MonitorId) {
+			return fmt.Errorf("the monitor id doesnot not match expected: %v", rs.Primary.Attributes["monitor_id"])
 		}
 
 		return nil

--- a/newrelic/resource_newrelic_synthetics_script_monitor.go
+++ b/newrelic/resource_newrelic_synthetics_script_monitor.go
@@ -153,7 +153,10 @@ func resourceNewRelicSyntheticsScriptMonitorCreate(ctx context.Context, d *schem
 		_ = d.Set("account_id", accountID)
 		_ = d.Set("period_in_minutes", syntheticsMonitorPeriodInMinutesValueMap[resp.Monitor.Period])
 
-		attrs := map[string]string{"guid": string(resp.Monitor.GUID)}
+		attrs := map[string]string{
+			"guid":       string(resp.Monitor.GUID),
+			"monitor_id": resp.Monitor.ID,
+		}
 		if err = setSyntheticsMonitorAttributes(d, attrs); err != nil {
 			return diag.FromErr(err)
 		}
@@ -174,7 +177,10 @@ func resourceNewRelicSyntheticsScriptMonitorCreate(ctx context.Context, d *schem
 		_ = d.Set("account_id", accountID)
 		_ = d.Set("period_in_minutes", syntheticsMonitorPeriodInMinutesValueMap[resp.Monitor.Period])
 
-		attrs := map[string]string{"guid": string(resp.Monitor.GUID)}
+		attrs := map[string]string{
+			"guid":       string(resp.Monitor.GUID),
+			"monitor_id": resp.Monitor.ID,
+		}
 		if err = setSyntheticsMonitorAttributes(d, attrs); err != nil {
 			return diag.FromErr(err)
 		}
@@ -228,11 +234,12 @@ func resourceNewRelicSyntheticsScriptMonitorRead(ctx context.Context, d *schema.
 		_ = d.Set("locations_public", getPublicLocationsFromEntityTags(entity.GetTags()))
 
 		err = setSyntheticsMonitorAttributes(d, map[string]string{
-			"name":   e.Name,
-			"type":   string(e.MonitorType),
-			"guid":   string(e.GUID),
-			"period": string(syntheticsMonitorPeriodValueMap[int(e.GetPeriod())]),
-			"status": string(e.MonitorSummary.Status),
+			"name":       e.Name,
+			"type":       string(e.MonitorType),
+			"guid":       string(e.GUID),
+			"period":     string(syntheticsMonitorPeriodValueMap[int(e.GetPeriod())]),
+			"status":     string(e.MonitorSummary.Status),
+			"monitor_id": e.MonitorId,
 		})
 
 		_ = d.Set("period_in_minutes", int(e.GetPeriod()))

--- a/newrelic/resource_newrelic_synthetics_script_monitor_test.go
+++ b/newrelic/resource_newrelic_synthetics_script_monitor_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/entities"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/synthetics"
 )
 
@@ -168,6 +169,11 @@ func testAccCheckNewRelicSyntheticsScriptMonitorExists(n string) resource.TestCh
 		if string((*result).GetGUID()) != rs.Primary.ID {
 			return fmt.Errorf("the monitor is not found %v - %v", (*result).GetGUID(), rs.Primary.ID)
 		}
+
+		if rs.Primary.Attributes["monitor_id"] != string((*result).(*entities.SyntheticMonitorEntity).MonitorId) {
+			return fmt.Errorf("the monitor id doesnot match, expected: %v", rs.Primary.Attributes["monitor_id"])
+		}
+
 		return nil
 	}
 }

--- a/newrelic/resource_newrelic_synthetics_step_monitor.go
+++ b/newrelic/resource_newrelic_synthetics_step_monitor.go
@@ -134,10 +134,11 @@ func resourceNewRelicSyntheticsStepMonitorCreate(ctx context.Context, d *schema.
 	_ = d.Set("period_in_minutes", syntheticsMonitorPeriodInMinutesValueMap[resp.Monitor.Period])
 
 	err = setSyntheticsMonitorAttributes(d, map[string]string{
-		"guid":   string(resp.Monitor.GUID),
-		"name":   resp.Monitor.Name,
-		"period": string(resp.Monitor.Period),
-		"status": string(resp.Monitor.Status),
+		"guid":       string(resp.Monitor.GUID),
+		"name":       resp.Monitor.Name,
+		"period":     string(resp.Monitor.Period),
+		"status":     string(resp.Monitor.Status),
+		"monitor_id": resp.Monitor.ID,
 	})
 
 	respRuntimeType := resp.Monitor.Runtime.RuntimeType
@@ -189,10 +190,11 @@ func resourceNewRelicSyntheticsStepMonitorRead(ctx context.Context, d *schema.Re
 		_ = d.Set("period_in_minutes", int(entity.GetPeriod()))
 
 		err = setSyntheticsMonitorAttributes(d, map[string]string{
-			"guid":   string(e.GUID),
-			"name":   entity.Name,
-			"period": string(syntheticsMonitorPeriodValueMap[int(entity.GetPeriod())]),
-			"status": string(entity.MonitorSummary.Status),
+			"guid":       string(e.GUID),
+			"name":       entity.Name,
+			"period":     string(syntheticsMonitorPeriodValueMap[int(entity.GetPeriod())]),
+			"status":     string(entity.MonitorSummary.Status),
+			"monitor_id": entity.MonitorId,
 		})
 
 		runtimeType, runtimeTypeVersion := getRuntimeValuesFromEntityTags(entity.GetTags())

--- a/website/docs/r/synthetics_broken_links_monitor.html.markdown
+++ b/website/docs/r/synthetics_broken_links_monitor.html.markdown
@@ -97,6 +97,7 @@ The following attributes are exported:
 
 * `id` - The ID (GUID) of the synthetics broken links monitor.
 * `period_in_minutes` - The interval in minutes at which Synthetic monitor should run.
+* `monitor_id` - The monitor id of the synthetics broken links monitor (not to be confused with the GUID of the monitor).
 
 ## Import
 

--- a/website/docs/r/synthetics_cert_check_monitor.html.markdown
+++ b/website/docs/r/synthetics_cert_check_monitor.html.markdown
@@ -101,6 +101,7 @@ The following attributes are exported:
 
 * `id` - The ID (GUID) of the certificate check synthetics monitor.
 * `period_in_minutes` - The interval in minutes at which Synthetic monitor should run.
+* `monitor_id` - The monitor id of the certificate check synthetics monitor (not to be confused with the GUID of the monitor).
 
 ## Import
 

--- a/website/docs/r/synthetics_monitor.html.markdown
+++ b/website/docs/r/synthetics_monitor.html.markdown
@@ -233,6 +233,7 @@ The following attributes are exported:
 
 * `id` - The ID (GUID) of the Synthetics monitor that the script is attached to.
 * `period_in_minutes` - The interval in minutes at which Synthetic monitor should run.
+* `monitor_id` - The monitor id of the Synthetics monitor (not to be confused with the GUID of the monitor).
 
 ## Import
 

--- a/website/docs/r/synthetics_script_monitor.html.markdown
+++ b/website/docs/r/synthetics_script_monitor.html.markdown
@@ -188,8 +188,9 @@ resource "newrelic_synthetics_script_monitor" "monitor" {
 
 The following attributes are exported:
 
-* `id` - The ID of the Synthetics script monitor.
+* `id` - The ID (GUID) of the Synthetics script monitor.
 * `period_in_minutes` - The interval in minutes at which Synthetic monitor should run.
+* `monitor_id` - The monitor id of the Synthetics script monitor (not to be confused with the GUID of the monitor).
 
 ## Import
 

--- a/website/docs/r/synthetics_step_monitor.html.markdown
+++ b/website/docs/r/synthetics_step_monitor.html.markdown
@@ -131,6 +131,7 @@ The following attributes are exported:
 
 * `id` - The ID (GUID) of the synthetics step monitor.
 * `period_in_minutes` - The interval in minutes at which Synthetic monitor should run.
+* `monitor_id` - The monitor id of the synthetics step monitor (not to be confused with the GUID of the monitor).
 
 ## Import
 


### PR DESCRIPTION
# Description

This PR aims to add support to Synthetic Monitor Resources to export monitor id.
Github Issue: https://github.com/newrelic/terraform-provider-newrelic/issues/2814

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.
