### PR TITLE
feat: security hub integration in terraform provider

### DIFF
--- a/newrelic/resource_newrelic_cloud_aws_integrations.go
+++ b/newrelic/resource_newrelic_cloud_aws_integrations.go
@@ -395,6 +395,13 @@ func resourceNewRelicCloudAwsIntegrations() *schema.Resource {
 				Elem:        cloudAwsIntegrationSnsSchemaElem(),
 				MaxItems:    1,
 			},
+			"security_hub": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Security Hub integration",
+				Elem:        cloudAwsIntegrationSecurityHubSchemaElem(),
+				MaxItems:    1,
+			},
 		},
 	}
 }
@@ -1088,6 +1095,25 @@ func cloudAwsIntegrationSnsSchemaElem() *schema.Resource {
 		Type:        schema.TypeBool,
 		Description: "Determine if extra inventory data be collected or not. May affect total data collection time and contribute to the Cloud provider API rate limit.",
 		Optional:    true,
+	}
+
+	return &schema.Resource{
+		Schema: s,
+	}
+}
+
+// function to add schema for SecurityHub integration
+
+func cloudAwsIntegrationSecurityHubSchemaElem() *schema.Resource {
+	s := cloudAwsIntegrationSchemaBase()
+
+	s["aws_regions"] = &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		Description: "Specify each AWS region that includes the resources that you want to monitor.",
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
 	}
 
 	return &schema.Resource{

--- a/newrelic/resource_newrelic_cloud_aws_integrations_test.go
+++ b/newrelic/resource_newrelic_cloud_aws_integrations_test.go
@@ -414,6 +414,10 @@ func testAccNewRelicAwsIntegrationsConfig(AWSIntegrationsTestConfig map[string]s
 		  fetch_extended_inventory = true
 		  metrics_polling_interval = 6000
 		}
+		security_hub {
+		  aws_regions              = ["us-east-1"]
+		  metrics_polling_interval = 6000
+		}
 	  }
 `)
 }
@@ -708,6 +712,10 @@ func testAccNewRelicAwsIntegrationsConfigUpdated(AWSIntegrationsTestConfig map[s
 		sns {
 		  aws_regions              = ["us-east-1"]
 		  fetch_extended_inventory = true
+		  metrics_polling_interval = 6000
+		}
+		security_hub {
+		  aws_regions              = ["us-east-1"]
 		  metrics_polling_interval = 6000
 		}
 	  }

--- a/newrelic/structures_newrelic_cloud_aws_integrations.go
+++ b/newrelic/structures_newrelic_cloud_aws_integrations.go
@@ -433,6 +433,14 @@ func expandCloudAwsIntegrationsInput(d *schema.ResourceData) (cloud.CloudIntegra
 				cloudDisableAwsIntegration.Sns = []cloud.CloudDisableAccountIntegrationInput{{LinkedAccountId: id}}
 			},
 		},
+		"security_hub": {
+			enableFunc: func(a []interface{}, id int) {
+				cloudAwsIntegration.SecurityHub = expandCloudAwsIntegrationSecurityHubInput(a, id)
+			},
+			disableFunc: func(id int) {
+				cloudDisableAwsIntegration.SecurityHub = []cloud.CloudDisableAccountIntegrationInput{{LinkedAccountId: id}}
+			},
+		},
 	}
 
 	for key, fun := range awsIntegrationMap {
@@ -567,6 +575,8 @@ func flattenCloudAwsLinkedAccount(d *schema.ResourceData, linkedAccount *cloud.C
 			_ = d.Set("ses", flattenCloudSesIntegration(t))
 		case *cloud.CloudSnsIntegration:
 			_ = d.Set("sns", flattenCloudSnsIntegration(t))
+		case *cloud.CloudSecurityHubIntegration:
+			_ = d.Set("security_hub", flattenCloudSecurityHubIntegration(t))
 		}
 	}
 }
@@ -789,6 +799,10 @@ func buildDeleteInput(d *schema.ResourceData) cloud.CloudDisableIntegrationsInpu
 
 	if _, ok := d.GetOk("sns"); ok {
 		cloudDisableAwsIntegration.Sns = []cloud.CloudDisableAccountIntegrationInput{{LinkedAccountId: linkedAccountID}}
+	}
+
+	if _, ok := d.GetOk("security_hub"); ok {
+		cloudDisableAwsIntegration.SecurityHub = []cloud.CloudDisableAccountIntegrationInput{{LinkedAccountId: linkedAccountID}}
 	}
 
 	deleteInput := cloud.CloudDisableIntegrationsInput{
@@ -2990,6 +3004,43 @@ func expandCloudAwsIntegrationSnsInput(b []interface{}, linkedAccountID int) []c
 	return expanded
 }
 
+// Expanding the SecurityHub input
+
+func expandCloudAwsIntegrationSecurityHubInput(x []interface{}, linkedAccountID int) []cloud.CloudSecurityHubIntegrationInput {
+	expanded := make([]cloud.CloudSecurityHubIntegrationInput, len(x))
+
+	for i, securityhub := range x {
+		var securityhubInput cloud.CloudSecurityHubIntegrationInput
+
+		if securityhub == nil {
+			securityhubInput.LinkedAccountId = linkedAccountID
+			expanded[i] = securityhubInput
+			return expanded
+		}
+
+		in := securityhub.(map[string]interface{})
+
+		securityhubInput.LinkedAccountId = linkedAccountID
+
+		if a, ok := in["aws_regions"]; ok {
+			awsRegions := a.([]interface{})
+			var regions []string
+
+			for _, region := range awsRegions {
+				regions = append(regions, region.(string))
+			}
+			securityhubInput.AwsRegions = regions
+		}
+
+		if m, ok := in["metrics_polling_interval"]; ok {
+			securityhubInput.MetricsPollingInterval = m.(int)
+		}
+		expanded[i] = securityhubInput
+	}
+
+	return expanded
+}
+
 // flatten for Billing integration
 
 func flattenCloudAwsBillingIntegration(in *cloud.CloudBillingIntegration) []interface{} {
@@ -3825,6 +3876,21 @@ func flattenCloudSnsIntegration(in *cloud.CloudSnsIntegration) []interface{} {
 	out["aws_regions"] = in.AwsRegions
 	out["metrics_polling_interval"] = in.MetricsPollingInterval
 	out["fetch_extended_inventory"] = in.FetchExtendedInventory
+
+	flattened[0] = out
+
+	return flattened
+}
+
+// flatten for SecurityHub integration
+
+func flattenCloudSecurityHubIntegration(in *cloud.CloudSecurityHubIntegration) []interface{} {
+	flattened := make([]interface{}, 1)
+
+	out := make(map[string]interface{})
+
+	out["aws_regions"] = in.AwsRegions
+	out["metrics_polling_interval"] = in.MetricsPollingInterval
 
 	flattened[0] = out
 


### PR DESCRIPTION
# Description

Add support for Aws Security Hub integration. 
Go client side PR : https://github.com/newrelic/newrelic-client-go/pull/1299

Jira ticket : https://new-relic.atlassian.net/browse/NR-412555

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

Note : Not Updating the documentation as of now in this PR. Documentation changes requires review from the content team.
So I'll raise another PR on the documentation change when this new feature goes live. 

## Checklist:

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Performed the testing for creating/updating Aws Security Hub integration locally for an NR account.
- Updated the go.mod file to use local go-client 
- updated the changed to newrelic.tf file to test :
`resource "newrelic_cloud_aws_link_account" "foo" {
  arn = "arn:aws:iam::22263*******:role/NewRelicInfrastructure-Integrations"
  metric_collection_mode = "PULL"
  name = "22263******"
}`

`resource "newrelic_cloud_aws_integrations" "bar" {
  linked_account_id = newrelic_cloud_aws_link_account.foo.id
  security_hub{
    metrics_polling_interval = 43200
    aws_regions              = ["us-east-1"]
  }`

- Was able to successfully create/update/delete the security hub integration. 
- Attaching some screenshot reference for the same :
![image](https://github.com/user-attachments/assets/bf45a7b9-5682-4071-9867-6930e26e7c2f)


