### PR TITLE
feat(synthetics): set runtime_type and runtime_type_version as required

### DIFF
--- a/newrelic/helpers_synthetics.go
+++ b/newrelic/helpers_synthetics.go
@@ -84,12 +84,12 @@ func syntheticsMonitorRuntimeOptions() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"runtime_type": {
 			Type:        schema.TypeString,
-			Required:    true,
+			Optional:    true,
 			Description: "The runtime type that the monitor will run.",
 		},
 		"runtime_type_version": {
 			Type:        schema.TypeString,
-			Required:    true,
+			Optional:    true,
 			Description: "The specific semver version of the runtime type.",
 		},
 	}

--- a/newrelic/resource_newrelic_synthetics_cert_check_monitor.go
+++ b/newrelic/resource_newrelic_synthetics_cert_check_monitor.go
@@ -105,12 +105,12 @@ func resourceNewRelicSyntheticsCertCheckMonitor() *schema.Resource {
 			},
 			"runtime_type": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "The runtime type that the monitor will run.",
 			},
 			"runtime_type_version": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "The specific semver version of the runtime type.",
 			},
 		},

--- a/newrelic/resource_newrelic_synthetics_script_monitor.go
+++ b/newrelic/resource_newrelic_synthetics_script_monitor.go
@@ -112,12 +112,12 @@ func syntheticsScriptMonitorCommonSchema() map[string]*schema.Schema {
 		},
 		"runtime_type": {
 			Type:        schema.TypeString,
-			Required:    true,
+			Optional:    true,
 			Description: "The runtime type that the monitor will run.",
 		},
 		"runtime_type_version": {
 			Type:        schema.TypeString,
-			Required:    true,
+			Optional:    true,
 			Description: "The specific semver version of the runtime type.",
 		},
 	}

--- a/newrelic/resource_newrelic_synthetics_step_monitor.go
+++ b/newrelic/resource_newrelic_synthetics_step_monitor.go
@@ -94,12 +94,12 @@ func syntheticsStepMonitorSchema() map[string]*schema.Schema {
 		},
 		"runtime_type": {
 			Type:        schema.TypeString,
-			Required:    true,
+			Optional:    true,
 			Description: "The runtime type that the monitor will run.",
 		},
 		"runtime_type_version": {
 			Type:        schema.TypeString,
-			Required:    true,
+			Optional:    true,
 			Description: "The specific semver version of the runtime type.",
 		},
 		"browsers": browsersSchema,


### PR DESCRIPTION
# Description

This PR aims to set `runtime_type` and `runtime_type_version` schema attributes as required for synthetic monitors.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [ ] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.
