### PR TITLE
Explain how the workload_id can be derived

### DIFF
--- a/website/docs/r/workload.html.markdown
+++ b/website/docs/r/workload.html.markdown
@@ -218,3 +218,5 @@ New Relic workloads can be imported using a concatenated string of the format
 ```bash
 $ terraform import newrelic_workload.foo 12345678:1456:MjUyMDUyOHxBUE18QVBRTElDQVRJT058MjE1MDM3Nzk1
 ```
+
+~> **NOTE:** The value of `<workload_id>` can be derived from the base64 decoded value of `<guid>` - e.g. `echo <guid> | base64 -d | cut -f 4 -d '|'`


### PR DESCRIPTION
# Description

Currently, the document says nothing about the `workload_id`.
We can't directly know this value from UI or Nerdgraph.

I finally find the way to derive this value from [this issue](https://github.com/newrelic/terraform-provider-newrelic/issues/817).
I think we should add documentation for this.


## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation

