### PR TITLE
feat(dashboards): add support for multi account queries in widgets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,14 @@ module github.com/newrelic/terraform-provider-newrelic/v2
 
 go 1.23.6
 
+replace github.com/newrelic/newrelic-client-go/v2 => github.com/newrelic/newrelic-client-go/v2 v2.66.1-0.20250722165456-186f235a16d7
+
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.30.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.66.0
+	github.com/newrelic/newrelic-client-go/v2 v2.66.1-0.20250722165456-186f235a16d7
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 )

--- a/go.mod
+++ b/go.mod
@@ -2,14 +2,12 @@ module github.com/newrelic/terraform-provider-newrelic/v2
 
 go 1.23.6
 
-replace github.com/newrelic/newrelic-client-go/v2 => github.com/newrelic/newrelic-client-go/v2 v2.66.1-0.20250722165456-186f235a16d7
-
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.30.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.66.1-0.20250722165456-186f235a16d7
+	github.com/newrelic/newrelic-client-go/v2 v2.67.0
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 )

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.66.1-0.20250722165456-186f235a16d7 h1:Fl3xQn6H0dgyZUw4wJ+NkZZ67x4FAGEvuY7H2qm1haY=
-github.com/newrelic/newrelic-client-go/v2 v2.66.1-0.20250722165456-186f235a16d7/go.mod h1:qrs1eeDeXWE1/8nrk6471ZHYIrfiF/BSMX33HLtcbu0=
+github.com/newrelic/newrelic-client-go/v2 v2.67.0 h1:7iTzwiAaZaYzbScSvaSJUPtBbPHb32fSWECdVc8KpFA=
+github.com/newrelic/newrelic-client-go/v2 v2.67.0/go.mod h1:qrs1eeDeXWE1/8nrk6471ZHYIrfiF/BSMX33HLtcbu0=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.66.0 h1:a4TgJxP9m4I9XKavBdmkMIjPAUh0bdl7bEe6TPdWX1w=
-github.com/newrelic/newrelic-client-go/v2 v2.66.0/go.mod h1:qrs1eeDeXWE1/8nrk6471ZHYIrfiF/BSMX33HLtcbu0=
+github.com/newrelic/newrelic-client-go/v2 v2.66.1-0.20250722165456-186f235a16d7 h1:Fl3xQn6H0dgyZUw4wJ+NkZZ67x4FAGEvuY7H2qm1haY=
+github.com/newrelic/newrelic-client-go/v2 v2.66.1-0.20250722165456-186f235a16d7/go.mod h1:qrs1eeDeXWE1/8nrk6471ZHYIrfiF/BSMX33HLtcbu0=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/newrelic/resource_newrelic_one_dashboard.go
+++ b/newrelic/resource_newrelic_one_dashboard.go
@@ -519,10 +519,11 @@ func dashboardWidgetNRQLQuerySchemaElem() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"account_id": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Computed:    true,
-				Description: "The account id used for the NRQL query.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				Description:  "The account ID(s) used for the NRQL query. Can be a single account ID or multiple account IDs in a JSON-encoded array.",
+				ValidateFunc: validateDashboardWidgetNRQLQueryAccountIDs,
 			},
 			"query": {
 				Type:        schema.TypeString,

--- a/newrelic/resource_newrelic_one_dashboard_test.go
+++ b/newrelic/resource_newrelic_one_dashboard_test.go
@@ -178,7 +178,14 @@ func TestAccNewRelicOneDashboard_PageNRQLAccountIdConflict(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckNewRelicOneDashboardConfig_PageNRQLAccountIdsUpdated(rName, strconv.Itoa(testAccountID)),
+				Config:      testAccCheckNewRelicOneDashboardConfig_PageNRQLAccountIdsUpdated(rName, strconv.Itoa(testAccountID)),
+				ExpectError: regexp.MustCompile(`Use a single numeric ID instead of a list`),
+			},
+			{
+				Config: testAccCheckNewRelicOneDashboardConfig_PageNRQLAccountIdsUpdated(
+					rName,
+					fmt.Sprintf("%s,%s", strconv.Itoa(testAccountID), strconv.Itoa(testSubAccountID)),
+				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicOneDashboardExists("newrelic_one_dashboard.bar", 10), // Sleep waiting for entity re-indexing
 				),

--- a/newrelic/resource_newrelic_one_dashboard_test.go
+++ b/newrelic/resource_newrelic_one_dashboard_test.go
@@ -162,6 +162,36 @@ func TestAccNewRelicOneDashboard_InvalidNRQL(t *testing.T) {
 	})
 }
 
+// TestAccNewRelicOneDashboard_PageNRQLAccountIdConflict ensures that we set both multiple account_ids and a single account_id in a same NRQL query block with account_id key
+func TestAccNewRelicOneDashboard_PageNRQLAccountIdConflict(t *testing.T) {
+
+	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicOneDashboardDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckNewRelicOneDashboardConfig_PageNRQLAccountId(rName, strconv.Itoa(testAccountID)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicOneDashboardExists("newrelic_one_dashboard.bar", 0),
+				),
+			},
+			{
+				Config: testAccCheckNewRelicOneDashboardConfig_PageNRQLAccountIdsUpdated(rName, strconv.Itoa(testAccountID)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicOneDashboardExists("newrelic_one_dashboard.bar", 10), // Sleep waiting for entity re-indexing
+				),
+			},
+			{
+				ResourceName:      "newrelic_one_dashboard.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 // TestAccNewRelicOneDashboard_FilterCurrentDashboard Checks if linked_entity_guid is set after updating
 func TestAccNewRelicOneDashboard_FilterCurrentDashboard(t *testing.T) {
 	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
@@ -1311,6 +1341,50 @@ resource "newrelic_one_dashboard" "tooltip_test" {
 
       tooltip {
         mode = "single"
+      }
+    }
+  }
+}`
+}
+
+func testAccCheckNewRelicOneDashboardConfig_PageNRQLAccountId(dashboardName string, accountID string) string {
+
+	return `
+	resource "newrelic_one_dashboard" "bar" {
+	  name = "` + dashboardName + `"
+	  permissions = "private"
+		page {
+		name = "` + dashboardName + `"
+		widget_line {
+		  title = "foo"
+		  row = 1
+		  column = 1
+		  nrql_query {
+			account_id = ` + accountID + `
+			query      = "FROM Transaction SELECT 1 TIMESERIES LIMIT 10"
+		  }
+		}
+	  }
+	}
+`
+}
+
+func testAccCheckNewRelicOneDashboardConfig_PageNRQLAccountIdsUpdated(dashboardName string, accountID string) string {
+	return `
+resource "newrelic_one_dashboard" "bar" {
+  name = "` + dashboardName + `"
+  permissions = "private"
+
+  page {
+    name = "` + dashboardName + `"
+
+    widget_line {
+      title = "foo"
+      row = 1
+      column = 1
+      nrql_query {
+		account_id = jsonencode([` + accountID + `])
+        query      = "FROM Transaction SELECT 1 TIMESERIES LIMIT 10"
       }
     }
   }

--- a/website/docs/guides/newrelic_one_dashboard_multi_account_guide.html.markdown
+++ b/website/docs/guides/newrelic_one_dashboard_multi_account_guide.html.markdown
@@ -1,0 +1,125 @@
+---
+layout: "newrelic"
+page_title: "New Relic: `newrelic_one_dashboard` - Multi-Account Query Upgrade Guide"
+sidebar_current: "docs-newrelic-provider-one-dashboard-multi-account-guide"
+description: |-
+  A guide for using the enhanced `account_id` attribute to support both single and multi-account NRQL queries in `newrelic_one_dashboard` widgets.
+---
+
+## Guide: Upgrading to Multi-Account Queries with the **account_id** Attribute in newrelic_one_dashboard resource
+
+The `newrelic_one_dashboard` resource allows you to create and manage dashboards in New Relic. Within this resource, the [`account_id`](providers/newrelic/newrelic/latest/docs/resources/one_dashboard#account_id-2) attribute in the [`nrql_query`](providers/newrelic/newrelic/latest/docs/resources/one_dashboard#nested-nrql_query-blocks) block (used with various widgets) is used to specify the account from which data is queried for widgets. To enhance its functionality, with v3.65.0 of the New Relic Terraform Provider, the `account_id` attribute has been upgraded to support querying across multiple accounts in a single widget.
+
+This guide explains what has changed, why it changed, and how to use the new, more powerful functionality.
+
+### Why the Change?
+
+Previously, each `nrql_query` could only target a single New Relic account. The primary motivation for this update was to **enable multi-account NRQL queries**, a highly requested addition that allows you to build much more powerful and consolidated dashboards, comprising widgets powered by cross-account queries.
+
+To achieve this without introducing breaking changes or confusing new attributes, we've made the existing `account_id` attribute more flexible.
+
+--- 
+
+### How to Use the New `account_id`
+
+The `account_id` attribute now accepts both a single ID (as before) and a list of IDs for multi-account queries.
+
+### For a Single Account ID
+
+There is **no change** to how you configure a single account. You can continue to provide the account ID as a plain number.
+
+```hcl
+resource "newrelic_one_dashboard" "example" {
+  # ...
+  page {
+    widget_bar {
+      title = "Single Account Widget"
+      nrql_query {
+        # This syntax remains the same.
+        account_id = 1234567
+        query      = "SELECT count(*) FROM Transaction"
+      }
+    }
+  }
+}
+```
+
+### For Multiple Account IDs (New)
+
+To query multiple accounts, provide a list of numbers to the `account_id` attribute using the Terraform built-in [`jsonencode()`](https://developer.hashicorp.com/terraform/language/functions/jsonencode) function.
+
+💡 Tip: Using `jsonencode()` is the standard and safest way to provide a list or complex type as a string to a Terraform attribute - and is hence, the recommended/supported approach for the `account_id` attribute to contain multiple account IDs.
+
+```hcl
+resource "newrelic_one_dashboard" "example" {
+  page {
+    widget_line {
+      title = "Multi-Account Widget"
+      nrql_query {
+        # Use jsonencode() to provide a list of account IDs.
+        account_id = jsonencode([1234567, 9876543, 5554443])
+        query      = "SELECT count(*) FROM Transaction"
+      }
+    }
+  }
+}
+```
+
+## 🚀 Upgrading from a Previous Version
+We have designed this change to be 100% backward-compatible. Your existing dashboard configurations will continue to work as usual, without any manual changes required.
+
+However, here's a full example showing how you might evolve your HCL file to use `nrql_query` with multiple account IDs.
+
+### Before (Old Provider Version, prior to v3.65.0)
+
+```hcl
+resource "newrelic_one_dashboard" "my_dashboard" {
+  name = "Production Overview"
+  page {
+    name = "Services"
+    widget_table {
+      title  = "Transaction Errors (App A)"
+      row    = 1
+      column = 1
+      nrql_query {
+        account_id = 1111111
+        query      = "SELECT count(*) FROM TransactionError FACET appName"
+      }
+    }
+  }
+}
+```
+### After (New Provider Version, v.3.65.0+)
+Notice how the existing widget for App A is untouched. We've simply added a new multi-account widget - you can modify/update the existing single account query to contain multiple account IDs too, with the `jsonencode()` syntax as shown.
+
+```hcl
+resource "newrelic_one_dashboard" "my_dashboard" {
+  name = "Production Overview"
+  page {
+    name = "Services"
+
+    # This existing widget requires NO changes.
+    widget_table {
+      title  = "Transaction Errors (App A)"
+      row    = 1
+      column = 1
+      nrql_query {
+        account_id = 1111111 # Still works perfectly.
+        query      = "SELECT count(*) FROM TransactionError FACET appName"
+      }
+    }
+
+    # NEW: A second widget querying multiple accounts.
+    widget_line {
+      title  = "Combined API Gateway Throughput"
+      row    = 1
+      column = 2
+      nrql_query {
+        account_id = jsonencode([1111111, 2222222, 3333333])
+        query      = "SELECT rate(count(*), 1 minute) FROM ApiGatewaySample"
+      }
+    }
+  }
+}
+```
+


### PR DESCRIPTION
TBD
Replaces #2912

```hcl
resource "newrelic_one_dashboard" "my_dashboard" {
  name        = "Test Dashboard 2807"
  permissions = "public_read_only"

  page {
    name = "Test Dashboard 2807"

    widget_table {
      title  = "List of Transactions"
      row    = 1
      column = 4
      width  = 6
      height = 3

      nrql_query {
#         account_id = 3959347
#         account_id = jsonencode([3959347, 3806526])
        query      = "SELECT average(duration), max(duration), min(duration) FROM Transaction FACET name SINCE 1 day ago"
      }
    }
  }
}
```