### PR TITLE
fix(accountmanagement): fix outliers in the resource, allow edge case with import, etc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.30.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.74.2
+	github.com/newrelic/newrelic-client-go/v2 v2.75.1
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 )

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.74.2 h1:5XGck+tgn6A8/p9BTuI8IDRbUNxCzz3dJCRzTHrTU4s=
-github.com/newrelic/newrelic-client-go/v2 v2.74.2/go.mod h1:P6rXSHPtayzr50+UEYvvjzYPiADv7w2SqeyKz0z5HkU=
+github.com/newrelic/newrelic-client-go/v2 v2.75.1 h1:ebmXwQwLtrTaYe4SXkoYsu8FbjGykS3F7SIRhuG4tjY=
+github.com/newrelic/newrelic-client-go/v2 v2.75.1/go.mod h1:P6rXSHPtayzr50+UEYvvjzYPiADv7w2SqeyKz0z5HkU=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/newrelic/data_source_newrelic_account.go
+++ b/newrelic/data_source_newrelic_account.go
@@ -88,7 +88,7 @@ func dataSourceNewRelicAccountRead(ctx context.Context, d *schema.ResourceData, 
 		// To ensure accuracy, additional steps are required to identify the exact match from the results.
 	}
 
-	getAccountsResponse, err := client.CustomerAdministration.GetAccounts(
+	getAccountsResponse, err := client.CustomerAdministration.GetAccountsMinimized(
 		"",
 		filterInput,
 		[]customeradministration.OrganizationAccountSortInput{},

--- a/newrelic/resource_newrelic_account_management_test.go
+++ b/newrelic/resource_newrelic_account_management_test.go
@@ -160,7 +160,7 @@ func testAccCheckNewRelicAccountExists(n string) resource.TestCheckFunc {
 
 		// Fetch account using customeradministration package
 		ctx := context.Background()
-		getAccountsResponse, err := client.CustomerAdministration.GetAccounts(
+		getAccountsResponse, err := client.CustomerAdministration.GetAccountsMinimized(
 			"",
 			customeradministration.OrganizationAccountFilterInput{
 				OrganizationId: customeradministration.OrganizationAccountOrganizationIdFilterInput{


### PR DESCRIPTION
Fixes the `newrelic_account_management` resource (that helps create, manage and import sub-accounts in organizations, via Terraform) to gracefully handle a bunch of issues we've recently discovered and deliberated with the IAM team(s) on; resulting in the necessity to work the resource around handling cancelled accounts for imports while also allowing for their destruction, an extended retry mechanism around cancelled and active accounts to allow eliminating false positives (introduced by a bug in the NerdGraph endpoint for accounts), paired with similar changes

While the change introduced via this PR are supposed to be pretty isolated, these may be considered a natural successor to the changes made via recent PRs

#2986 
#2974 

and continue the process of investigative fixes, as we continue to dodge multiple API&Terraform induced edge cases customers seem to be landing into, as reported in #2983.

## Edge Cases Handled

- **Eventual consistency**: 10s sleep after create/update to allow backend indexing
- **Retry logic**: Read operations retry within 5min timeout to handle indexing delays
- **Canceled accounts**: `fetchAccountsInOrganization()` checks both active and canceled statuses
- **Account lifecycle**: Delete cancels (not deletes) account per NerdGraph API limitations

## Example Usage

```hcl
resource "newrelic_account_management" "sub_account" {
  name   = "Production Sub-Account"
  region = "us01"
}

# Import existing account
terraform import newrelic_account_management.sub_account 1234567
```