### PR TITLE
feat: example onboarding for logging integration

### DIFF
--- a/examples/modules/cloud-integrations/oci/oci-logging-integration/main.tf
+++ b/examples/modules/cloud-integrations/oci/oci-logging-integration/main.tf
@@ -1,3 +1,10 @@
+# OCI New Relic Account Linking
+resource "newrelic_cloud_oci_link_account" "nr_link_account" {
+  tenant_id = var.tenancy_ocid
+  name = var.tenancy_ocid
+  description = "[DO NOT REMOVE] Links OCI tenancy to New Relic for cloud integration"
+}
+
 # Cross-Tenancy New Relic Read-Only Access Policy
 resource "oci_identity_policy" "cross_tenancy_read_only_policy" {
   compartment_id = var.compartment_ocid
@@ -6,8 +13,8 @@ resource "oci_identity_policy" "cross_tenancy_read_only_policy" {
   statements     = [
     "Define tenancy NRTenancyAlias as ${var.new_relic_tenancy_ocid}",
     "Define group NRCustomerOCIAccessGroupAlias as ${var.new_relic_group_ocid}",
-    "Admit group NRCustomerOCIAccessGroupAlias of tenancy NRTenancyAlias to read virtual-network-family in tenancy",
     "Admit group NRCustomerOCIAccessGroupAlias of tenancy NRTenancyAlias to read log-content in tenancy",
+    "Admit group NRCustomerOCIAccessGroupAlias of tenancy NRTenancyAlias to inspect compartments in tenancy"
   ]
 }
 
@@ -49,7 +56,7 @@ resource "oci_identity_policy" "functions_vault_access_policy" {
 # Vault Resources for New Relic API Key
 resource "oci_kms_vault" "newrelic_vault" {
   compartment_id = var.compartment_ocid
-  display_name   = var.kms_vault_name
+  display_name   = "newrelic-vault"
   vault_type     = "DEFAULT"
 }
 
@@ -74,11 +81,4 @@ resource "oci_vault_secret" "api_key" {
     content      = base64encode(var.newrelic_ingest_api_key)
     name         = "testkey"
   }
-}
-
-# Link OCI Tenancy to New Relic Account
-resource "newrelic_cloud_oci_link_account" "nr_link_account" {
-  tenant_id = var.tenancy_ocid
-  name = var.tenancy_ocid
-  description = "Links OCI tenancy to New Relic for logging integration"
 }

--- a/examples/modules/cloud-integrations/oci/oci-logging-integration/providers.tf
+++ b/examples/modules/cloud-integrations/oci/oci-logging-integration/providers.tf
@@ -15,18 +15,12 @@ terraform {
 provider "oci" {
   alias                = "home"
   tenancy_ocid         = var.tenancy_ocid
-  user_ocid            = data.oci_identity_user.current_user.user_id
+  user_ocid            = var.current_user_ocid
   region               = var.region
-  private_key_path     = var.private_key_path != "" ? var.private_key_path : null
-  fingerprint          = var.fingerprint
 }
 
 provider "newrelic" {
   region = "US" # US or EU
   account_id = var.newrelic_account_id
   api_key = var.newrelic_user_api_key
-}
-
-data "oci_identity_user" "current_user" {
-  user_id = var.current_user_ocid
 }

--- a/examples/modules/cloud-integrations/oci/oci-logging-integration/variables.tf
+++ b/examples/modules/cloud-integrations/oci/oci-logging-integration/variables.tf
@@ -19,17 +19,6 @@ variable "region" {
   default     = "us-ashburn-1"
 }
 
-variable "private_key_path" {
-  type        = string
-  description = "The path to the private key file used for OCI API authentication. Generate using: openssl genrsa -out ~/.oci/oci_api_key.pem 2048"
-  default     = ""
-}
-
-variable "fingerprint" {
-  type        = string
-  description = "The fingerprint of the public key. Get this from OCI Console -> User Settings -> API Keys"
-}
-
 variable "new_relic_tenancy_ocid" {
   description = "The OCID of the New Relic tenancy to which access will be granted."
   type        = string
@@ -42,24 +31,15 @@ variable "new_relic_group_ocid" {
 
 variable "newrelic_account_id" {
   type        = string
-  sensitive   = true
   description = "The New Relic account ID for sending metrics to New Relic endpoints"
 }
 
 variable "newrelic_ingest_api_key" {
   type        = string
-  sensitive   = true
   description = "The Ingest API key for sending logs to New Relic endpoints"
 }
 
 variable "newrelic_user_api_key" {
   type        = string
-  sensitive   = true
   description = "The User API key for Linking the OCI Account to the New Relic account"
-}
-
-variable "kms_vault_name" {
-  type        = string
-  description = "The display name of the KMS vault for storing New Relic secrets"
-  default     = "newrelic-vault"
 }


### PR DESCRIPTION
# Description
This PR creates onboarding flow for OCI - Logging Integrations. 
1. Defines NRTenancyAlias and NRCustomerOCIAccessGroupAlias. 
2. Allows NRTenancyAlias to read virtual-network-family and log-content in tenancy.
3. Allows connector hubs to read log content and invoke function. 
4. Allows functions to read secret bundles. 
5. Creates vault for license key. 
6. Links OCI tenancy to New Relic for logging integration. 


## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update