### PR TITLE
fix(notifications): prevent orphaned channels/destinations on create errors

### DIFF
--- a/newrelic/resource_newrelic_notifications_destination.go
+++ b/newrelic/resource_newrelic_notifications_destination.go
@@ -304,12 +304,17 @@ func resourceNewRelicNotificationDestinationCreate(ctx context.Context, d *schem
 		return newDiagErr
 	}
 
+	// Always persist the destination ID to state if the backend created it, even if the
+	// response also contains errors. This prevents orphaned resources when the API
+	// creates the destination successfully but also returns errors in the response.
+	if destinationResponse.Destination.ID != "" {
+		d.SetId(destinationResponse.Destination.ID)
+	}
+
 	errors := buildAiNotificationsErrors(destinationResponse.Errors)
 	if len(errors) > 0 {
 		return errors
 	}
-
-	d.SetId(destinationResponse.Destination.ID)
 
 	return resourceNewRelicNotificationDestinationRead(updatedContext, d, meta)
 }


### PR DESCRIPTION
Fixes #3037

## Summary

The NR API can return both a valid resource ID and errors in the same `AiNotificationsChannelResponse` (e.g. `UNKNOWN_ERROR` with null description). When this happens, the provider returns the error **before** calling `d.SetId()`, so the resource is created in New Relic but never recorded in Terraform state — producing orphaned resources and an infinite create→fail loop.

**Fix**: call `d.SetId()` before the error check when the response contains a valid ID. Per the [Plugin SDK docs](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema#ResourceData.SetId), this saves the resource to state. Terraform then [marks it as tainted](https://developer.hashicorp.com/terraform/plugin/framework/resources/create#caveats) and reconciles on the next refresh — which is the correct behavior.

Applied to both `newrelic_notification_channel` and `newrelic_notification_destination` (same pattern).

## Changes

- `resource_newrelic_notifications_channel.go`: set channel ID before error check
- `resource_newrelic_notifications_destination.go`: set destination ID before error check

<details>
<summary>Before / After</summary>

**Before:**
```go
errors := buildAiNotificationsErrors(channelResponse.Errors)
if len(errors) > 0 {
    return errors                         // exits, d.SetId() never called
}
d.SetId(channelResponse.Channel.ID)       // orphaned resource
```

**After:**
```go
if channelResponse.Channel.ID != "" {
    d.SetId(channelResponse.Channel.ID)   // always persist if backend created it
}
errors := buildAiNotificationsErrors(channelResponse.Errors)
if len(errors) > 0 {
    return errors                         // resource is in state (tainted)
}
```
</details>