### PR TITLE
fix(newrelic_one_dashboard): add plan-time validation for `account_ids` in `variable{}` block

### DIFF
--- a/newrelic/resource_newrelic_one_dashboard.go
+++ b/newrelic/resource_newrelic_one_dashboard.go
@@ -145,6 +145,7 @@ func dashboardVariableSchemaElem() *schema.Resource {
 						"account_ids": {
 							Type:        schema.TypeList,
 							Optional:    true,
+							Computed:    true,
 							Description: "New Relic account ID(s) to issue the query against.",
 							Elem: &schema.Schema{
 								Type: schema.TypeInt,

--- a/newrelic/resource_newrelic_one_dashboard.go
+++ b/newrelic/resource_newrelic_one_dashboard.go
@@ -145,7 +145,6 @@ func dashboardVariableSchemaElem() *schema.Resource {
 						"account_ids": {
 							Type:        schema.TypeList,
 							Optional:    true,
-							Computed:    true,
 							Description: "New Relic account ID(s) to issue the query against.",
 							Elem: &schema.Schema{
 								Type: schema.TypeInt,

--- a/newrelic/resource_newrelic_one_dashboard_test.go
+++ b/newrelic/resource_newrelic_one_dashboard_test.go
@@ -586,7 +586,7 @@ func TestAccNewRelicOneDashboard_VariableAccountIDsValidation(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccNewRelicOneDashboardConfigVariableAccountIDs(rName),
-				ExpectError: regexp.MustCompile(`variable\[0\]: account_ids cannot be empty for NRQL variables`),
+				ExpectError: regexp.MustCompile("`account_ids` cannot be empty for NRQL variables"),
 			},
 		},
 	})

--- a/newrelic/resource_newrelic_one_dashboard_test.go
+++ b/newrelic/resource_newrelic_one_dashboard_test.go
@@ -1673,3 +1673,125 @@ EOT
 	  }
 	}`
 }
+
+// TestAccNewRelicOneDashboard_VariableDefaultAccountIDs tests the default behavior of account_ids in variables
+func TestAccNewRelicOneDashboard_VariableDefaultAccountIDs(t *testing.T) {
+	resourceName := "newrelic_one_dashboard.bar"
+	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicOneDashboardDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create dashboard with variable but without explicit account_ids
+			{
+				Config: testAccNewRelicOneDashboardConfigVariableAccountIDsOmitted(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicOneDashboardExists(resourceName, 0),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "variable.0.name", "test_variable"),
+					resource.TestCheckResourceAttr(resourceName, "variable.0.type", "nrql"),
+				),
+			},
+			// Step 2: Update with explicit account_ids - should not cause drift
+			{
+				Config: testAccNewRelicOneDashboardConfigVariableAccountIDsExplicit(rName, strconv.Itoa(testAccountID)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicOneDashboardExists(resourceName, 0),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					// account_ids should be explicitly set in state
+					resource.TestCheckResourceAttr(resourceName, "variable.0.nrql_query.0.account_ids.#", "1"),
+				),
+			},
+			// Step 3: Remove explicit account_ids again - should not cause drift
+			{
+				Config: testAccNewRelicOneDashboardConfigVariableAccountIDsOmitted(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicOneDashboardExists(resourceName, 0),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			// Step 4: Import test to verify state consistency
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Test configuration with variable account_ids omitted
+func testAccNewRelicOneDashboardConfigVariableAccountIDsOmitted(dashboardName string) string {
+	return fmt.Sprintf(`
+resource "newrelic_one_dashboard" "bar" {
+  name = "%[1]s"
+
+  page {
+    name = "Test Page"
+
+    widget_line {
+      title  = "Test Widget"
+      row    = 1
+      column = 1
+      width  = 6
+      height = 3
+
+      nrql_query {
+        query = "FROM Transaction SELECT average(duration) FACET appName TIMESERIES"
+      }
+    }
+  }
+
+  variable {
+    name               = "test_variable"
+    title              = "Test Variable"
+    type               = "nrql"
+    replacement_strategy = "default"
+
+    nrql_query {
+      # account_ids intentionally omitted to test defaulting
+      query = "FROM Transaction SELECT uniques(appName)"
+    }
+  }
+}
+`, dashboardName)
+}
+
+// Test configuration with variable account_ids explicitly set
+func testAccNewRelicOneDashboardConfigVariableAccountIDsExplicit(dashboardName string, accountID string) string {
+	return fmt.Sprintf(`
+resource "newrelic_one_dashboard" "bar" {
+  name = "%[1]s"
+
+  page {
+    name = "Test Page"
+
+    widget_line {
+      title  = "Test Widget"
+      row    = 1
+      column = 1
+      width  = 6
+      height = 3
+
+      nrql_query {
+        query = "FROM Transaction SELECT average(duration) FACET appName TIMESERIES"
+      }
+    }
+  }
+
+  variable {
+    name               = "test_variable"
+    title              = "Test Variable"
+    type               = "nrql"
+    replacement_strategy = "default"
+
+    nrql_query {
+      account_ids = [%[2]s]
+      query       = "FROM Transaction SELECT uniques(appName)"
+    }
+  }
+}
+`, dashboardName, accountID)
+}

--- a/newrelic/structures_newrelic_one_dashboard.go
+++ b/newrelic/structures_newrelic_one_dashboard.go
@@ -213,8 +213,7 @@ func expandVariableNRQLQuery(in []interface{}, meta interface{}) *dashboards.Das
 
 		// Default to provider account ID if not set or empty
 		if !hasAccountIDs {
-			log.Printf("[DEBUG] expandVariableNRQLQuery: account_ids not set or empty, attempting to default from provider...")
-			
+			log.Printf("[DEBUG] expandVariableNRQLQuery: account_ids not set or empty, attempting to default from provider.")
 			if metaMap, ok := meta.(map[string]interface{}); ok {
 				if acct, exists := metaMap["account_id"]; exists {
 					accountIDs = []int{acct.(int)}

--- a/newrelic/structures_newrelic_one_dashboard.go
+++ b/newrelic/structures_newrelic_one_dashboard.go
@@ -139,7 +139,7 @@ func expandDashboardVariablesInput(variables []interface{}, meta interface{}) ([
 		}
 
 		if q, ok := v["nrql_query"]; ok && len(q.([]interface{})) > 0 {
-			variable.NRQLQuery = expandVariableNRQLQuery(q.([]interface{}), meta)
+			variable.NRQLQuery = expandVariableNRQLQuery(q.([]interface{}))
 		}
 
 		if r, ok := v["replacement_strategy"]; ok {
@@ -190,7 +190,7 @@ func expandVariableItems(in []interface{}) []dashboards.DashboardVariableEnumIte
 	return out
 }
 
-func expandVariableNRQLQuery(in []interface{}, meta interface{}) *dashboards.DashboardVariableNRQLQueryInput {
+func expandVariableNRQLQuery(in []interface{}) *dashboards.DashboardVariableNRQLQueryInput {
 
 	var out dashboards.DashboardVariableNRQLQueryInput
 
@@ -203,42 +203,6 @@ func expandVariableNRQLQuery(in []interface{}, meta interface{}) *dashboards.Das
 
 	return &out
 
-	//var out dashboards.DashboardVariableNRQLQueryInput
-	//
-	//for _, v := range in {
-	//	cfg := v.(map[string]interface{})
-	//
-	//	var accountIDs []int
-	//	rawAccountIDs, hasAccountIDs := cfg["account_ids"]
-	//
-	//	// Check if account_ids is explicitly set AND non-empty
-	//	if hasAccountIDs && rawAccountIDs != nil {
-	//		accountIDsSlice := rawAccountIDs.([]interface{})
-	//		if len(accountIDsSlice) > 0 {
-	//			// Non-empty slice, use as-is
-	//			accountIDs = expandVariableAccountIDs(accountIDsSlice)
-	//		} else {
-	//			// Empty slice - treat as omitted for defaulting purposes
-	//			hasAccountIDs = false
-	//		}
-	//	}
-	//
-	//	// Default to provider account ID if not set or empty
-	//	if !hasAccountIDs {
-	//		log.Printf("[DEBUG] expandVariableNRQLQuery: account_ids not set or empty, attempting to default from provider.")
-	//		if metaMap, ok := meta.(map[string]interface{}); ok {
-	//			if acct, exists := metaMap["account_id"]; exists {
-	//				accountIDs = []int{acct.(int)}
-	//			}
-	//		}
-	//	}
-	//
-	//	out = dashboards.DashboardVariableNRQLQueryInput{
-	//		AccountIDs: accountIDs,
-	//		Query:      nrdb.NRQL(cfg["query"].(string)),
-	//	}
-	//}
-	//return &out
 }
 
 func expandVariableAccountIDs(in []interface{}) []int {

--- a/newrelic/structures_newrelic_one_dashboard.go
+++ b/newrelic/structures_newrelic_one_dashboard.go
@@ -37,7 +37,7 @@ func expandDashboardInput(d *schema.ResourceData, meta interface{}, dashboardNam
 		return nil, err
 	}
 
-	dash.Variables, err = expandDashboardVariablesInput(d.Get("variable").([]interface{}), meta)
+	dash.Variables, err = expandDashboardVariablesInput(d.Get("variable").([]interface{}))
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func validateDashboardWidgetNRQLQueryAccountIDs(accountIDValue interface{}, key 
 	return
 }
 
-func expandDashboardVariablesInput(variables []interface{}, meta interface{}) ([]dashboards.DashboardVariableInput, error) {
+func expandDashboardVariablesInput(variables []interface{}) ([]dashboards.DashboardVariableInput, error) {
 	if len(variables) < 1 {
 		return []dashboards.DashboardVariableInput{}, nil
 	}

--- a/newrelic/structures_newrelic_one_dashboard.go
+++ b/newrelic/structures_newrelic_one_dashboard.go
@@ -191,7 +191,6 @@ func expandVariableItems(in []interface{}) []dashboards.DashboardVariableEnumIte
 }
 
 func expandVariableNRQLQuery(in []interface{}) *dashboards.DashboardVariableNRQLQueryInput {
-
 	var out dashboards.DashboardVariableNRQLQueryInput
 
 	for _, v := range in {
@@ -202,7 +201,6 @@ func expandVariableNRQLQuery(in []interface{}) *dashboards.DashboardVariableNRQL
 	}
 
 	return &out
-
 }
 
 func expandVariableAccountIDs(in []interface{}) []int {

--- a/newrelic/structures_newrelic_one_dashboard.go
+++ b/newrelic/structures_newrelic_one_dashboard.go
@@ -1901,12 +1901,12 @@ func validateDashboardVariableNRQLAccountIDs(d *schema.ResourceDiff, meta interf
 
 			// Check if account_ids is missing or empty
 			if !accountIDsOk {
-				return fmt.Errorf("variable[%d]: account_ids is required for NRQL variables. Default provider account ID is %d - consider setting account_ids = [%d]",
+				return fmt.Errorf("variable[%d]: `account_ids` is required for NRQL variables. The default provider account ID is %d - consider setting `account_ids = [%d]`",
 					i, defaultAccountID, defaultAccountID)
 			}
 
 			if accountIDsSlice, ok := accountIDs.([]interface{}); ok && len(accountIDsSlice) == 0 {
-				return fmt.Errorf("variable[%d]: account_ids cannot be empty for NRQL variables. Default provider account ID is %d - consider setting account_ids = [%d]",
+				return fmt.Errorf("variable[%d]: `account_ids` cannot be empty for NRQL variables. The default provider account ID is %d - consider setting `account_ids = [%d]`",
 					i, defaultAccountID, defaultAccountID)
 			}
 		}

--- a/website/docs/r/one_dashboard.html.markdown
+++ b/website/docs/r/one_dashboard.html.markdown
@@ -428,7 +428,7 @@ This attribute requires specifying the following attributes in a nested block -
 
   data_format {
     name = "Max duration"
-    Type = "duration"
+    type = "duration"
   }
 
   data_format {
@@ -446,13 +446,13 @@ This attribute requires specifying the following attributes in a nested block -
 ```hcl
   data_format {
     name = "timestamp"
-    Type = "date"
+    type = "date"
   }
 
   data_format {
     name = "timestamp"
-    Type = "custom"
-    Format = "%Y-%m-%dT%X.%L%Z"
+    type = "custom"
+    format = "%Y-%m-%dT%X.%L%Z"
   }
 ```
 * Similarly, in order to use `data_format{}` with numeric values, the `type` would be need to set to `decimal`. The `precision` of the value may also be specified with type `decimal`. However, in order to have "Autoformat" enabled on the numeric value, specify the type as `humanized`.

--- a/website/docs/r/one_dashboard.html.markdown
+++ b/website/docs/r/one_dashboard.html.markdown
@@ -249,6 +249,21 @@ EOT
 ```
 See additional [examples](#additional-examples).
 
+## Important: NRQL Query Schema Differences
+
+⚠️ **Critical Difference:** Widget and variable NRQL blocks use different attribute names and formats for account specifications:
+
+| Block Type | Attribute Name | Format | Example |
+|------------|----------------|--------|---------|
+| **Widget** `nrql_query` | `account_id` | String/Number or JSON-encoded array | `12345` or `jsonencode([12345, 67890])` |
+| **Variable** `nrql_query` | `account_ids` | List of integers | `[12345, 67890]` |
+
+**Historical Context:** This difference exists because:
+- **Variables** were designed with multi-account support from the beginning (v3.9.0+).
+- **Widgets** originally supported only single accounts, with multi-account support added later (v3.65.0+) using JSON encoding for backward compatibility.
+
+Both blocks default to the provider's configured account ID when the account field is omitted or empty.
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -318,31 +333,31 @@ All nested `widget` blocks support the following common arguments:
 Each widget type supports an additional set of arguments:
 
   * `widget_area`
-    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql_query-blocks) below for details.
+    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks (for Widgets)](#nested-nrql_query-blocks-for-widgets) below for details.
   * `widget_bar`
-    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql_query-blocks) below for details.
+    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks (for Widgets)](#nested-nrql_query-blocks-for-widgets) below for details.
     * `linked_entity_guids`: (Optional) Related entity GUIDs. Currently only supports Dashboard entity GUIDs.
     * `filter_current_dashboard`: (Optional) Use this item to filter the current dashboard.
   * `widget_billboard`
-    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql_query-blocks) below for details.
+    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks (for Widgets)](#nested-nrql_query-blocks-for-widgets) below for details.
     * `critical` - (Optional) Threshold above which the displayed value will be styled with a red color.
     * `warning` - (Optional) Threshold above which the displayed value will be styled with a yellow color.
     * `data_format` - (Optional) A nested block that describes data format. See [Nested data_format blocks](#nested-data_format-blocks) below for details.
   * `widget_bullet`
-    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql_query-blocks) below for details.
+    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks (for Widgets)](#nested-nrql_query-blocks-for-widgets) below for details.
     * `limit` - (Required) Visualization limit for the widget.
   * `widget_funnel`
-    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql_query-blocks) below for details.
+    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks (for Widgets)](#nested-nrql_query-blocks-for-widgets) below for details.
   * `widget_json`
-    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql_query-blocks) below for details.
+    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks (for Widgets)](#nested-nrql_query-blocks-for-widgets) below for details.
   * `widget_heatmap`
-    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql_query-blocks) below for details.
+    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks (for Widgets)](#nested-nrql_query-blocks-for-widgets) below for details.
     * `linked_entity_guids`: (Optional) Related entity GUIDs. Currently only supports Dashboard entity GUIDs.
     * `filter_current_dashboard`: (Optional) Use this item to filter the current dashboard.
   * `widget_histogram`
-    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql_query-blocks) below for details.
+    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks (for Widgets)](#nested-nrql_query-blocks-for-widgets) below for details.
   * `widget_line`
-    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql_query-blocks) below for details.
+    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks (for Widgets)](#nested-nrql_query-blocks-for-widgets) below for details.
     * `y_axis_left_zero` - (Optional) An attribute that specifies if the values on the graph to be rendered need to be fit to scale, or printed within the specified range from `y_axis_left_min` (or 0 if it is not defined) to `y_axis_left_max`. Use `y_axis_left_zero = true` with a combination of `y_axis_left_min` and `y_axis_left_max` to render values from 0 or the specified minimum to the maximum, and `y_axis_left_zero = false` to fit the graph to scale.
     * `y_axis_right` - (Optional) An attribute which helps specify the configuration of the Y-Axis displayed on the right side of the line widget. This is a nested block, which includes the following attributes:
       * `y_axis_right_zero` - (Optional) An attribute that specifies if the values on the graph to be rendered need to be fit to scale, or printed within the specified range from `y_axis_right_min` (or 0 if it is not defined) to `y_axis_right_max`. Use `y_axis_right_zero = true` with a combination of `y_axis_right_min` and `y_axis_right_max` to render values from 0 or the specified minimum to the maximum, and `y_axis_right_zero = false` to fit the graph to scale.
@@ -357,15 +372,15 @@ Each widget type supports an additional set of arguments:
   * `widget_markdown`:
     * `text` - (Required) The markdown source to be rendered in the widget.
   * `widget_stacked_bar`
-    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql_query-blocks) below for details.
+    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks (for Widgets)](#nested-nrql_query-blocks-for-widgets) below for details.
   * `widget_pie`
-    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql_query-blocks) below for details.
+    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks (for Widgets)](#nested-nrql_query-blocks-for-widgets) below for details.
     * `linked_entity_guids`: (Optional) Related entity GUIDs. Currently only supports Dashboard entity GUIDs.
     * `filter_current_dashboard`: (Optional) Use this item to filter the current dashboard.
   * `widget_log_table`
-    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql_query-blocks) below for details.
+    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks (for Widgets)](#nested-nrql_query-blocks-for-widgets) below for details.
   * `widget_table`
-    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks](#nested-nrql_query-blocks) below for details.
+    * `nrql_query` - (Required) A nested block that describes a NRQL Query. See [Nested nrql\_query blocks (for Widgets)](#nested-nrql_query-blocks-for-widgets) below for details.
     * `linked_entity_guids`: (Optional) Related entity GUIDs. Currently only supports Dashboard entity GUIDs.
     * `filter_current_dashboard`: (Optional) Use this item to filter the current dashboard.
     * `threshold` - (Optional) An attribute that helps specify multiple thresholds, each inclusive of a range of values between which the threshold would need to function, the name of the threshold and its severity. Multiple thresholds can be defined in a table widget. The `threshold` attribute requires specifying the following attributes in a nested block - 
@@ -468,20 +483,23 @@ This attribute requires specifying the following attributes in a nested block -
   }
 ```
 
-### Nested `nrql_query` blocks
+### Nested `nrql_query` blocks (for Widgets)
 
-Nested `nrql_query` blocks allow you to make one or more NRQL queries within a widget, against a specified account.
+Nested `nrql_query` blocks in **widget** allow you to make one or more NRQL queries within a widget, against one or more specified accounts.
 
 The following arguments are supported:
 
 -> **❗<b style="color:green;">\*NEW\*</b>** **Starting v3.65.0 of the New Relic Terraform Provider**, <b style="color:green;">one can provide a list of account IDs as the value of the attribute** `account_id`.</b> **This allows creating a dashboard that queries data from multiple accounts**, and is particularly useful for cross-account dashboards.<br><br>The value should be a JSON-encoded list of account IDs, e.g., `jsonencode([12345, 67890])`. See the example below for details on the usage of `account_id` with multiple account IDs.
 
-  * `account_id` - (Optional) Determines the New Relic Account ID(s) to be used to compute the results of the queries provided, corresponding to the widget the `nrql_query` block is used with. _If omitted_, defaults to the account associated with the API key being used. See the example below for usage.
+  * `account_id` - (Optional) Determines the New Relic Account ID(s) to be used to compute the results of the queries provided, corresponding to the widget the `nrql_query` block is used with. Can be:
+    - A single account ID: `12345`. 
+    - A JSON-encoded array for multiple accounts: `jsonencode([12345, 67890])`.
+    - _If omitted_, defaults to the provider's configured account ID.
   * `query` - (Required) Valid NRQL query string. See [Writing NRQL Queries](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/using-nrql/introduction-nrql) for help.
 
 -> **NOTE:** If a widget attempts to query data from an account for which you do not have permissions, Terraform will not throw an error. The operation will succeed, but the widget will display a "data inaccessible" message within the New Relic UI.
 
-The following example demonstrates the usage of `nrql_query` with single and multiple `account_id`s. 
+The following example demonstrates the usage of widget `nrql_query` with single and multiple `account_id`s. 
  * Also see [_this detailed guide_](/providers/newrelic/newrelic/latest/docs/guides/newrelic_one_dashboard_multi_account_guide) which explains the nuances of the change made to have `account_id` accept both, a single account ID, and a JSON-encoded list of (multiple) account IDs, in greater detail with examples.
 
 -> **NOTE:** While `account_id` is an optional attribute and defaults to the account used in the provider configuration if not specified, it is **highly recommended** to **specify the account ID (or) JSON-encoded list of account IDs** in the `nrql_query` block. This ensures that the queries are executed against the correct account(s), facilitates accurate drift management (provides adequate visibility into changes _if any_ occurring to the account IDs associated with the query from external sources such as the UI), and avoids potential issues with data visibility.
@@ -521,13 +539,78 @@ The following arguments are supported:
   * `is_multi_selection` - (Optional) Indicates whether this variable supports multiple selection or not. Only applies to variables of type `nrql` or `enum`.
   * `item` - (Optional) List of possible values for variables of type `enum`. See [Nested item blocks](#nested-item-blocks) below for details.
   * `name` - (Required) The variable identifier.
-  * `nrql_query` - (Optional) Configuration for variables of type `nrql`. See [Nested nrql\_query blocks](#nested-nrql_query-blocks) for details.
+  * `nrql_query` - (Optional) Configuration for variables of type `nrql`. See [Nested nrql\_query blocks for Variables](#nested-nrql_query-blocks-for-variables) for details.
   * `replacement_strategy` - (Optional) Indicates the strategy to apply when replacing a variable in a NRQL query. One of `default`, `identifier`, `number` or `string`.
   * `title` - (Optional) Human-friendly display string for this variable.
   * `type` - (Required) Specifies the data type of the variable and where its possible values may come from. One of `enum`, `nrql` or `string`
   * `options` - (Optional) Specifies additional options to be added to dashboard variables. Supports the following nested attribute(s) -
     * `ignore_time_range` - (Optional) An argument with a boolean value that is supported only by variables of `type` _nrql_ - when true, the time range specified in the query will override the time picker on dashboards and other pages.
     * `excluded` - (Optional) An argument with a boolean value. With this turned on, the query condition defined with the variable will not be included in the query. Defaults to `false`.
+### Nested `nrql_query` blocks (for Variables)
+
+Nested `nrql_query` blocks in **variable** allow you to make NRQL queries to populate dashboard variables with dynamic values from one or more accounts.
+
+The following arguments are supported:
+
+  * `account_ids` - (Optional) List of account IDs such as `[12345, 67890]`. If omitted or set to `[]` (empty list), defaults to the provider's configured account ID.
+  * `query` - (Required) Valid NRQL query string. See [Writing NRQL Queries](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/using-nrql/introduction-nrql) for help.
+
+Example usage:
+```hcl
+variable {
+    default_values     = ["value"]
+    is_multi_selection = true
+    item {
+      title = "item"
+      value = "ITEM"
+    }
+    name = "variable"
+    nrql_query {
+      # Multi-account query - specify multiple account IDs as list of integers
+      account_ids = [12345, 67890]
+      query       = "FROM Transaction SELECT average(duration) FACET appName"
+    }
+    replacement_strategy = "default"
+    title                = "title"
+    type                 = "nrql"
+}
+
+variable {
+    default_values     = ["value"]
+    is_multi_selection = true
+    item {
+      title = "item"
+      value = "ITEM"
+    }
+    name = "variable"
+    nrql_query {
+      # Single account - use list format
+      account_ids = [12345]
+      query       = "FROM Transaction SELECT average(duration) FACET appName"
+    }
+    replacement_strategy = "default"
+    title                = "title"
+    type                 = "nrql"
+}
+
+variable {
+    default_values     = ["value"]
+    is_multi_selection = true
+    item {
+      title = "item"
+      value = "ITEM"
+    }
+    name = "variable"
+    nrql_query {
+      # account_ids defaults to provider account if omitted or empty
+      query       = "FROM Transaction SELECT average(duration) FACET appName"
+    }
+    replacement_strategy = "default"
+    title                = "title"
+    type                 = "nrql"
+}
+```
+
 ### Nested `item` blocks
 
 The following arguments are supported:

--- a/website/docs/r/one_dashboard.html.markdown
+++ b/website/docs/r/one_dashboard.html.markdown
@@ -580,23 +580,6 @@ variable {
     title                = "title"
     type                 = "nrql"
 }
-
-variable {
-    default_values     = ["value"]
-    is_multi_selection = true
-    item {
-      title = "item"
-      value = "ITEM"
-    }
-    name = "variable"
-    nrql_query {
-      # account_ids defaults to provider account if omitted or empty
-      query       = "FROM Transaction SELECT average(duration) FACET appName"
-    }
-    replacement_strategy = "default"
-    title                = "title"
-    type                 = "nrql"
-}
 ```
 
 -> **NOTE:** This is not to be confused with `nrql_query` used with widgets blocks - for more details on the differences between the two, please see the [Important: `nrql_query` Blocks: Schema Differences](#important-nrql_query-blocks-schema-differences) section.
@@ -650,8 +633,6 @@ The following arguments are supported:
 **Historical Context:** This difference exists because:
 - **Variables** were designed with multi-account support from the beginning (v3.9.0+).
 - **Widgets** originally supported only single accounts, with multi-account support added later (v3.65.0+) using JSON encoding for backward compatibility.
-
-Both blocks default to the provider's configured account ID when the account field is omitted or empty.
 
 ## Additional Examples
 

--- a/website/docs/r/one_dashboard.html.markdown
+++ b/website/docs/r/one_dashboard.html.markdown
@@ -249,21 +249,6 @@ EOT
 ```
 See additional [examples](#additional-examples).
 
-## Important: NRQL Query Schema Differences
-
-⚠️ **Critical Difference:** Widget and variable NRQL blocks use different attribute names and formats for account specifications:
-
-| Block Type | Attribute Name | Format | Example |
-|------------|----------------|--------|---------|
-| **Widget** `nrql_query` | `account_id` | String/Number or JSON-encoded array | `12345` or `jsonencode([12345, 67890])` |
-| **Variable** `nrql_query` | `account_ids` | List of integers | `[12345, 67890]` |
-
-**Historical Context:** This difference exists because:
-- **Variables** were designed with multi-account support from the beginning (v3.9.0+).
-- **Widgets** originally supported only single accounts, with multi-account support added later (v3.65.0+) using JSON encoding for backward compatibility.
-
-Both blocks default to the provider's configured account ID when the account field is omitted or empty.
-
 ## Argument Reference
 
 The following arguments are supported:
@@ -531,6 +516,8 @@ widget_line {
 }
 ```
 
+-> **NOTE:** This is not to be confused with `nrql_query` used with variables blocks - for more details on the differences between the two, please see the [Important: `nrql_query` Blocks: Schema Differences](#important-nrql_query-blocks-schema-differences) section.
+
 ### Nested `variable` blocks
 
 The following arguments are supported:
@@ -546,6 +533,7 @@ The following arguments are supported:
   * `options` - (Optional) Specifies additional options to be added to dashboard variables. Supports the following nested attribute(s) -
     * `ignore_time_range` - (Optional) An argument with a boolean value that is supported only by variables of `type` _nrql_ - when true, the time range specified in the query will override the time picker on dashboards and other pages.
     * `excluded` - (Optional) An argument with a boolean value. With this turned on, the query condition defined with the variable will not be included in the query. Defaults to `false`.
+
 ### Nested `nrql_query` blocks (for Variables)
 
 Nested `nrql_query` blocks in **variable** allow you to make NRQL queries to populate dashboard variables with dynamic values from one or more accounts.
@@ -611,6 +599,8 @@ variable {
 }
 ```
 
+-> **NOTE:** This is not to be confused with `nrql_query` used with widgets blocks - for more details on the differences between the two, please see the [Important: `nrql_query` Blocks: Schema Differences](#important-nrql_query-blocks-schema-differences) section.
+
 ### Nested `item` blocks
 
 The following arguments are supported:
@@ -647,6 +637,21 @@ The following arguments are supported:
   * `all` - Show tooltip for all data points.
   * `single` - Show tooltip for a single data point.
   * `hidden` - Hide tooltips completely.
+
+### Important: `nrql_query` Blocks: Schema Differences
+
+⚠️ **Critical Difference:** Widget and variable NRQL blocks use different attribute names and formats for account specifications:
+
+| Block Type | Attribute Name | Format | Example |
+|------------|----------------|--------|---------|
+| **Widget** `nrql_query` | `account_id` | String/Number or JSON-encoded array | `12345` or `jsonencode([12345, 67890])` |
+| **Variable** `nrql_query` | `account_ids` | List of integers | `[12345, 67890]` |
+
+**Historical Context:** This difference exists because:
+- **Variables** were designed with multi-account support from the beginning (v3.9.0+).
+- **Widgets** originally supported only single accounts, with multi-account support added later (v3.65.0+) using JSON encoding for backward compatibility.
+
+Both blocks default to the provider's configured account ID when the account field is omitted or empty.
 
 ## Additional Examples
 

--- a/website/docs/r/one_dashboard.html.markdown
+++ b/website/docs/r/one_dashboard.html.markdown
@@ -540,7 +540,7 @@ Nested `nrql_query` blocks in **variable** allow you to make NRQL queries to pop
 
 The following arguments are supported:
 
-  * `account_ids` - (Optional) List of account IDs such as `[12345, 67890]`. If omitted or set to `[]` (empty list), defaults to the provider's configured account ID.
+  * `account_ids` - (Required) List of account IDs such as `[12345, 67890]`.
   * `query` - (Required) Valid NRQL query string. See [Writing NRQL Queries](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/using-nrql/introduction-nrql) for help.
 
 Example usage:


### PR DESCRIPTION
## Description

This PR aims to add a plan-time validation for the `account_ids` attribute inside the `nrql_query{}` for `variable{}` block. It ensures that `terraform plan` will fail if the attribute is either omitted or set to an empty list (`[]`).

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.
