### PR TITLE
fix(alerts): add policy entity guid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.30.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.83.1-0.20260428214407-247aaabe351c
+	github.com/newrelic/newrelic-client-go/v2 v2.83.1
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.30.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.83.0
+	github.com/newrelic/newrelic-client-go/v2 v2.83.1-0.20260428214407-247aaabe351c
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,8 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.83.1-0.20260428214407-247aaabe351c h1:Ja2gUGTadoTZ8NwwLvnRrtcXuzPM1tQJCZNBaoFXCz8=
-github.com/newrelic/newrelic-client-go/v2 v2.83.1-0.20260428214407-247aaabe351c/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
+github.com/newrelic/newrelic-client-go/v2 v2.83.1 h1:LnnMu7132WZ6LwtgfH+jgwdbuuWKgV5CisjAm3FiMNM=
+github.com/newrelic/newrelic-client-go/v2 v2.83.1/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,8 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.83.0 h1:HuxTno3USbhxJ2wQt1fKkyUnNrAMW6UYgnbWgRJaVzw=
-github.com/newrelic/newrelic-client-go/v2 v2.83.0/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
+github.com/newrelic/newrelic-client-go/v2 v2.83.1-0.20260428214407-247aaabe351c h1:Ja2gUGTadoTZ8NwwLvnRrtcXuzPM1tQJCZNBaoFXCz8=
+github.com/newrelic/newrelic-client-go/v2 v2.83.1-0.20260428214407-247aaabe351c/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/integration_test_utilities/integration_test_mappings.yaml
+++ b/integration_test_utilities/integration_test_mappings.yaml
@@ -466,6 +466,9 @@ structures_newrelic_alert_policy_channel.go:
 structures_newrelic_alert_policy_channel_test.go:
   test: true
   product_mapping: ALERTS
+structures_newrelic_alert_policy_test.go:
+  test: true
+  product_mapping: ALERTS
 structures_newrelic_api_access_key.go:
   test: false
   product_mapping: APIKS

--- a/newrelic/data_source_newrelic_alert_policy.go
+++ b/newrelic/data_source_newrelic_alert_policy.go
@@ -41,6 +41,11 @@ func dataSourceNewRelicAlertPolicy() *schema.Resource {
 				Computed:    true,
 				Description: "The time the policy was last updated.",
 			},
+			"entity_guid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The entity GUID of the alert policy.",
+			},
 		},
 	}
 }

--- a/newrelic/data_source_newrelic_alert_policy_test.go
+++ b/newrelic/data_source_newrelic_alert_policy_test.go
@@ -25,6 +25,7 @@ func TestAccNewRelicAlertPolicyDataSource_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicAlertPolicyDataSource("data.newrelic_alert_policy.policy"),
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tf-test-%s", rName)),
+					resource.TestCheckResourceAttrSet("data.newrelic_alert_policy.policy", "entity_guid"),
 				),
 			},
 		},

--- a/newrelic/resource_newrelic_alert_policy.go
+++ b/newrelic/resource_newrelic_alert_policy.go
@@ -60,6 +60,11 @@ func resourceNewRelicAlertPolicy() *schema.Resource {
 				Description: "An array of channel IDs (integers) to assign to the policy. Adding or removing channel IDs from this array will result in a new alert policy resource being created and the old one being destroyed. Also note that channel IDs cannot be imported via terraform import.",
 				Deprecated:  "The `channel_ids` attribute is deprecated and will be removed in the next major release of the provider.",
 			},
+			"entity_guid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The entity GUID of the alert policy.",
+			},
 		},
 	}
 }

--- a/newrelic/resource_newrelic_alert_policy_integration_test.go
+++ b/newrelic/resource_newrelic_alert_policy_integration_test.go
@@ -25,6 +25,7 @@ func TestAccNewRelicAlertPolicy_Basic(t *testing.T) {
 				Config: testAccNewRelicAlertPolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicAlertPolicyExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "entity_guid"),
 				),
 			},
 			// Test: Update
@@ -32,6 +33,7 @@ func TestAccNewRelicAlertPolicy_Basic(t *testing.T) {
 				Config: testAccNewRelicAlertPolicyConfigUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicAlertPolicyExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "entity_guid"),
 				),
 			},
 			// Test: Import
@@ -40,6 +42,9 @@ func TestAccNewRelicAlertPolicy_Basic(t *testing.T) {
 				ImportStateIdFunc: testAccImportStateIDFunc(resourceName, strconv.Itoa(testAccountID)),
 				ImportStateVerify: true,
 				ResourceName:      resourceName,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "entity_guid"),
+				),
 			},
 		},
 	})

--- a/newrelic/structures_newrelic_alert_policy.go
+++ b/newrelic/structures_newrelic_alert_policy.go
@@ -23,5 +23,10 @@ func flattenAlertPolicy(policy *alerts.AlertsPolicy, d *schema.ResourceData, acc
 		return err
 	}
 
+	err = d.Set("entity_guid", policy.EntityGuid)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/newrelic/structures_newrelic_alert_policy_test.go
+++ b/newrelic/structures_newrelic_alert_policy_test.go
@@ -1,0 +1,109 @@
+//go:build unit
+
+package newrelic
+
+import (
+	"testing"
+
+	"github.com/newrelic/newrelic-client-go/v2/pkg/alerts"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlattenAlertPolicy_Basic(t *testing.T) {
+	t.Parallel()
+
+	mockPolicy := &alerts.AlertsPolicy{
+		ID:                  "123456",
+		Name:                "Test Policy",
+		IncidentPreference:  alerts.AlertsIncidentPreference("PER_POLICY"),
+		EntityGuid:          "test-entity-guid-123",
+	}
+
+	r := resourceNewRelicAlertPolicy()
+	d := r.TestResourceData()
+	d.SetId("123456")
+
+	accountID := 12345
+
+	err := flattenAlertPolicy(mockPolicy, d, accountID)
+	require.NoError(t, err)
+
+	require.Equal(t, "Test Policy", d.Get("name"))
+	require.Equal(t, "PER_POLICY", d.Get("incident_preference"))
+	require.Equal(t, accountID, d.Get("account_id"))
+	require.Equal(t, "test-entity-guid-123", d.Get("entity_guid"))
+}
+
+func TestFlattenAlertPolicy_EmptyEntityGuid(t *testing.T) {
+	t.Parallel()
+
+	mockPolicy := &alerts.AlertsPolicy{
+		ID:                  "123456",
+		Name:                "Test Policy",
+		IncidentPreference:  alerts.AlertsIncidentPreference("PER_CONDITION"),
+		EntityGuid:          "",
+	}
+
+	r := resourceNewRelicAlertPolicy()
+	d := r.TestResourceData()
+	d.SetId("123456")
+
+	accountID := 12345
+
+	err := flattenAlertPolicy(mockPolicy, d, accountID)
+	require.NoError(t, err)
+
+	require.Equal(t, "Test Policy", d.Get("name"))
+	require.Equal(t, "PER_CONDITION", d.Get("incident_preference"))
+	require.Equal(t, accountID, d.Get("account_id"))
+	require.Equal(t, "", d.Get("entity_guid"))
+}
+
+func TestFlattenAlertPolicy_AllIncidentPreferences(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name               string
+		incidentPreference string
+		entityGuid         string
+	}{
+		{
+			name:               "PER_POLICY",
+			incidentPreference: "PER_POLICY",
+			entityGuid:         "entity-guid-per-policy",
+		},
+		{
+			name:               "PER_CONDITION",
+			incidentPreference: "PER_CONDITION",
+			entityGuid:         "entity-guid-per-condition",
+		},
+		{
+			name:               "PER_CONDITION_AND_TARGET",
+			incidentPreference: "PER_CONDITION_AND_TARGET",
+			entityGuid:         "entity-guid-per-condition-and-target",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockPolicy := &alerts.AlertsPolicy{
+				ID:                  "123456",
+				Name:                "Test Policy",
+				IncidentPreference:  alerts.AlertsIncidentPreference(tc.incidentPreference),
+				EntityGuid:          tc.entityGuid,
+			}
+
+			r := resourceNewRelicAlertPolicy()
+			d := r.TestResourceData()
+			d.SetId("123456")
+
+			accountID := 12345
+
+			err := flattenAlertPolicy(mockPolicy, d, accountID)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.incidentPreference, d.Get("incident_preference"))
+			require.Equal(t, tc.entityGuid, d.Get("entity_guid"))
+		})
+	}
+}

--- a/website/docs/r/alert_policy.html.markdown
+++ b/website/docs/r/alert_policy.html.markdown
@@ -37,6 +37,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
   * `id` - The ID of the policy.
+  * `entity_guid` - The entity GUID of the alert policy.
 
 ## Additional Examples
 


### PR DESCRIPTION
# Description

https://github.com/newrelic/newrelic-client-go/pull/1401

This adds entityGuid field in the to the newrelic_alert_policy resource. 

Fixes https://new-relic.atlassian.net/browse/NR-529749

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

Create a policy:
```
resource "newrelic_alert_policy" "foo" {
  name = "gabe tf test"
}
```

run terraform show to see the newrelic_alert_policy which should now include the entity_guid