### PR TITLE
feat(notifications): make property optional for SERVICE_NOW_APP channels

### DIFF
--- a/newrelic/structures_newrelic_notifications_channel.go
+++ b/newrelic/structures_newrelic_notifications_channel.go
@@ -12,7 +12,13 @@ func expandNotificationChannel(d *schema.ResourceData) notifications.AiNotificat
 		Type:          notifications.AiNotificationsChannelType(d.Get("type").(string)),
 		Product:       notifications.AiNotificationsProduct(d.Get("product").(string)),
 	}
-	channel.Properties = expandNotificationChannelProperties(d.Get("property").(*schema.Set).List())
+	
+	// SERVICE_NOW_APP requires an empty properties array, not null
+	properties := expandNotificationChannelProperties(d.Get("property").(*schema.Set).List())
+	if properties == nil {
+		properties = []notifications.AiNotificationsPropertyInput{}
+	}
+	channel.Properties = properties
 
 	return channel
 }

--- a/website/docs/r/notification_channel.html.markdown
+++ b/website/docs/r/notification_channel.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 * `type` - (Required) The type of channel.  One of: `EMAIL`, `SERVICENOW_INCIDENTS`, `SERVICE_NOW_APP`, `WEBHOOK`, `JIRA_CLASSIC`, `MOBILE_PUSH`, `EVENT_BRIDGE`, `SLACK` and `SLACK_COLLABORATION`, `PAGERDUTY_ACCOUNT_INTEGRATION`, `PAGERDUTY_SERVICE_INTEGRATION`, `MICROSOFT_TEAMS` or `WORKFLOW_AUTOMATION`.
 * `destination_id` - (Required) The id of the destination.
 * `product` - (Required) The type of product.  One of: `DISCUSSIONS`, `ERROR_TRACKING` or `IINT` (workflows).
-* `property` - A nested block that describes a notification channel property. See [Nested property blocks](#nested-property-blocks) below for details.
+* `property` - (Optional for `SERVICE_NOW_APP`, Required for all other channel types) A nested block that describes a notification channel property. See [Nested property blocks](#nested-property-blocks) below for details.
 
 ### Nested `property` blocks
 Most properties can use variables, which will be filled at the time of sending the notification with data from the issue. The properties where this is not available generally correlate to identifiers in the third party, such as Slack channel id or Jira project id. 


### PR DESCRIPTION
Make the `property` field optional for SERVICE_NOW_APP notification channels while keeping it required for all other channel types.

# Description

- Modified schema: `property` field is now Optional instead of Required
- Added CustomizeDiff validation to ensure `property` is still required for all channel types except SERVICE_NOW_APP
- Skip adding monitoring property for SERVICE_NOW_APP channels during creation
- Ensure properties array is never nil (empty array instead)
- Updated documentation to reflect optional property for SERVICE_NOW_APP

Technical Details:
- SERVICE_NOW_APP channels do not accept properties, not even the automatically added monitoring property
- CustomizeDiff function validates at plan time that non-SERVICE_NOW_APP channels must have at least one property defined
- Empty properties array is explicitly initialized to prevent nil serialization issues

Fixes #3004

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [X] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

## 1. Unit Tests

Run the unit tests to verify the implementation logic:

```bash
make test-unit
```

**Expected result**: All 89 tests should pass with no errors.

**Output**:
```
PASS newrelic (coverage: 9.5% of statements)
DONE 89 tests in 0.989s
```

## 2. Validation Test with Local Provider

Test the CustomizeDiff validation without making API calls:

```bash
# Compile the provider
make compile

# Create a test directory
mkdir test-validation && cd test-validation

# Create a test configuration
cat > main.tf << 'EOF'
terraform {
  required_providers {
    newrelic = {
      source = "newrelic/newrelic"
    }
  }
}

provider "newrelic" {
  account_id = 12345
  api_key    = "dummy"
}

resource "newrelic_notification_destination" "test" {
  account_id = 12345
  name       = "test-destination"
  type       = "WEBHOOK"

  property {
    key   = "url"
    value = "https://example.com"
  }

  auth_basic {
    user     = "test"
    password = "test"
  }
}

# This should PASS validation - SERVICE_NOW_APP without properties
resource "newrelic_notification_channel" "servicenow_ok" {
  account_id     = 12345
  name           = "servicenow-no-props"
  type           = "SERVICE_NOW_APP"
  product        = "IINT"
  destination_id = newrelic_notification_destination.test.id
  # No property block - this is OK for SERVICE_NOW_APP
}

# This should FAIL validation - WEBHOOK without properties
resource "newrelic_notification_channel" "webhook_fail" {
  account_id     = 12345
  name           = "webhook-no-props"
  type           = "WEBHOOK"
  product        = "IINT"
  destination_id = newrelic_notification_destination.test.id
  # No property block - this should FAIL for WEBHOOK
}
EOF

# Create local provider override
cat > .terraformrc << 'EOF'
provider_installation {
  dev_overrides {
    "newrelic/newrelic" = "../bin/linux"
  }
  direct {}
}
EOF

# Test validation
TF_CLI_CONFIG_FILE=.terraformrc terraform init
TF_CLI_CONFIG_FILE=.terraformrc terraform validate
TF_CLI_CONFIG_FILE=.terraformrc terraform plan

# Cleanup
cd .. && rm -rf test-validation
```

**Expected results**:
- `terraform validate` should succeed (both resources are valid)
- `terraform plan` should fail with error message:
  ```
  Error: property is required for channel type WEBHOOK
  
    with newrelic_notification_channel.webhook_fail,
    on main.tf line 35, in resource "newrelic_notification_channel" "webhook_fail":
    35: resource "newrelic_notification_channel" "webhook_fail" {
  ```
- The `servicenow_ok` resource should be valid (no error)
- The error should specifically mention the `webhook_fail` resource

This validates that:
1. SERVICE_NOW_APP channels can be created without properties ✅
2. WEBHOOK channels require properties ✅
3. The validation happens at plan time (no API call needed) ✅