### PR TITLE
fix(browser-app): implement drift detection for deleted resources

### DIFF
--- a/newrelic/resource_newrelic_agent_application_browser.go
+++ b/newrelic/resource_newrelic_agent_application_browser.go
@@ -15,7 +15,6 @@ import (
 	"github.com/newrelic/newrelic-client-go/v2/pkg/agentapplications"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/entities"
-	nrErrors "github.com/newrelic/newrelic-client-go/v2/pkg/errors"
 )
 
 func resourceNewRelicBrowserApplication() *schema.Resource {
@@ -129,17 +128,12 @@ func resourceNewRelicBrowserApplicationRead(ctx context.Context, d *schema.Resou
 	retryErr := resource.RetryContext(ctx, d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
 		resp, err := client.Entities.GetEntityWithContext(ctx, common.EntityGUID(guid))
 		if err != nil {
-			// Defensive check for NotFound error (though GetEntityWithContext typically returns nil response instead)
-			if _, ok := err.(*nrErrors.NotFound); ok {
-				d.SetId("")
-				return nil
-			}
 			return resource.NonRetryableError(err)
 		}
 
 		// When entity doesn't exist, API returns nil response with no error
-		// Check for nil response - retry as it may be due to eventual consistency during creation,
-		// but if retries exhaust, we'll handle it as a deleted resource below
+		// Retry to allow time for eventual consistency during resource creation
+		// If retries exhaust, we handle it as a deleted resource in the retryErr check below
 		if resp == nil || *resp == nil {
 			return resource.RetryableError(fmt.Errorf("entity with GUID %s not found", guid))
 		}

--- a/newrelic/resource_newrelic_agent_application_browser.go
+++ b/newrelic/resource_newrelic_agent_application_browser.go
@@ -15,6 +15,7 @@ import (
 	"github.com/newrelic/newrelic-client-go/v2/pkg/agentapplications"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/entities"
+	nrErrors "github.com/newrelic/newrelic-client-go/v2/pkg/errors"
 )
 
 func resourceNewRelicBrowserApplication() *schema.Resource {
@@ -128,9 +129,17 @@ func resourceNewRelicBrowserApplicationRead(ctx context.Context, d *schema.Resou
 	retryErr := resource.RetryContext(ctx, d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
 		resp, err := client.Entities.GetEntityWithContext(ctx, common.EntityGUID(guid))
 		if err != nil {
+			// Defensive check for NotFound error (though GetEntityWithContext typically returns nil response instead)
+			if _, ok := err.(*nrErrors.NotFound); ok {
+				d.SetId("")
+				return nil
+			}
 			return resource.NonRetryableError(err)
 		}
 
+		// When entity doesn't exist, API returns nil response with no error
+		// Check for nil response - retry as it may be due to eventual consistency during creation,
+		// but if retries exhaust, we'll handle it as a deleted resource below
 		if resp == nil || *resp == nil {
 			return resource.RetryableError(fmt.Errorf("entity with GUID %s not found", guid))
 		}
@@ -176,7 +185,13 @@ func resourceNewRelicBrowserApplicationRead(ctx context.Context, d *schema.Resou
 	})
 
 	if retryErr != nil {
-		d.SetId("")
+		// After all retries exhausted, if the entity was not found, it means it was deleted outside Terraform
+		// Clear the ID and return nil (not an error) to signal Terraform the resource should be recreated
+		if strings.Contains(retryErr.Error(), "not found") {
+			d.SetId("")
+			return nil
+		}
+		// For other errors (non-not-found), return them as actual errors
 		return diag.FromErr(retryErr)
 	}
 


### PR DESCRIPTION
## Summary
- Implements drift detection for `newrelic_browser_application` resource
- Fixes issue where manually deleted browser applications were not detected during Terraform refresh
- Brings browser application resource behavior in line with other resources like `newrelic_entity_tags`

## Problem Statement
When a browser application was deleted outside of Terraform (e.g., manually through the UI or API), the provider was not correctly handling the missing resource. The original code would:
1. Detect the resource was missing (via retries timing out)
2. Clear the resource ID
3. **But then return an error**

When the Read function returns an error, Terraform treats it as a failure rather than recognizing the resource needs recreation. This caused `newrelic_entity_tags` (which correctly implements drift detection) to fail when trying to tag the non-existent browser application.

## What Changed
### Before
```go
if retryErr != nil {
    d.SetId("")
    return diag.FromErr(retryErr)  // Returns error - Terraform fails
}
```

### After
```go
if retryErr != nil {
    if strings.Contains(retryErr.Error(), "not found") {
        d.SetId("")
        return nil  // Returns nil - Terraform marks for recreation
    }
    return diag.FromErr(retryErr)  // Only error for non-NotFound cases
}
```

### Additional improvements:
- Added explicit `NotFound` error handling for immediate detection
- Maintains backward compatibility with retry logic for eventual consistency
- Only returns errors for actual failures, not missing resources

## Testing
- ✅ All existing integration tests pass
- ✅ Verified resource creation, update, and deletion workflows
- ✅ Tested with parallel test execution

## Related Issue
Fixes #3055

## Test Plan
1. Create a browser application via Terraform
2. Manually delete it from New Relic UI or API
3. Run `terraform plan` - should detect drift and plan to recreate
4. Run `terraform apply` - should successfully recreate the resource
5. Verify dependent resources (like entity_tags) no longer fail