### PR TITLE
fix(log-parsing-rule): prevent state corruption on authentication errors

### DIFF
--- a/newrelic/resource_newrelic_log_parsing_rule.go
+++ b/newrelic/resource_newrelic_log_parsing_rule.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/newrelic/newrelic-client-go/v2/newrelic"
+	nrErrors "github.com/newrelic/newrelic-client-go/v2/pkg/errors"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/logconfigurations"
 )
 
@@ -127,7 +128,16 @@ func resourceNewRelicLogParsingRuleRead(ctx context.Context, d *schema.ResourceD
 	ruleID := d.Id()
 	rule, err := getLogParsingRuleByID(ctx, client, accountID, ruleID)
 
-	if err != nil && rule == nil {
+	if err != nil {
+		if _, ok := err.(*nrErrors.NotFound); ok {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+
+	// Defensive: should never happen given function contract, but be safe
+	if rule == nil {
 		d.SetId("")
 		return nil
 	}
@@ -262,7 +272,7 @@ func getLogParsingRuleByID(ctx context.Context, client *newrelic.NewRelic, accou
 			return v, nil
 		}
 	}
-	return nil, errors.New("parsing rule not found")
+	return nil, nrErrors.NewNotFound("parsing rule not found")
 
 }
 


### PR DESCRIPTION
## Summary
This PR fixes a critical bug in `newrelic_log_parsing_rule` where invalid API credentials cause silent state file corruption. Previously, authentication errors during `terraform plan` or `apply` would remove the resource from state instead of failing with an error, requiring manual `terraform import` to recover. The fix updates error handling to properly distinguish between "resource not found" (404) and other errors like authentication failures, aligning with the pattern used across 24+ other resources in this provider.

## Changes
- Updated `resourceNewRelicLogParsingRuleRead` to use type assertion for `NotFound` errors
- Modified `getLogParsingRuleByID` to return properly typed `NotFound` errors
- Added import for `nrErrors` from newrelic-client-go error package
- Authentication and permission errors now properly propagate to Terraform instead of silently clearing state

Resolves NR-548992