### PR TITLE
feat(alerts): Add support for target entity in NRQL conditions

### DIFF
--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -415,6 +415,11 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 					return (strings.EqualFold(old, string(alerts.NrqlSignalSeasonalities.NewRelicCalculation)) && new == "") || strings.EqualFold(old, new)
 				},
 			},
+			"target_entity": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "BETA PREVIEW: the `target_entity` field is in limited release and only enabled for preview on a per-account basis. - The GUID of the entity explicitly targeted by the condition. Issues triggered by this condition will affect the health status of this entity instead of having the affected entity detected automatically",
+			},
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Second),

--- a/newrelic/resource_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition_test.go
@@ -725,6 +725,39 @@ func TestAccNewRelicNrqlAlertCondition_SignalSeasonality(t *testing.T) {
 	})
 }
 
+func TestAccNewRelicNrqlAlertCondition_TargetEntity(t *testing.T) {
+	resourceName := "newrelic_nrql_alert_condition.foo"
+	rName := acctest.RandString(5)
+	targetEntity := "MTE1NTc3N3xOQXwxMjM0NTY3OHwwfDE2ODg5NjU3NjU"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicNrqlAlertConditionDestroy,
+		Steps: []resource.TestStep{
+			// Test: Create condition with target entity
+			{
+				Config: testAccNewRelicNrqlAlertConditionWithTargetEntity(
+					rName,
+					targetEntity,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),
+				),
+			},
+			// Test: Target entity is nullable
+			{
+				Config: testAccNewRelicNrqlAlertConditionWithNullTargetEntity(
+					rName,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicNrqlAlertConditionExists(resourceName),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckNewRelicNrqlAlertConditionDestroy(s *terraform.State) error {
 	providerConfig := testAccProvider.Meta().(*ProviderConfig)
 	client := providerConfig.NewClient
@@ -1545,6 +1578,73 @@ resource "newrelic_nrql_alert_condition" "foo" {
 		threshold_duration    = 120
 		threshold_occurrences = "ALL"
 		disable_health_status_reporting = true
+	}
+}
+`, name)
+}
+
+func testAccNewRelicNrqlAlertConditionWithTargetEntity(
+	name string,
+	targetEntity string,
+) string {
+	return fmt.Sprintf(`
+resource "newrelic_alert_policy" "foo" {
+	name = "tf-test-%[1]s"
+}
+
+resource "newrelic_nrql_alert_condition" "foo" {
+	policy_id = newrelic_alert_policy.foo.id
+
+	name                         = "tf-test-%[1]s"
+	type                         = "static"
+	enabled                      = false
+	violation_time_limit_seconds = 3600
+	aggregation_delay            = 120
+	aggregation_method           = "event_flow"
+	target_entity                = "%[2]s"
+
+	nrql {
+		query = "SELECT uniqueCount(hostname) FROM ComputeSample"
+	}
+
+	critical {
+		operator              = "below"
+		threshold             = 0
+		threshold_duration    = 120
+		threshold_occurrences = "ALL"
+	}
+}
+`, name)
+}
+
+func testAccNewRelicNrqlAlertConditionWithNullTargetEntity(
+	name string,
+) string {
+	return fmt.Sprintf(`
+resource "newrelic_alert_policy" "foo" {
+	name = "tf-test-%[1]s"
+}
+
+resource "newrelic_nrql_alert_condition" "foo" {
+	policy_id = newrelic_alert_policy.foo.id
+
+	name                         = "tf-test-%[1]s"
+	type                         = "static"
+	enabled                      = false
+	violation_time_limit_seconds = 3600
+	aggregation_delay            = 120
+	aggregation_method           = "event_flow"
+	target_entity                = null
+
+	nrql {
+		query = "SELECT uniqueCount(hostname) FROM ComputeSample"
+	}
+
+	critical {
+		operator              = "below"
+		threshold             = 0
+		threshold_duration    = 120
+		threshold_occurrences = "ALL"
 	}
 }
 `, name)

--- a/newrelic/structures_newrelic_nrql_alert_condition.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/alerts"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
 )
 
 var (
@@ -94,6 +95,11 @@ func expandNrqlAlertConditionCreateInput(d *schema.ResourceData) (*alerts.NrqlCo
 		input.TitleTemplate = &template
 	}
 
+	if targetEntity, ok := d.GetOk("target_entity"); ok {
+		target := common.EntityGUID(targetEntity.(string))
+		input.TargetEntity = &target
+	}
+
 	if violationTimeLimitSec, ok := d.GetOk("violation_time_limit_seconds"); ok {
 		input.ViolationTimeLimitSeconds = violationTimeLimitSec.(int)
 	} else if violationTimeLimit, ok := d.GetOk("violation_time_limit"); ok {
@@ -164,6 +170,11 @@ func expandNrqlAlertConditionUpdateInput(d *schema.ResourceData) (*alerts.NrqlCo
 	if titleTemplate, ok := d.GetOk("title_template"); ok {
 		template := titleTemplate.(string)
 		input.TitleTemplate = &template
+	}
+
+	if targetEntity, ok := d.GetOk("target_entity"); ok {
+		target := common.EntityGUID(targetEntity.(string))
+		input.TargetEntity = &target
 	}
 
 	if violationTimeLimitSec, ok := d.GetOk("violation_time_limit_seconds"); ok {
@@ -594,6 +605,7 @@ func flattenNrqlAlertCondition(accountID int, condition *alerts.NrqlAlertConditi
 	_ = d.Set("name", condition.Name)
 	_ = d.Set("runbook_url", condition.RunbookURL)
 	_ = d.Set("title_template", condition.TitleTemplate)
+	_ = d.Set("target_entity", condition.TargetEntity)
 	_ = d.Set("enabled", condition.Enabled)
 	_ = d.Set("entity_guid", condition.EntityGUID)
 

--- a/newrelic/structures_newrelic_nrql_alert_condition_test.go
+++ b/newrelic/structures_newrelic_nrql_alert_condition_test.go
@@ -53,6 +53,8 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 
 	titleTemplate := "Title {{template}}"
 
+	targetEntity := "MXxBUE18QVBQTElDQVRJT058MQ"
+
 	signalSeasonality := alerts.NrqlSignalSeasonalities.Daily
 
 	cases := map[string]struct {
@@ -424,6 +426,24 @@ func TestExpandNrqlAlertConditionInput(t *testing.T) {
 				NrqlConditionCreateBase: alerts.NrqlConditionCreateBase{},
 			},
 		},
+		"target entity not nil": {
+			Data: map[string]interface{}{
+				"nrql":          []interface{}{nrql},
+				"target_entity": targetEntity,
+			},
+			Expanded: &alerts.NrqlConditionCreateInput{
+				NrqlConditionCreateBase: alerts.NrqlConditionCreateBase{},
+			},
+		},
+		"target entity nil": {
+			Data: map[string]interface{}{
+				"nrql":          []interface{}{nrql},
+				"target_entity": nil,
+			},
+			Expanded: &alerts.NrqlConditionCreateInput{
+				NrqlConditionCreateBase: alerts.NrqlConditionCreateBase{},
+			},
+		},
 	}
 
 	r := resourceNewRelicNrqlAlertCondition()
@@ -578,6 +598,7 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 		NrqlConditionBase: alerts.NrqlConditionBase{
 			Description:   "description test",
 			TitleTemplate: &titleTemplate,
+			TargetEntity:  &common.EntityGUID(targetEntity),
 			Enabled:       true,
 			Name:          "name-test",
 			Nrql: alerts.NrqlConditionQuery{
@@ -696,6 +717,9 @@ func TestFlattenNrqlAlertCondition(t *testing.T) {
 
 		titleTemplate := d.Get("title_template").(string)
 		assert.Equal(t, "Title {{template}}", titleTemplate)
+
+		targetEntity := d.Get("target_entity").(string)
+		assert.Equal(t, "MXxBUE18QVBQTElDQVRJT058MQ", targetEntity)
 
 		switch condition.Type {
 		case alerts.NrqlConditionTypes.Baseline:

--- a/website/docs/r/nrql_alert_condition.html.markdown
+++ b/website/docs/r/nrql_alert_condition.html.markdown
@@ -29,6 +29,7 @@ resource "newrelic_nrql_alert_condition" "foo" {
   name                           = "foo"
   description                    = "Alert when transactions are taking too long"
   title_template                 = "Issue in environment: {{ tags.environment }}"
+  target_entity                  = "MXxBUE18QVBQTElDQVRJT058MQ"
   runbook_url                    = "https://www.example.com"
   enabled                        = true
   violation_time_limit_seconds   = 3600
@@ -72,6 +73,7 @@ The following arguments are supported:
 - `baseline_direction` - (Optional) The baseline direction of a _baseline_ NRQL alert condition. Valid values are: `lower_only`, `upper_and_lower`, `upper_only` (case insensitive).
 - `description` - (Optional) The description of the NRQL alert condition.
 - `title_template` - (Optional) The custom title to be used when incidents are opened by the condition. Setting this field will override the default title. Must be [Handlebars](https://handlebarsjs.com/) format.
+- `target_entity` - (Optional) BETA PREVIEW: The GUID of the entity explicitly targeted by the condition. Issues triggered by this condition will affect the health status of this entity instead of having the affected entity detected automatically. The entity's account ID must be either `account_id` or `nrql.data_account_id`.
 - `policy_id` - (Required) The ID of the policy where this condition should be used.
 - `name` - (Required) The title of the condition.
 - `type` - (Optional) The type of the condition. Valid values are `static` or `baseline`. Defaults to `static`.


### PR DESCRIPTION
The target entity feature for NRQL conditions is still in beta, but I'd like to start doing internal testing on it.

Builds will fail until newrelic/newrelic-client-go#1336 is released, at which point I will update `go.mod` and `go.sum` to use the latest version of the Go client.