### PR TITLE
feat: add enable_pull_mode variable to make pull mode optional

### DIFF
--- a/examples/modules/cloud-integrations/aws/main.tf
+++ b/examples/modules/cloud-integrations/aws/main.tf
@@ -219,6 +219,7 @@ resource "aws_cloudwatch_metric_stream" "newrelic_metric_stream" {
 }
 
 resource "newrelic_cloud_aws_link_account" "newrelic_cloud_integration_pull" {
+  count                  = local.should_create_pull_mode ? 1 : 0
   account_id             = var.newrelic_account_id
   arn                    = aws_iam_role.newrelic_aws_role.arn
   metric_collection_mode = "PULL"
@@ -227,8 +228,9 @@ resource "newrelic_cloud_aws_link_account" "newrelic_cloud_integration_pull" {
 }
 
 resource "newrelic_cloud_aws_integrations" "newrelic_cloud_integration_pull" {
+  count             = local.should_create_pull_mode ? 1 : 0
   account_id        = var.newrelic_account_id
-  linked_account_id = newrelic_cloud_aws_link_account.newrelic_cloud_integration_pull.id
+  linked_account_id = newrelic_cloud_aws_link_account.newrelic_cloud_integration_pull[0].id
   billing {}
   cloudtrail {}
   health {}
@@ -290,6 +292,7 @@ resource "aws_s3_bucket" "newrelic_configuration_recorder_s3" {
 
 locals {
   should_create_recorder = var.enable_config_recorder
+  should_create_pull_mode = var.enable_pull_mode
 }
 
 resource "aws_iam_role" "newrelic_configuration_recorder" {

--- a/examples/modules/cloud-integrations/aws/variables.tf
+++ b/examples/modules/cloud-integrations/aws/variables.tf
@@ -44,3 +44,9 @@ variable "enable_config_recorder" {
   type        = bool
   default     = false
 }
+
+variable "enable_pull_mode" {
+  description = "Set to true to enable PULL mode integration (API polling). Set to false if you only want PUSH mode (metric stream)."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
# Description

 Add optional `enable_pull_mode` variable to allow users to disable PULL mode integration when only PUSH mode (metric stream) is needed.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [ ] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

 - Test 1: Verify PULL mode is created by default (backwards compatibility)
 - Test 2: Verify PULL mode can be disabled
 - Test 3: Verify existing deployments continue to work
