### PR TITLE
fix(deps): upgrade v2 to v3 to allow go.dev listing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/newrelic/terraform-provider-newrelic/v2
+module github.com/newrelic/terraform-provider-newrelic/v3
 
 go 1.23.6
 

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
-	"github.com/newrelic/terraform-provider-newrelic/v2/newrelic"
+	"github.com/newrelic/terraform-provider-newrelic/v3/newrelic"
 )
 
 var (

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,4 +1,4 @@
-module github.com/newrelic/terraform-provider-newrelic/v2/tools
+module github.com/newrelic/terraform-provider-newrelic/v3/tools
 
 go 1.23.6
 


### PR DESCRIPTION
As suggested in #2769, this PR aims at upgrading the version tag in all `terraform-provider-newrelic/v*` references in the codebase, to ensure that the tags we're currently releasing versions with (i.e. `v3.*.*`) matches the semantic version inside these references, without which the versions are not being listed currently in go.dev.