### PR TITLE
Modify AWS Metrics Stream to be usable in multiple regions, resolve a perpetual diff. 

### DIFF
--- a/examples/modules/cloud-integrations/aws/main.tf
+++ b/examples/modules/cloud-integrations/aws/main.tf
@@ -226,61 +226,20 @@ resource "newrelic_cloud_aws_link_account" "newrelic_cloud_integration_pull" {
   depends_on             = [aws_iam_role_policy_attachment.newrelic_aws_policy_attach]
 }
 
+# NOTE: At the time of writing this metric streams not are supported for the following resources:
+# Cloudtrail
+# Health
+# Trusted Advisor
+# AWS X-Ray
+# We will only configure API polling for these unsupported services. 
 resource "newrelic_cloud_aws_integrations" "newrelic_cloud_integration_pull" {
   account_id        = var.newrelic_account_id
   linked_account_id = newrelic_cloud_aws_link_account.newrelic_cloud_integration_pull.id
-  billing {}
+
   cloudtrail {}
+  x_ray {}
   health {}
   trusted_advisor {}
-  vpc {}
-  x_ray {}
-  s3 {}
-  doc_db {}
-  sqs {}
-  ebs {}
-  alb {}
-  elasticache {}
-  api_gateway {}
-  auto_scaling {}
-  aws_app_sync {}
-  aws_athena {}
-  aws_cognito {}
-  aws_connect {}
-  aws_direct_connect {}
-  aws_fsx {}
-  aws_glue {}
-  aws_kinesis_analytics {}
-  aws_media_convert {}
-  aws_media_package_vod {}
-  aws_mq {}
-  aws_msk {}
-  aws_neptune {}
-  aws_qldb {}
-  aws_route53resolver {}
-  aws_states {}
-  aws_transit_gateway {}
-  aws_waf {}
-  aws_wafv2 {}
-  cloudfront {}
-  dynamodb {}
-  ec2 {}
-  ecs {}
-  efs {}
-  elasticbeanstalk {}
-  elasticsearch {}
-  elb {}
-  emr {}
-  iam {}
-  iot {}
-  kinesis {}
-  kinesis_firehose {}
-  lambda {}
-  rds {}
-  redshift {}
-  route53 {}
-  ses {}
-  sns {}
 }
 
 resource "aws_s3_bucket" "newrelic_configuration_recorder_s3" {

--- a/examples/modules/cloud-integrations/aws/main.tf
+++ b/examples/modules/cloud-integrations/aws/main.tf
@@ -240,10 +240,18 @@ resource "newrelic_cloud_aws_integrations" "newrelic_cloud_integration_pull" {
   account_id        = var.newrelic_account_id
   linked_account_id = newrelic_cloud_aws_link_account.newrelic_cloud_integration_pull[0].id
 
-  cloudtrail {}
-  x_ray {}
-  health {}
-  trusted_advisor {}
+  cloudtrail {
+    metrics_polling_interval = 300
+  }
+  x_ray {
+    metrics_polling_interval = 60
+  }
+  health {
+    metrics_polling_interval = 300
+  }
+  trusted_advisor {
+    metrics_polling_interval = 3600
+  }
 }
 
 resource "aws_s3_bucket" "newrelic_configuration_recorder_s3" {

--- a/examples/modules/cloud-integrations/aws/main.tf
+++ b/examples/modules/cloud-integrations/aws/main.tf
@@ -68,6 +68,7 @@ resource "aws_iam_role_policy_attachment" "newrelic_aws_policy_attach" {
 }
 
 resource "newrelic_cloud_aws_link_account" "newrelic_cloud_integration_push" {
+  count                  = var.is_primary_region ? 1 : 0
   account_id             = var.newrelic_account_id
   arn                    = aws_iam_role.newrelic_aws_role.arn
   metric_collection_mode = "PUSH"
@@ -123,8 +124,8 @@ resource "aws_s3_bucket_ownership_controls" "newrelic_ownership_controls" {
 
 locals {
   newrelic_urls = {
-    US      = "https://aws-api.newrelic.com/cloudwatch-metrics/v1"
-    EU      = "https://aws-api.eu01.nr-data.net/cloudwatch-metrics/v1"
+    US = "https://aws-api.newrelic.com/cloudwatch-metrics/v1"
+    EU = "https://aws-api.eu01.nr-data.net/cloudwatch-metrics/v1"
   }
 }
 
@@ -137,6 +138,7 @@ resource "aws_kinesis_firehose_delivery_stream" "newrelic_firehose_stream" {
     access_key         = newrelic_api_access_key.newrelic_aws_access_key.key
     buffering_size     = 1
     buffering_interval = 60
+    retry_duration     = 60
     role_arn           = aws_iam_role.firehose_newrelic_role.arn
     s3_backup_mode     = "FailedDataOnly"
     s3_configuration {
@@ -219,6 +221,7 @@ resource "aws_cloudwatch_metric_stream" "newrelic_metric_stream" {
 }
 
 resource "newrelic_cloud_aws_link_account" "newrelic_cloud_integration_pull" {
+  count                  = var.is_primary_region ? 1 : 0
   account_id             = var.newrelic_account_id
   arn                    = aws_iam_role.newrelic_aws_role.arn
   metric_collection_mode = "PULL"
@@ -226,15 +229,16 @@ resource "newrelic_cloud_aws_link_account" "newrelic_cloud_integration_pull" {
   depends_on             = [aws_iam_role_policy_attachment.newrelic_aws_policy_attach]
 }
 
-# NOTE: At the time of writing this metric streams not are supported for the following resources:
+# NOTE: At time of writing, metrics streams aren't supported for the following services:
 # Cloudtrail
 # Health
 # Trusted Advisor
 # AWS X-Ray
 # We will only configure API polling for these unsupported services. 
 resource "newrelic_cloud_aws_integrations" "newrelic_cloud_integration_pull" {
+  count             = var.is_primary_region ? 1 : 0
   account_id        = var.newrelic_account_id
-  linked_account_id = newrelic_cloud_aws_link_account.newrelic_cloud_integration_pull.id
+  linked_account_id = newrelic_cloud_aws_link_account.newrelic_cloud_integration_pull[0].id
 
   cloudtrail {}
   x_ray {}
@@ -301,7 +305,7 @@ resource "aws_config_configuration_recorder" "newrelic_recorder" {
 
 resource "aws_config_configuration_recorder_status" "newrelic_recorder_status" {
   name       = aws_config_configuration_recorder.newrelic_recorder.name
-  is_enabled = true
+  is_enabled = var.recorder_enabled
   depends_on = [aws_config_delivery_channel.newrelic_recorder_delivery]
 }
 

--- a/examples/modules/cloud-integrations/aws/migrations.tf
+++ b/examples/modules/cloud-integrations/aws/migrations.tf
@@ -1,0 +1,14 @@
+moved {
+  from = newrelic_cloud_aws_link_account.newrelic_cloud_integration_pull 
+  to = newrelic_cloud_aws_link_account.newrelic_cloud_integration_pull[0]
+}
+
+moved {
+  from = newrelic_cloud_aws_integrations.newrelic_cloud_integration_pull 
+  to = newrelic_cloud_aws_integrations.newrelic_cloud_integration_pull[0]
+}
+
+moved {
+  from = newrelic_cloud_aws_link_account.newrelic_cloud_integration_push
+  to = newrelic_cloud_aws_link_account.newrelic_cloud_integration_push[0]
+}

--- a/examples/modules/cloud-integrations/aws/providers.tf
+++ b/examples/modules/cloud-integrations/aws/providers.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 1.1.0"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/examples/modules/cloud-integrations/aws/variables.tf
+++ b/examples/modules/cloud-integrations/aws/variables.tf
@@ -28,3 +28,15 @@ variable "include_metric_filters" {
   type        = map(list(string))
   default     = {}
 }
+
+variable "is_primary_region" {
+  description = "Determines if certain mutually exclusive resources are created."
+  type = bool
+  default = true
+}
+
+variable "recorder_enabled" {
+  description = "Allows enabling or disabling the AWS Config Recorder"
+  type = bool
+  default = true
+}


### PR DESCRIPTION
# Description

This modifies the AWS Firehose metrics stream example to allow it's use in multi-region setup and solves a perpetual diff. 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

1. Apply something similar to the following that uses the previous version of the example 
2. Apply it again and note the perpetual diff. 

```
module "newrelic-aws-cloud-integrations-us-east-1" {
  providers = {
    aws = aws.us-east-1
  }
  source = $PREVIOUSMODULEVERSIONHERE

  newrelic_account_id     = local.newrelic_account_id
  newrelic_account_region = "US"
  name                    = "primary"
}
```

1. Apply this code with the previous version of the module 
2. It fails.

```
module "newrelic-aws-cloud-integrations-us-east-1" {
  providers = {
    aws = aws.us-east-1
  }
  source = "../../../../../terraform-provider-newrelic//examples/modules/cloud-integrations/aws"

  newrelic_account_id     = local.newrelic_account_id
  newrelic_account_region = "US"
  name                    = "primary"
}

module "newrelic-aws-cloud-integrations-us-west-2" {
  providers = {
    aws = aws.us-west-2
  }
  source = "../../../../../terraform-provider-newrelic//examples/modules/cloud-integrations/aws"

  newrelic_account_id     = local.newrelic_account_id
  newrelic_account_region = "US"
  name                    = "us-west-2"
  is_primary_region       = false
}
```

1. Apply the previous code with this version of the module.
2. It doesn't fail
3. Apply it again.
4. There isn't a perpetual diff. 
