### PR TITLE
NR-465895: config recorder check

### DIFF
--- a/examples/modules/cloud-integrations/aws/outputs.tf
+++ b/examples/modules/cloud-integrations/aws/outputs.tf
@@ -1,0 +1,20 @@
+output "aws_config_recorder_check" {
+  description = "Status of AWS Config Configuration Recorder check"
+  value = {
+    has_existing_recorder = local.has_existing_recorder
+    should_create_new     = local.should_create_recorder
+    check_log            = local.recorder_check_log
+    recorder_count       = try(data.external.check_existing_recorder.result.count, "unknown")
+    existing_recorders   = try(data.external.check_existing_recorder.result.recorder_names, "none")
+    region              = try(data.external.check_existing_recorder.result.region, data.aws_region.current.id)
+  }
+}
+
+output "newrelic_integration_details" {
+  description = "New Relic integration configuration details"
+  value = {
+    account_id = var.newrelic_account_id
+    region     = var.newrelic_account_region
+    name       = var.name
+  }
+}


### PR DESCRIPTION
# Description

We were getting errors for AWS integration when config recorder already exists in customer's account. 
In this PR, we are checking first if the recorder exists then we are not creating a new recorder. 

Fixes # (issue)
https://new-relic.atlassian.net/browse/NR-465895

## Type of change
Added an additional check before creating recorder in customer's aws account

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.

- [ *] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ *] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [ *] I have performed a self-review of my own code
- [ *] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

This can be tested by running aws terraform deployment in one of the testing account, if all good then this prints following 

```aws_config_recorder_check = {                                                                                                                                                                                    
  "check_log" = "Found 1 existing AWS Config Configuration Recorder(s) in region us-east-1 - Skipping creation to avoid AWS limits."
  "existing_recorders" = "default"
  "has_existing_recorder" = true
  "recorder_count" = "1"
  "region" = "us-east-1"
  "should_create_new" = false
}
newrelic_integration_details = {
  "account_id" = "*"
  "name" = "*"
  "region" = "US"
}```
