### PR TITLE
fix(accountmanagement): curb organization query induced bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.30.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.74.1
+	github.com/newrelic/newrelic-client-go/v2 v2.74.2
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 )

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.74.1 h1:NIX29vhrSEh69pMFKlZT679Tavff9KwwKa8gt3d4VGw=
-github.com/newrelic/newrelic-client-go/v2 v2.74.1/go.mod h1:P6rXSHPtayzr50+UEYvvjzYPiADv7w2SqeyKz0z5HkU=
+github.com/newrelic/newrelic-client-go/v2 v2.74.2 h1:5XGck+tgn6A8/p9BTuI8IDRbUNxCzz3dJCRzTHrTU4s=
+github.com/newrelic/newrelic-client-go/v2 v2.74.2/go.mod h1:P6rXSHPtayzr50+UEYvvjzYPiADv7w2SqeyKz0z5HkU=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/newrelic/data_source_newrelic_account.go
+++ b/newrelic/data_source_newrelic_account.go
@@ -33,7 +33,7 @@ func dataSourceNewRelicAccount() *schema.Resource {
 				Description:   "The ID of the account in New Relic.",
 				ConflictsWith: []string{NewRelicAccountManagementSchemaName},
 			},
-			// deprecated and no longer used by the data source, just adding this here for feature parity
+			// deprecated and no longer used by the data source; just adding this here for feature parity
 			"scope": {
 				Type:         schema.TypeString,
 				Optional:     true,


### PR DESCRIPTION
# Description

This is an ⚠️ experimental ⚠️ PR that bumps `newrelic-client-go` to v2.74.2, which removes (presumed) capability-gated fields from the organization query.

In v3.76.1, v2.74.1 of the Go Client was pointed to (that was updated with functions to manage organizations) - in which the organization query requested `administrator`, `customerId`, `storageAccountId`, and `telemetryId` fields. These require specific permissions that:
- Custom roles often lack, causing "Unauthorized" errors
- Cannot be queried for canceled accounts, causing 5-minute retry loops

The updated client queries only `id` and `name` - the essential fields needed for account operations.

(might fix #2983, hopefully :)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


