### PR TITLE
feat(fleet): fleet configuration resource and data source

### DIFF
--- a/build/lint.mk
+++ b/build/lint.mk
@@ -26,11 +26,11 @@ lint-fix: deps spell-check-fix gofmt-fix goimports
 #
 spell-check: deps
 	@echo "=== $(PROJECT_NAME) === [ spell-check      ]: Checking for spelling mistakes with $(MISSPELL)..."
-	@$(MISSPELL) -source text $(FILES)
+	@$(MISSPELL) -source text -i importas $(FILES)
 
 spell-check-fix: deps
 	@echo "=== $(PROJECT_NAME) === [ spell-check-fix  ]: Fixing spelling mistakes with $(MISSPELL)..."
-	@$(MISSPELL) -source text -w $(FILES)
+	@$(MISSPELL) -source text -i importas -w $(FILES)
 
 gofmt: deps
 	@echo "=== $(PROJECT_NAME) === [ gofmt            ]: Checking file format with $(GOFMT)..."

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.30.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.83.2-0.20260503171303-84ab672496a7
+	github.com/newrelic/newrelic-client-go/v2 v2.83.2
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.30.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.83.1
+	github.com/newrelic/newrelic-client-go/v2 v2.83.2-0.20260503171303-84ab672496a7
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,8 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.83.2-0.20260503171303-84ab672496a7 h1:nBV/Vtnvvm/OqCwS9nteGPtZ1pB6e9sZgirBpOkFgpY=
-github.com/newrelic/newrelic-client-go/v2 v2.83.2-0.20260503171303-84ab672496a7/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
+github.com/newrelic/newrelic-client-go/v2 v2.83.2 h1:+c7hY6mJMNwWw0+oZ6V1UuQaqZsVUda1nD65upVWuaI=
+github.com/newrelic/newrelic-client-go/v2 v2.83.2/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,8 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.83.1 h1:LnnMu7132WZ6LwtgfH+jgwdbuuWKgV5CisjAm3FiMNM=
-github.com/newrelic/newrelic-client-go/v2 v2.83.1/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
+github.com/newrelic/newrelic-client-go/v2 v2.83.2-0.20260503171303-84ab672496a7 h1:nBV/Vtnvvm/OqCwS9nteGPtZ1pB6e9sZgirBpOkFgpY=
+github.com/newrelic/newrelic-client-go/v2 v2.83.2-0.20260503171303-84ab672496a7/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/integration_test_utilities/integration_test_mappings.yaml
+++ b/integration_test_utilities/integration_test_mappings.yaml
@@ -43,6 +43,12 @@ data_source_newrelic_entity_integration_test.go:
 data_source_newrelic_entity_unit_test.go:
   test: true
   product_mapping: ENTITY
+data_source_newrelic_fleet_configuration.go:
+  test: false
+  product_mapping: FLEET
+data_source_newrelic_fleet_configuration_test.go:
+  test: true
+  product_mapping: FLEET
 data_source_newrelic_group_management.go:
   test: false
   product_mapping: AUTH
@@ -249,6 +255,12 @@ resource_newrelic_events_to_metrics_rule_test.go:
   product_mapping: EVENTS
 resource_newrelic_fleet.go:
   test: false
+  product_mapping: FLEET
+resource_newrelic_fleet_configuration.go:
+  test: false
+  product_mapping: FLEET
+resource_newrelic_fleet_configuration_test.go:
+  test: true
   product_mapping: FLEET
 resource_newrelic_fleet_test.go:
   test: true

--- a/newrelic/data_source_newrelic_fleet_configuration.go
+++ b/newrelic/data_source_newrelic_fleet_configuration.go
@@ -1,0 +1,231 @@
+package newrelic
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	nr "github.com/newrelic/newrelic-client-go/v2/newrelic"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/fleetcontrol"
+)
+
+func dataSourceNewRelicFleetConfiguration() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceNewRelicFleetConfigurationRead,
+		Schema: map[string]*schema.Schema{
+			// ── inputs (mutually exclusive) ────────────────────────────────
+			"configuration_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"version_entity_id", "name"},
+				Description:   "The GUID of the fleet configuration entity. Returns the content of the latest version. Populated automatically when looking up by version_entity_id.",
+			},
+			"version_entity_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"configuration_id", "name"},
+				Description:   "The GUID of a specific configuration version entity. Returns the content of that exact version.",
+			},
+			"name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"configuration_id", "version_entity_id"},
+				Description:   "The name of the fleet configuration. The first matching configuration is returned. Returns the content of its latest version.",
+			},
+			// ── optional context ──────────────────────────────────────────
+			"organization_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The organization ID. Resolved automatically from the provider when omitted.",
+			},
+			// ── outputs ───────────────────────────────────────────────────
+			"configuration_content": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The raw configuration content (YAML/JSON) of the resolved version.",
+			},
+			"latest_version_entity_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The entity GUID of the latest version. Populated when looking up by configuration_id or name.",
+			},
+			"version_entity_ids": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Entity GUIDs of all versions ordered by version number (oldest first). Populated when looking up by configuration_id or name.",
+			},
+		},
+	}
+}
+
+func dataSourceNewRelicFleetConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*ProviderConfig)
+	client := cfg.NewClient
+
+	orgID, err := getOrganizationID(ctx, cfg, d.Get("organization_id").(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	var configID string
+	var content *fleetcontrol.GetConfigurationResponse
+	var diags diag.Diagnostics
+
+	switch {
+	case d.Get("configuration_id").(string) != "":
+		configID, content, diags = dsFleetReadByConfigID(d, client, orgID)
+	case d.Get("version_entity_id").(string) != "":
+		configID, content, diags = dsFleetReadByVersionGUID(d, client, orgID)
+	case d.Get("name").(string) != "":
+		configID, orgID, content, diags = dsFleetReadByName(d, client, orgID)
+	default:
+		return diag.Errorf("one of configuration_id, version_entity_id, or name must be specified")
+	}
+
+	if diags.HasError() {
+		return diags
+	}
+
+	if content == nil {
+		return diag.Errorf("received nil content for fleet configuration %q", configID)
+	}
+
+	d.SetId(configID)
+	if setErr := d.Set("organization_id", orgID); setErr != nil {
+		return diag.FromErr(setErr)
+	}
+	if setErr := d.Set("configuration_content", string(*content)); setErr != nil {
+		return diag.FromErr(setErr)
+	}
+
+	return nil
+}
+
+func dsFleetReadByConfigID(d *schema.ResourceData, client *nr.NewRelic, orgID string) (string, *fleetcontrol.GetConfigurationResponse, diag.Diagnostics) {
+	configID := d.Get("configuration_id").(string)
+	content, err := client.FleetControl.FleetControlGetConfiguration(
+		configID, orgID, fleetcontrol.GetConfigurationModeTypes.ConfigEntity, 0,
+	)
+	if err != nil {
+		return "", nil, diag.FromErr(fmt.Errorf("failed to fetch fleet configuration %q: %w", configID, err))
+	}
+	if diags := setVersionFields(d, client, configID, orgID); diags != nil {
+		return "", nil, diags
+	}
+	return configID, content, nil
+}
+
+func dsFleetReadByVersionGUID(d *schema.ResourceData, client *nr.NewRelic, orgID string) (string, *fleetcontrol.GetConfigurationResponse, diag.Diagnostics) {
+	versionGUID := d.Get("version_entity_id").(string)
+	content, err := client.FleetControl.FleetControlGetConfiguration(
+		versionGUID, orgID, fleetcontrol.GetConfigurationModeTypes.ConfigVersionEntity, 0,
+	)
+	if err != nil {
+		return "", nil, diag.FromErr(fmt.Errorf("failed to fetch fleet configuration version %q: %w", versionGUID, err))
+	}
+
+	// Resolve the parent configuration GUID from the version entity
+	entityIface, entityErr := client.FleetControl.GetEntity(versionGUID)
+	if entityErr == nil && entityIface != nil {
+		if versionEntity, ok := (*entityIface).(*fleetcontrol.EntityManagementAgentConfigurationVersionEntity); ok && versionEntity.AgentConfiguration != "" {
+			if setErr := d.Set("configuration_id", versionEntity.AgentConfiguration); setErr != nil {
+				return "", nil, diag.FromErr(setErr)
+			}
+		}
+	}
+
+	return versionGUID, content, nil
+}
+
+func dsFleetReadByName(d *schema.ResourceData, client *nr.NewRelic, orgID string) (string, string, *fleetcontrol.GetConfigurationResponse, diag.Diagnostics) {
+	name := d.Get("name").(string)
+	// The entity management entitySearch API only supports type-based filtering;
+	// name filtering is not a valid predicate. Fetch all AGENT_CONFIGURATION
+	// entities and filter by name client-side.
+	result, searchErr := client.FleetControl.GetEntitySearch(
+		"", "type = 'AGENT_CONFIGURATION'",
+	)
+	if searchErr != nil {
+		return "", orgID, nil, diag.FromErr(fmt.Errorf("failed to search fleet configurations by name %q: %w", name, searchErr))
+	}
+	if result == nil || len(result.Entities) == 0 {
+		return "", orgID, nil, diag.Errorf("no fleet configuration found with name %q", name)
+	}
+
+	var configID string
+	for _, entity := range result.Entities {
+		if cfgEntity, ok := entity.(*fleetcontrol.EntityManagementAgentConfigurationEntity); ok {
+			if cfgEntity.Name != name {
+				continue
+			}
+			configID = cfgEntity.ID
+			if cfgEntity.Scope.Type == "ORGANIZATION" {
+				orgID = cfgEntity.Scope.ID
+			}
+			break
+		}
+	}
+	if configID == "" {
+		return "", orgID, nil, diag.Errorf("no fleet configuration found with name %q", name)
+	}
+
+	if setErr := d.Set("configuration_id", configID); setErr != nil {
+		return "", orgID, nil, diag.FromErr(setErr)
+	}
+
+	content, err := client.FleetControl.FleetControlGetConfiguration(
+		configID, orgID, fleetcontrol.GetConfigurationModeTypes.ConfigEntity, 0,
+	)
+	if err != nil {
+		return "", orgID, nil, diag.FromErr(fmt.Errorf("failed to fetch fleet configuration %q (found via name %q): %w", configID, name, err))
+	}
+	if diags := setVersionFields(d, client, configID, orgID); diags != nil {
+		return "", orgID, nil, diags
+	}
+
+	return configID, orgID, content, nil
+}
+
+// setVersionFields fetches all versions for configID and populates
+// latest_version_entity_id and version_entity_ids.
+func setVersionFields(d *schema.ResourceData, client *nr.NewRelic, configID, orgID string) diag.Diagnostics {
+	versionsResp, err := client.FleetControl.FleetControlGetConfigurationVersions(configID, orgID)
+	if err != nil {
+		// Non-fatal: log and skip rather than failing the data source read
+		return nil
+	}
+	if versionsResp == nil || len(versionsResp.Versions) == 0 {
+		return nil
+	}
+
+	// Sort by version number (Version field is a string representing an int)
+	versions := versionsResp.Versions
+	sort.Slice(versions, func(i, j int) bool {
+		ni, _ := strconv.Atoi(versions[i].Version)
+		nj, _ := strconv.Atoi(versions[j].Version)
+		return ni < nj
+	})
+
+	// Collect GUIDs in sorted order
+	guids := make([]string, len(versions))
+	for i, v := range versions {
+		guids[i] = v.EntityGUID
+	}
+
+	// Latest = highest version number = last after sort
+	latestGUID := versions[len(versions)-1].EntityGUID
+
+	if setErr := d.Set("latest_version_entity_id", latestGUID); setErr != nil {
+		return diag.FromErr(setErr)
+	}
+	if setErr := d.Set("version_entity_ids", guids); setErr != nil {
+		return diag.FromErr(setErr)
+	}
+	return nil
+}

--- a/newrelic/data_source_newrelic_fleet_configuration_test.go
+++ b/newrelic/data_source_newrelic_fleet_configuration_test.go
@@ -1,0 +1,205 @@
+//go:build integration || FLEET
+
+package newrelic
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// TestAccNewRelicFleetConfigurationDataSource_ByConfigurationID fetches configuration
+// content using the configuration GUID. Expects the latest version's content.
+func TestAccNewRelicFleetConfigurationDataSource_ByConfigurationID(t *testing.T) {
+	rName := fmt.Sprintf("tf-test-ds-id-%s", acctest.RandString(5))
+	resourceName := "newrelic_fleet_configuration.src"
+	dataSourceName := "data.newrelic_fleet_configuration.by_id"
+
+	setupFleetTestCredentials(t)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckFleetEnvVars(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicFleetConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFleetConfigDataSourceByID(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "configuration_content"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "organization_id"),
+					// Data source content must match the resource's latest version content
+					resource.TestCheckResourceAttrPair(
+						dataSourceName, "configuration_content",
+						resourceName, "version.0.configuration_content",
+					),
+				),
+			},
+		},
+	})
+}
+
+// TestAccNewRelicFleetConfigurationDataSource_ByVersionEntityID fetches configuration
+// content for a specific version using the version entity GUID.
+func TestAccNewRelicFleetConfigurationDataSource_ByVersionEntityID(t *testing.T) {
+	rName := fmt.Sprintf("tf-test-ds-ver-%s", acctest.RandString(5))
+	dataSourceName := "data.newrelic_fleet_configuration.by_version"
+
+	setupFleetTestCredentials(t)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckFleetEnvVars(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicFleetConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFleetConfigDataSourceByVersionID(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "configuration_content"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "organization_id"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccNewRelicFleetConfigurationDataSource_ByName searches for a configuration by name
+// and verifies the data source resolves to the correct entity.
+func TestAccNewRelicFleetConfigurationDataSource_ByName(t *testing.T) {
+
+	rName := fmt.Sprintf("tf-test-ds-name-%s", acctest.RandString(5))
+	dataSourceName := "data.newrelic_fleet_configuration.by_name"
+	resourceName := "newrelic_fleet_configuration.src"
+
+	setupFleetTestCredentials(t)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckFleetEnvVars(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicFleetConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFleetConfigDataSourceByName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "configuration_content"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "organization_id"),
+					// Name-based lookup must resolve the same content as the resource
+					resource.TestCheckResourceAttrPair(
+						dataSourceName, "configuration_content",
+						resourceName, "version.0.configuration_content",
+					),
+				),
+			},
+		},
+	})
+}
+
+// TestAccNewRelicFleetConfigurationDataSource_NotFound verifies that querying a
+// non-existent configuration by name returns an appropriate error.
+func TestAccNewRelicFleetConfigurationDataSource_NotFound(t *testing.T) {
+	setupFleetTestCredentials(t)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckFleetEnvVars(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccFleetConfigDataSourceNotFound(),
+				ExpectError: regexp.MustCompile(`no fleet configuration found with name`),
+			},
+		},
+	})
+}
+
+// TestAccNewRelicFleetConfigurationDataSource_MutuallyExclusive verifies that specifying
+// two lookup inputs simultaneously is rejected at plan time.
+func TestAccNewRelicFleetConfigurationDataSource_MutuallyExclusive(t *testing.T) {
+	setupFleetTestCredentials(t)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckFleetEnvVars(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccFleetConfigDataSourceConflict(),
+				ExpectError: regexp.MustCompile(`conflicts with`),
+			},
+		},
+	})
+}
+
+// ── config templates ──────────────────────────────────────────────────────────
+
+func testAccFleetConfigDataSourceByID(name string) string {
+	return fmt.Sprintf(`
+resource "newrelic_fleet_configuration" "src" {
+  name                = %q
+  agent_type          = "NRInfra"
+  managed_entity_type = "HOST"
+
+  version {
+    configuration_content = "log:\n  level: info\n# ds-by-id\n"
+  }
+}
+
+data "newrelic_fleet_configuration" "by_id" {
+  configuration_id = newrelic_fleet_configuration.src.configuration_id
+}
+`, name)
+}
+
+func testAccFleetConfigDataSourceByVersionID(name string) string {
+	return fmt.Sprintf(`
+resource "newrelic_fleet_configuration" "src" {
+  name                = %q
+  agent_type          = "NRInfra"
+  managed_entity_type = "HOST"
+
+  version {
+    configuration_content = "log:\n  level: info\n# ds-by-version\n"
+  }
+}
+
+data "newrelic_fleet_configuration" "by_version" {
+  version_entity_id = newrelic_fleet_configuration.src.latest_version_entity_id
+}
+`, name)
+}
+
+func testAccFleetConfigDataSourceByName(name string) string {
+	return fmt.Sprintf(`
+resource "newrelic_fleet_configuration" "src" {
+  name                = %q
+  agent_type          = "NRInfra"
+  managed_entity_type = "HOST"
+
+  version {
+    configuration_content = "log:\n  level: info\n# ds-by-name\n"
+  }
+}
+
+data "newrelic_fleet_configuration" "by_name" {
+  name = newrelic_fleet_configuration.src.name
+  depends_on = [newrelic_fleet_configuration.src]
+}
+`, name)
+}
+
+func testAccFleetConfigDataSourceNotFound() string {
+	return `
+data "newrelic_fleet_configuration" "missing" {
+  name = "tf-test-does-not-exist-zzzzzzzz"
+}
+`
+}
+
+func testAccFleetConfigDataSourceConflict() string {
+	return `
+data "newrelic_fleet_configuration" "conflict" {
+  configuration_id  = "some-guid"
+  version_entity_id = "other-guid"
+}
+`
+}

--- a/newrelic/provider_newrelic.go
+++ b/newrelic/provider_newrelic.go
@@ -136,6 +136,7 @@ func Provider() *schema.Provider {
 			"newrelic_test_grok_pattern":            dataSourceNewRelicTestGrokPattern(),
 			"newrelic_service_level_alert_helper":   dataSourceNewRelicServiceLevelAlertHelper(),
 			"newrelic_user":                         dataSourceNewRelicUser(),
+			"newrelic_fleet_configuration":          dataSourceNewRelicFleetConfiguration(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -193,6 +194,7 @@ func Provider() *schema.Provider {
 			"newrelic_workload":                                 resourceNewRelicWorkload(),
 			"newrelic_user":                                     resourceNewRelicUser(),
 			"newrelic_fleet":                                    resourceNewRelicFleet(),
+			"newrelic_fleet_configuration":                      resourceNewRelicFleetConfiguration(),
 			"newrelic_workflow_automation":                      resourceNewRelicWorkflowAutomation(),
 		},
 	}

--- a/newrelic/resource_newrelic_fleet_configuration.go
+++ b/newrelic/resource_newrelic_fleet_configuration.go
@@ -1,0 +1,691 @@
+package newrelic
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	nrErrors "github.com/newrelic/newrelic-client-go/v2/pkg/errors"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/fleetcontrol"
+)
+
+func resourceNewRelicFleetConfiguration() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNewRelicFleetConfigurationCreate,
+		ReadContext:   resourceNewRelicFleetConfigurationRead,
+		UpdateContext: resourceNewRelicFleetConfigurationUpdate,
+		DeleteContext: resourceNewRelicFleetConfigurationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceNewRelicFleetConfigurationImportState,
+		},
+		CustomizeDiff: resourceNewRelicFleetConfigurationCustomizeDiff,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the configuration.",
+			},
+			"agent_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"NRInfra",
+					"NRDOT",
+					"FluentBit",
+					"NRPrometheusAgent",
+				}, false),
+				Description: "The type of agent this configuration is for. Allowed values: NRInfra, NRDOT, FluentBit, NRPrometheusAgent.",
+			},
+			"managed_entity_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"HOST",
+					"KUBERNETESCLUSTER",
+				}, false),
+				Description: "The type of entities this configuration manages. Allowed values: HOST, KUBERNETESCLUSTER.",
+			},
+			// TypeList — preserves insertion order so CustomizeDiff sees all blocks (including
+			// duplicates) and positional removal is unambiguous (surviving blocks encode which
+			// one was removed). This also makes rollback sequences like v1(A)→v2(B)→v3(A) safe,
+			// because identical-content blocks are NOT collapsed before CustomizeDiff runs.
+			//
+			// FUTURE: TypeSet alternative preserved below if content-hash deduplication is preferred.
+			"version": {
+				Type:     schema.TypeList,
+				Required: true,
+				MinItems: 1,
+				Description: "Configuration versions. At least one required. Each version must have unique content. " +
+					"Use file() to load content: configuration_content = file(\"${path.module}/config.yaml\").",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"configuration_content": {
+							Type:     schema.TypeString,
+							Required: true,
+							Description: "Configuration content for this version (YAML or JSON). " +
+								"Content must be unique across version blocks. " +
+								"Use file() to load from a file: file(\"${path.module}/config.yaml\").",
+						},
+						"version_number": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Version number assigned by the API (1, 2, 3, ...).",
+						},
+						"version_entity_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Version entity GUID.",
+						},
+					},
+				},
+			},
+			/* TypeSet alternative — uncomment to switch back if content-hash deduplication is preferred:
+			"version": {
+				Type:     schema.TypeSet,
+				Required: true,
+				MinItems: 1,
+				Description: "Configuration versions. At least one required. Each version must have unique content. " +
+					"Use file() to load content: configuration_content = file(\"${path.module}/config.yaml\").",
+				Set: func(v interface{}) int {
+					m := v.(map[string]interface{})
+					return schema.HashString(m["configuration_content"].(string))
+				},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"configuration_content": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"version_number": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"version_entity_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			*/
+			"organization_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The organization ID. Auto-fetched from the account if not provided.",
+			},
+			"configuration_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The configuration entity GUID.",
+			},
+			"latest_version_number": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The highest version number across all versions.",
+			},
+			"latest_version_entity_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Entity GUID of the highest-numbered version.",
+			},
+			"total_versions": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Total number of versions.",
+			},
+		},
+	}
+}
+
+// resourceNewRelicFleetConfigurationCustomizeDiff validates version blocks and
+// marks derived scalar fields as unknown when the version list changes.
+//
+// Three checks are performed:
+//
+//  1. In-place content modification guard — versions are immutable in the API;
+//     there is no "update content" mutation. Editing configuration_content of an
+//     existing block would silently delete that version and create a new one with a
+//     higher version number. We detect this and surface a clear error instead.
+//
+//     Detection heuristic: for each position i present in both old and new lists,
+//     if old[i] has a persisted version_entity_id (it was previously applied) AND
+//     new[i] has different content AND that new content did not exist anywhere in
+//     the old list (ruling out blocks that merely shifted position due to a removal),
+//     we treat it as an attempted in-place edit.
+//
+//  2. Duplicate content guard — with TypeList the SDK does NOT deduplicate blocks
+//     before this function runs, so this is the primary uniqueness check.
+//
+//  3. SetNewComputed — marks derived scalar fields as unknown whenever the version
+//     list changes so the plan accurately shows they will be re-evaluated.
+func resourceNewRelicFleetConfigurationCustomizeDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+	versionsRaw, ok := d.GetOk("version")
+	if !ok {
+		return nil
+	}
+
+	// --- Check 1: in-place content modification ---
+	//
+	// Only meaningful when the list length is unchanged. If the count differs,
+	// the change is a pure addition or removal — positional comparison would
+	// produce false positives (e.g. a version deleted from the API is removed
+	// from state by Read, making the counts differ on the next plan).
+	if d.HasChange("version") {
+		oldRaw, newRaw := d.GetChange("version")
+		oldList := oldRaw.([]interface{})
+		newList := newRaw.([]interface{})
+
+		if len(oldList) > 0 && len(oldList) == len(newList) {
+			// Build a set of all content values present in the old state so we can
+			// distinguish a genuinely new content value from a block that shifted
+			// position due to a prior removal that was already applied.
+			oldContentSet := make(map[string]bool, len(oldList))
+			for _, v := range oldList {
+				content := v.(map[string]interface{})["configuration_content"].(string)
+				oldContentSet[content] = true
+			}
+
+			var violations []string
+			for i := 0; i < len(oldList); i++ {
+				oldMap := oldList[i].(map[string]interface{})
+				newMap := newList[i].(map[string]interface{})
+
+				entityID, _ := oldMap["version_entity_id"].(string)
+				oldContent, _ := oldMap["configuration_content"].(string)
+				newContent, _ := newMap["configuration_content"].(string)
+
+				// A persisted block whose content changed to something not present
+				// anywhere in the old list is an in-place edit attempt.
+				if entityID != "" && oldContent != newContent && !oldContentSet[newContent] {
+					violations = append(violations, fmt.Sprintf(
+						"  - index %d: to replace this content, add a new version block with "+
+							"the updated content (apply), then remove the old one (apply again)",
+						i,
+					))
+				}
+			}
+			if len(violations) > 0 {
+				return fmt.Errorf(
+					"configuration_content cannot be modified in place — versions are immutable:\n%s",
+					strings.Join(violations, "\n"),
+				)
+			}
+		}
+	}
+
+	// --- Check 2: duplicate content ---
+	// seen maps configuration_content → version_number of first occurrence (0 if not yet assigned).
+	seen := make(map[string]int)
+	for _, v := range versionsRaw.([]interface{}) {
+		vMap := v.(map[string]interface{})
+		content := vMap["configuration_content"].(string)
+		vNum, _ := vMap["version_number"].(int)
+		if existingNum, exists := seen[content]; exists {
+			if existingNum > 0 {
+				return fmt.Errorf(
+					"duplicate configuration_content detected — matches version %d; "+
+						"add a distinguishing comment if you intend to roll back to that content",
+					existingNum,
+				)
+			}
+			return fmt.Errorf(
+				"duplicate configuration_content detected across version blocks — " +
+					"each version must have unique content; add a distinguishing comment " +
+					"if two versions are otherwise identical",
+			)
+		}
+		seen[content] = vNum
+	}
+
+	// --- Check 3: mark derived scalar fields as unknown ---
+	// When the version list changes, mark derived scalar fields as unknown so
+	// Terraform re-evaluates them (and dependent outputs) after apply.
+	if d.HasChange("version") {
+		for _, field := range []string{"total_versions", "latest_version_number", "latest_version_entity_id"} {
+			if err := d.SetNewComputed(field); err != nil {
+				return fmt.Errorf("failed to mark %s as computed: %w", field, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// resourceNewRelicFleetConfigurationImportState handles:
+//
+//   - Plain ID:  terraform import newrelic_fleet_configuration.x <configGUID>
+//     name, agent_type, managed_entity_type remain empty and must be filled in
+//     manually after import.
+//
+//   - Compound ID: <configGUID>:<orgID>:<agentType>:<managedEntityType>:<name>
+//     All required fields are reconstructed from the import ID so that
+//     ImportStateVerify passes without an additional API round-trip.
+func resourceNewRelicFleetConfigurationImportState(ctx context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), ":", 5)
+	if len(parts) == 5 {
+		d.SetId(parts[0])
+		_ = d.Set("organization_id", parts[1])
+		_ = d.Set("agent_type", parts[2])
+		_ = d.Set("managed_entity_type", parts[3])
+		_ = d.Set("name", parts[4])
+	}
+	return []*schema.ResourceData{d}, nil
+}
+
+func resourceNewRelicFleetConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+
+	organizationID, err := getOrganizationID(ctx, providerConfig, d.Get("organization_id").(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	versions := d.Get("version").([]interface{})
+
+	// Create configuration atomically with first version (v1).
+	firstVersion := versions[0].(map[string]interface{})
+	configBody := []byte(firstVersion["configuration_content"].(string))
+
+	result, err := providerConfig.NewClient.FleetControl.FleetControlCreateConfiguration(
+		configBody,
+		map[string]interface{}{
+			"x-newrelic-client-go-custom-headers": map[string]string{
+				"Newrelic-Entity": fmt.Sprintf(
+					`{"name": "%s", "agentType": "%s", "managedEntityType": "%s"}`,
+					d.Get("name").(string),
+					d.Get("agent_type").(string),
+					d.Get("managed_entity_type").(string),
+				),
+			},
+		},
+		organizationID,
+	)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(result.ConfigurationEntityGUID)
+
+	// content → version data map for state assembly
+	contentToVersion := map[string]map[string]interface{}{
+		firstVersion["configuration_content"].(string): {
+			"configuration_content": firstVersion["configuration_content"],
+			"version_number":        result.ConfigurationVersion.ConfigurationVersionNumber,
+			"version_entity_id":     result.ConfigurationVersion.ConfigurationVersionEntityGUID,
+		},
+	}
+
+	// Create additional versions (v2+).
+	for i := 1; i < len(versions); i++ {
+		vMap := versions[i].(map[string]interface{})
+		content := vMap["configuration_content"].(string)
+
+		vr, err := providerConfig.NewClient.FleetControl.FleetControlCreateConfiguration(
+			[]byte(content),
+			map[string]interface{}{
+				"x-newrelic-client-go-custom-headers": map[string]string{
+					"Newrelic-Entity": fmt.Sprintf(`{"agentConfiguration": "%s"}`, result.ConfigurationEntityGUID),
+				},
+			},
+			organizationID,
+		)
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("failed to create version %d: %w", i+1, err))
+		}
+		contentToVersion[content] = map[string]interface{}{
+			"configuration_content": content,
+			"version_number":        vr.ConfigurationVersion.ConfigurationVersionNumber,
+			"version_entity_id":     vr.ConfigurationVersion.ConfigurationVersionEntityGUID,
+		}
+	}
+
+	versionsList := fleetConfigBuildVersionsList(versions, contentToVersion)
+
+	if err := d.Set("version", versionsList); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("configuration_id", result.ConfigurationEntityGUID); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("organization_id", organizationID); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("total_versions", len(versionsList)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	fleetConfigSetLatestVersionFields(d, versionsList)
+	// Call Read to ensure all computed fields (version_entity_id, version_number) are
+	// populated from the API in a single apply — avoids the output-only drift that
+	// otherwise requires a second apply to resolve.
+	return resourceNewRelicFleetConfigurationRead(ctx, d, meta)
+}
+
+func resourceNewRelicFleetConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+
+	organizationID := d.Get("organization_id").(string)
+	if organizationID == "" {
+		var err error
+		organizationID, err = getOrganizationID(ctx, providerConfig, "")
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	// Always sync computed fields that can be derived without an extra API call.
+	if setErr := d.Set("configuration_id", d.Id()); setErr != nil {
+		return diag.FromErr(setErr)
+	}
+	if setErr := d.Set("organization_id", organizationID); setErr != nil {
+		return diag.FromErr(setErr)
+	}
+
+	versionsResp, err := providerConfig.NewClient.FleetControl.FleetControlGetConfigurationVersions(
+		d.Id(), organizationID,
+	)
+	if err != nil {
+		if _, ok := err.(*nrErrors.NotFound); ok {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+
+	if versionsResp == nil || len(versionsResp.Versions) == 0 {
+		d.SetId("")
+		return nil
+	}
+
+	// Sort API versions by version number (ascending) so state order is stable.
+	apiVersions := make([]fleetcontrol.ConfigurationVersion, len(versionsResp.Versions))
+	copy(apiVersions, versionsResp.Versions)
+	sort.Slice(apiVersions, func(i, j int) bool {
+		ni, _ := strconv.Atoi(apiVersions[i].Version)
+		nj, _ := strconv.Atoi(apiVersions[j].Version)
+		return ni < nj
+	})
+
+	// Track the highest version number and build API entity-id set.
+	apiVersionSet := make(map[string]bool, len(apiVersions))
+	var latestVersionNum int
+	var latestVersionEntityID string
+	for _, v := range apiVersions {
+		apiVersionSet[v.EntityGUID] = true
+		num, parseErr := strconv.Atoi(v.Version)
+		if parseErr != nil {
+			return diag.FromErr(fmt.Errorf("failed to parse version number %q: %w", v.Version, parseErr))
+		}
+		if num > latestVersionNum {
+			latestVersionNum = num
+			latestVersionEntityID = v.EntityGUID
+		}
+	}
+
+	// Index current state versions by entity_id so we can carry content forward.
+	stateVersions := d.Get("version").([]interface{})
+	stateByEntityID := make(map[string]map[string]interface{}, len(stateVersions))
+	for _, sv := range stateVersions {
+		svMap := sv.(map[string]interface{})
+		entityID, _ := svMap["version_entity_id"].(string)
+		if entityID != "" {
+			stateByEntityID[entityID] = svMap
+		}
+	}
+
+	// Warn about state versions that no longer exist in the API (externally deleted).
+	var diags diag.Diagnostics
+	for i, sv := range stateVersions {
+		svMap := sv.(map[string]interface{})
+		entityID, _ := svMap["version_entity_id"].(string)
+		if entityID != "" && !apiVersionSet[entityID] {
+			log.Printf("[WARN] Version %s (index %d) no longer exists in API, removing from state", entityID, i)
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  fmt.Sprintf("Version at index %d was deleted externally", i),
+				Detail: fmt.Sprintf(
+					"Version entity %s (index %d, version_number=%v) was not found in the API — "+
+						"it was likely deleted outside of Terraform.\n\n"+
+						"If this deletion was intentional, remove the corresponding version block "+
+						"from your configuration to avoid it being recreated on the next apply.\n\n"+
+						"If it was not intentional, run 'terraform apply' to recreate it.",
+					entityID, i, svMap["version_number"],
+				),
+			})
+		}
+	}
+
+	// Rebuild version list from API order. For versions already in state, carry content
+	// forward. For versions not in state (import case), fetch content from the API.
+	syncedVersions := make([]map[string]interface{}, 0, len(apiVersions))
+	for _, apiVer := range apiVersions {
+		versionNum, _ := strconv.Atoi(apiVer.Version)
+		if svMap, ok := stateByEntityID[apiVer.EntityGUID]; ok {
+			syncedVersions = append(syncedVersions, svMap)
+		} else {
+			// Version not in state — fetch content so import reconstructs full state.
+			content, fetchErr := providerConfig.NewClient.FleetControl.FleetControlGetConfiguration(
+				apiVer.EntityGUID, organizationID, fleetcontrol.GetConfigurationModeTypes.ConfigVersionEntity, 0,
+			)
+			var contentStr string
+			if fetchErr != nil {
+				log.Printf("[WARN] Could not fetch content for version entity %s: %v", apiVer.EntityGUID, fetchErr)
+			} else if content != nil {
+				contentStr = string(*content)
+			}
+			syncedVersions = append(syncedVersions, map[string]interface{}{
+				"version_entity_id":     apiVer.EntityGUID,
+				"version_number":        versionNum,
+				"configuration_content": contentStr,
+			})
+		}
+	}
+
+	if err := d.Set("version", syncedVersions); err != nil {
+		return append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("total_versions", len(versionsResp.Versions)); err != nil {
+		return append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("latest_version_entity_id", latestVersionEntityID); err != nil {
+		return append(diags, diag.FromErr(err)...)
+	}
+	if err := d.Set("latest_version_number", latestVersionNum); err != nil {
+		return append(diags, diag.FromErr(err)...)
+	}
+
+	return diags
+}
+
+func resourceNewRelicFleetConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	if d.HasChange("name") {
+		return diag.Errorf("configuration name cannot be updated — create a new configuration resource instead")
+	}
+
+	if !d.HasChange("version") {
+		return nil
+	}
+
+	oldRaw, newRaw := d.GetChange("version")
+	oldList := oldRaw.([]interface{})
+	newList := newRaw.([]interface{})
+
+	providerConfig := meta.(*ProviderConfig)
+	organizationID := d.Get("organization_id").(string)
+
+	// Index old state by content so we can look up entity_ids for deletion and
+	// identify which contents already exist (no API call needed).
+	// For the edge case of duplicate content in old state (should not happen after
+	// CustomizeDiff, but defensive), first occurrence wins.
+	oldByContent := make(map[string]map[string]interface{})
+	for _, v := range oldList {
+		vMap := v.(map[string]interface{})
+		content := vMap["configuration_content"].(string)
+		if _, exists := oldByContent[content]; !exists {
+			oldByContent[content] = vMap
+		}
+	}
+
+	// Determine which content values are present in the new desired list.
+	newContentSet := make(map[string]bool)
+	for _, v := range newList {
+		newContentSet[v.(map[string]interface{})["configuration_content"].(string)] = true
+	}
+
+	// Delete versions whose content no longer appears in the new list.
+	for content, vMap := range oldByContent {
+		if newContentSet[content] {
+			continue
+		}
+		entityID, _ := vMap["version_entity_id"].(string)
+		if entityID == "" {
+			continue
+		}
+		log.Printf("[INFO] Deleting removed version %s", entityID)
+		if err := providerConfig.NewClient.FleetControl.FleetControlDeleteConfigurationVersion(
+			entityID, organizationID,
+		); err != nil {
+			return diag.FromErr(fmt.Errorf("failed to delete version %s: %w", entityID, err))
+		}
+	}
+
+	// Create versions whose content does not exist in old state.
+	newVersionData := make(map[string]map[string]interface{})
+	for _, v := range newList {
+		vMap := v.(map[string]interface{})
+		content := vMap["configuration_content"].(string)
+		if _, exists := oldByContent[content]; exists {
+			continue
+		}
+
+		vr, err := providerConfig.NewClient.FleetControl.FleetControlCreateConfiguration(
+			[]byte(content),
+			map[string]interface{}{
+				"x-newrelic-client-go-custom-headers": map[string]string{
+					"Newrelic-Entity": fmt.Sprintf(`{"agentConfiguration": "%s"}`, d.Id()),
+				},
+			},
+			organizationID,
+		)
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("failed to create new version: %w", err))
+		}
+
+		newVersionData[content] = map[string]interface{}{
+			"configuration_content": content,
+			"version_number":        vr.ConfigurationVersion.ConfigurationVersionNumber,
+			"version_entity_id":     vr.ConfigurationVersion.ConfigurationVersionEntityGUID,
+		}
+	}
+
+	// Merge old (unchanged) and new (just created) version data, then assemble
+	// final state ordered by the new desired list.
+	mergedData := make(map[string]map[string]interface{}, len(oldByContent)+len(newVersionData))
+	for k, v := range oldByContent {
+		mergedData[k] = v
+	}
+	for k, v := range newVersionData {
+		mergedData[k] = v
+	}
+
+	versionsList := fleetConfigBuildVersionsList(newList, mergedData)
+
+	if err := d.Set("version", versionsList); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("total_versions", len(versionsList)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	fleetConfigSetLatestVersionFields(d, versionsList)
+	// Call Read to ensure all computed fields are populated from the API after
+	// the update — avoids the output-only drift requiring a second apply.
+	return resourceNewRelicFleetConfigurationRead(ctx, d, meta)
+}
+
+func resourceNewRelicFleetConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+
+	organizationID := d.Get("organization_id").(string)
+	if organizationID == "" {
+		var err error
+		organizationID, err = getOrganizationID(ctx, providerConfig, "")
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	log.Printf("[INFO] Deleting New Relic Fleet Configuration %s", d.Id())
+
+	// Delete all versions first — the API rejects configuration deletion if any version still exists.
+	for _, v := range d.Get("version").([]interface{}) {
+		vMap := v.(map[string]interface{})
+		entityID, _ := vMap["version_entity_id"].(string)
+		if entityID == "" {
+			continue
+		}
+		log.Printf("[INFO] Deleting version %s", entityID)
+		if err := providerConfig.NewClient.FleetControl.FleetControlDeleteConfigurationVersion(
+			entityID, organizationID,
+		); err != nil {
+			return diag.FromErr(fmt.Errorf("failed to delete version %s: %w", entityID, err))
+		}
+	}
+
+	// Delete the configuration entity.
+	// The API auto-deletes the config when its last version is removed, so NotFound is a success.
+	_, err := providerConfig.NewClient.FleetControl.FleetControlDeleteConfiguration(d.Id(), organizationID)
+	if err != nil {
+		if _, ok := err.(*nrErrors.NotFound); ok {
+			log.Printf("[INFO] Fleet configuration %s already gone (auto-removed by API)", d.Id())
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+// fleetConfigBuildVersionsList assembles the []map to write into state.
+// It iterates the desired version elements and backfills computed fields
+// (version_entity_id, version_number) from contentToVersion, keyed by configuration_content.
+func fleetConfigBuildVersionsList(versions []interface{}, contentToVersion map[string]map[string]interface{}) []map[string]interface{} {
+	out := make([]map[string]interface{}, 0, len(versions))
+	for _, v := range versions {
+		content := v.(map[string]interface{})["configuration_content"].(string)
+		if known, ok := contentToVersion[content]; ok {
+			out = append(out, known)
+		} else {
+			// Should not happen in normal flow; preserve whatever came in.
+			out = append(out, v.(map[string]interface{}))
+		}
+	}
+	return out
+}
+
+// fleetConfigSetLatestVersionFields scans all versions and sets latest_version_number
+// and latest_version_entity_id to the entry with the highest version_number.
+// Required because the API returns versions in unsorted order.
+func fleetConfigSetLatestVersionFields(d *schema.ResourceData, versions []map[string]interface{}) {
+	var latestNum int
+	var latestEntityID string
+	for _, v := range versions {
+		num, _ := v["version_number"].(int)
+		if num > latestNum {
+			latestNum = num
+			latestEntityID, _ = v["version_entity_id"].(string)
+		}
+	}
+	_ = d.Set("latest_version_number", latestNum)
+	_ = d.Set("latest_version_entity_id", latestEntityID)
+}

--- a/newrelic/resource_newrelic_fleet_configuration_test.go
+++ b/newrelic/resource_newrelic_fleet_configuration_test.go
@@ -1,0 +1,555 @@
+//go:build integration || FLEET
+
+package newrelic
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/fleetcontrol"
+)
+
+// TestAccNewRelicFleetConfiguration_Basic covers the create → read → import → destroy lifecycle
+// with a single version block. Also verifies computed fields are populated after a single apply
+// (no second-apply required for output variables).
+func TestAccNewRelicFleetConfiguration_Basic(t *testing.T) {
+	rName := fmt.Sprintf("tf-test-config-%s", acctest.RandString(5))
+	resourceName := "newrelic_fleet_configuration.foo"
+
+	setupFleetTestCredentials(t)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckFleetEnvVars(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicFleetConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFleetConfigBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicFleetConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "agent_type", "NRInfra"),
+					resource.TestCheckResourceAttr(resourceName, "managed_entity_type", "HOST"),
+					resource.TestCheckResourceAttrSet(resourceName, "configuration_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
+					resource.TestCheckResourceAttr(resourceName, "total_versions", "1"),
+					resource.TestCheckResourceAttr(resourceName, "latest_version_number", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "latest_version_entity_id"),
+					// TypeList positional checks
+					resource.TestCheckResourceAttr(resourceName, "version.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "version.0.version_number", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "version.0.version_entity_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "version.0.configuration_content"),
+				),
+			},
+			// Import — compound ID reconstructs non-API-readable fields (agent_type, etc.)
+			{
+				ResourceName:        resourceName,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdFunc:   testAccFleetConfigImportID(resourceName),
+			},
+		},
+	})
+}
+
+// TestAccNewRelicFleetConfiguration_SingleApplyOutputs verifies that all computed fields
+// (including version_entity_id and version_number) are populated after a single apply,
+// confirming the Read-at-end-of-Create fix.
+func TestAccNewRelicFleetConfiguration_SingleApplyOutputs(t *testing.T) {
+	rName := fmt.Sprintf("tf-test-output-%s", acctest.RandString(5))
+	resourceName := "newrelic_fleet_configuration.foo"
+
+	setupFleetTestCredentials(t)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckFleetEnvVars(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicFleetConfigurationDestroy,
+		Steps: []resource.TestStep{
+			// Single apply — all fields must be set without a follow-up plan/apply cycle
+			{
+				Config: testAccFleetConfigBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					// These would be empty string if Read was not called at end of Create
+					resource.TestCheckResourceAttrSet(resourceName, "version.0.version_entity_id"),
+					resource.TestCheckResourceAttr(resourceName, "version.0.version_number", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "latest_version_entity_id"),
+					resource.TestCheckResourceAttr(resourceName, "latest_version_number", "1"),
+				),
+			},
+			// Plan-only step: zero diff expected (no "known after apply" drift)
+			{
+				Config:             testAccFleetConfigBasic(rName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// TestAccNewRelicFleetConfiguration_MultiVersion creates a configuration with two versions
+// and verifies both are tracked correctly with unique entity IDs and version numbers.
+func TestAccNewRelicFleetConfiguration_MultiVersion(t *testing.T) {
+	rName := fmt.Sprintf("tf-test-multi-%s", acctest.RandString(5))
+	resourceName := "newrelic_fleet_configuration.multi"
+
+	setupFleetTestCredentials(t)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckFleetEnvVars(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicFleetConfigurationDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create with v1 only
+			{
+				Config: testAccFleetConfigOneVersion(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicFleetConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "version.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "total_versions", "1"),
+					resource.TestCheckResourceAttr(resourceName, "latest_version_number", "1"),
+					resource.TestCheckResourceAttr(resourceName, "version.0.version_number", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "version.0.version_entity_id"),
+				),
+			},
+			// Step 2: Add v2 — verify v1 entity_id is preserved, latest_version_number advances
+			{
+				Config: testAccFleetConfigTwoVersions(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "version.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "total_versions", "2"),
+					resource.TestCheckResourceAttr(resourceName, "latest_version_number", "2"),
+					resource.TestCheckResourceAttr(resourceName, "version.0.version_number", "1"),
+					resource.TestCheckResourceAttr(resourceName, "version.1.version_number", "2"),
+					resource.TestCheckResourceAttrSet(resourceName, "version.0.version_entity_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "version.1.version_entity_id"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccNewRelicFleetConfiguration_VersionSequence exercises the full add/remove sequence:
+// v1 → +v2 → +v3 → -v2 → +v4+v5 → -v1-v5
+// Verifies that entity_ids for unchanged versions remain stable (TypeList key advantage).
+func TestAccNewRelicFleetConfiguration_VersionSequence(t *testing.T) {
+	rName := fmt.Sprintf("tf-test-seq-%s", acctest.RandString(5))
+	resourceName := "newrelic_fleet_configuration.seq"
+
+	setupFleetTestCredentials(t)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckFleetEnvVars(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicFleetConfigurationDestroy,
+		Steps: []resource.TestStep{
+			// v1 only
+			{
+				Config: testAccFleetConfigSeq(rName, true, false, false, false, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "version.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "total_versions", "1"),
+					resource.TestCheckResourceAttr(resourceName, "version.0.version_number", "1"),
+				),
+			},
+			// +v2
+			{
+				Config: testAccFleetConfigSeq(rName, true, true, false, false, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "version.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "total_versions", "2"),
+					resource.TestCheckResourceAttr(resourceName, "version.0.version_number", "1"),
+					resource.TestCheckResourceAttr(resourceName, "version.1.version_number", "2"),
+				),
+			},
+			// +v3 (v1, v2, v3)
+			{
+				Config: testAccFleetConfigSeq(rName, true, true, true, false, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "version.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "total_versions", "3"),
+					resource.TestCheckResourceAttr(resourceName, "version.2.version_number", "3"),
+				),
+			},
+			// -v2 (v1, v3 remain) — content-based matching must delete v2's entity, not position
+			{
+				Config: testAccFleetConfigSeq(rName, true, false, true, false, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "version.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "total_versions", "2"),
+					resource.TestCheckResourceAttr(resourceName, "version.0.version_number", "1"),
+					resource.TestCheckResourceAttr(resourceName, "version.1.version_number", "3"),
+				),
+			},
+			// +v4+v5 simultaneously (v1, v3, v4, v5)
+			{
+				Config: testAccFleetConfigSeq(rName, true, false, true, true, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "version.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "total_versions", "4"),
+				),
+			},
+			// -v1-v5 simultaneously (v3, v4 remain)
+			{
+				Config: testAccFleetConfigSeq(rName, false, false, true, true, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "version.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "total_versions", "2"),
+					resource.TestCheckResourceAttr(resourceName, "version.0.version_number", "3"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccNewRelicFleetConfiguration_RollbackWorkflow exercises the rollback pattern:
+// v1(A) → v2(B) → v3(A) — verifies that re-using version A's content creates a new version
+// rather than resurrecting the old entity_id, since the TypeList in-place edit guard only
+// fires when block count stays the same and a block's content changes.
+func TestAccNewRelicFleetConfiguration_RollbackWorkflow(t *testing.T) {
+	rName := fmt.Sprintf("tf-test-rollback-%s", acctest.RandString(5))
+	resourceName := "newrelic_fleet_configuration.rollback"
+
+	const contentA = "log:\n  level: info\n# rollback-a\n"
+	const contentB = "log:\n  level: debug\n# rollback-b\n"
+
+	setupFleetTestCredentials(t)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckFleetEnvVars(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicFleetConfigurationDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create with content A (version 1)
+			{
+				Config: testAccFleetConfigRollback(rName, []string{contentA}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "version.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "version.0.version_number", "1"),
+					resource.TestCheckResourceAttr(resourceName, "latest_version_number", "1"),
+				),
+			},
+			// Step 2: Add content B (version 2)
+			{
+				Config: testAccFleetConfigRollback(rName, []string{contentA, contentB}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "version.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "version.1.version_number", "2"),
+					resource.TestCheckResourceAttr(resourceName, "latest_version_number", "2"),
+				),
+			},
+			// Step 3: Add content A again (version 3 — rollback to same content as v1)
+			// This must succeed: adding a block with content that previously existed
+			// but is not currently in state is a pure addition, not an in-place edit.
+			{
+				Config: testAccFleetConfigRollback(rName, []string{contentA, contentB, contentA + "# copy\n"}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "version.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "total_versions", "3"),
+					resource.TestCheckResourceAttr(resourceName, "latest_version_number", "3"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccNewRelicFleetConfiguration_Kubernetes verifies a Kubernetes-targeted configuration.
+func TestAccNewRelicFleetConfiguration_Kubernetes(t *testing.T) {
+	rName := fmt.Sprintf("tf-test-k8s-%s", acctest.RandString(5))
+	resourceName := "newrelic_fleet_configuration.k8s"
+
+	setupFleetTestCredentials(t)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckFleetEnvVars(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicFleetConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFleetConfigKubernetes(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicFleetConfigurationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "agent_type", "NRInfra"),
+					resource.TestCheckResourceAttr(resourceName, "managed_entity_type", "KUBERNETESCLUSTER"),
+					resource.TestCheckResourceAttr(resourceName, "version.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "total_versions", "1"),
+					resource.TestCheckResourceAttr(resourceName, "version.0.version_number", "1"),
+				),
+			},
+			{
+				ResourceName:        resourceName,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdFunc:   testAccFleetConfigImportID(resourceName),
+			},
+		},
+	})
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// testAccFleetConfigImportID builds the compound import ID needed by the custom
+// importer: configGUID:orgID:agentType:managedEntityType:name.
+// The API does not expose agent_type/managed_entity_type/name via any working
+// read endpoint, so we encode them in the import ID to satisfy ImportStateVerify.
+func testAccFleetConfigImportID(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource not found: %s", resourceName)
+		}
+		return fmt.Sprintf("%s:%s:%s:%s:%s",
+			rs.Primary.ID,
+			rs.Primary.Attributes["organization_id"],
+			rs.Primary.Attributes["agent_type"],
+			rs.Primary.Attributes["managed_entity_type"],
+			rs.Primary.Attributes["name"],
+		), nil
+	}
+}
+
+func testAccCheckNewRelicFleetConfigurationExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no configuration ID is set")
+		}
+
+		organizationID := rs.Primary.Attributes["organization_id"]
+		if organizationID == "" {
+			return fmt.Errorf("no organization_id is set")
+		}
+
+		client := testAccProvider.Meta().(*ProviderConfig).NewClient
+		resp, err := client.FleetControl.FleetControlGetConfigurationVersions(
+			rs.Primary.ID, organizationID,
+		)
+		if err != nil {
+			return err
+		}
+		if resp == nil || len(resp.Versions) == 0 {
+			return fmt.Errorf("fleet configuration %s has no versions", rs.Primary.ID)
+		}
+		return nil
+	}
+}
+
+func testAccCheckNewRelicFleetConfigurationDestroy(s *terraform.State) error {
+	for _, r := range s.RootModule().Resources {
+		if r.Type != "newrelic_fleet_configuration" {
+			continue
+		}
+
+		organizationID := r.Primary.Attributes["organization_id"]
+		if organizationID == "" {
+			continue
+		}
+
+		client := testAccProvider.Meta().(*ProviderConfig).NewClient
+		mode := fleetcontrol.GetConfigurationModeTypes.ConfigEntity
+		_, err := client.FleetControl.FleetControlGetConfiguration(
+			r.Primary.ID, organizationID, mode, 0,
+		)
+		if err == nil {
+			return fmt.Errorf("fleet configuration still exists: %s", r.Primary.ID)
+		}
+	}
+	return nil
+}
+
+// ── config templates ─────────────────────────────────────────────────────────
+
+func testAccFleetConfigBasic(name string) string {
+	return fmt.Sprintf(`
+resource "newrelic_fleet_configuration" "foo" {
+  name                = %q
+  agent_type          = "NRInfra"
+  managed_entity_type = "HOST"
+
+  version {
+    configuration_content = <<-EOT
+      log:
+        level: info
+      metrics:
+        enabled: true
+      # v1
+    EOT
+  }
+}
+`, name)
+}
+
+func testAccFleetConfigOneVersion(name string) string {
+	return fmt.Sprintf(`
+resource "newrelic_fleet_configuration" "multi" {
+  name                = %q
+  agent_type          = "NRInfra"
+  managed_entity_type = "HOST"
+
+  version {
+    configuration_content = <<-EOT
+      log:
+        level: info
+      # v1
+    EOT
+  }
+}
+`, name)
+}
+
+func testAccFleetConfigTwoVersions(name string) string {
+	return fmt.Sprintf(`
+resource "newrelic_fleet_configuration" "multi" {
+  name                = %q
+  agent_type          = "NRInfra"
+  managed_entity_type = "HOST"
+
+  version {
+    configuration_content = <<-EOT
+      log:
+        level: info
+      # v1
+    EOT
+  }
+
+  version {
+    configuration_content = <<-EOT
+      log:
+        level: debug
+      # v2
+    EOT
+  }
+}
+`, name)
+}
+
+// testAccFleetConfigSeq generates a config for the version sequence test.
+// Each boolean flag controls whether that version block is included.
+func testAccFleetConfigSeq(name string, v1, v2, v3, v4, v5 bool) string {
+	cfg := fmt.Sprintf(`
+resource "newrelic_fleet_configuration" "seq" {
+  name                = %q
+  agent_type          = "NRInfra"
+  managed_entity_type = "HOST"
+`, name)
+
+	if v1 {
+		cfg += `
+  version {
+    configuration_content = <<-EOT
+      log:
+        level: info
+      metrics:
+        enabled: true
+        sample_rate: 30
+      # v1
+    EOT
+  }
+`
+	}
+	if v2 {
+		cfg += `
+  version {
+    configuration_content = <<-EOT
+      log:
+        level: debug
+      metrics:
+        enabled: true
+        sample_rate: 10
+      # v2
+    EOT
+  }
+`
+	}
+	if v3 {
+		cfg += `
+  version {
+    configuration_content = <<-EOT
+      log:
+        level: warn
+      metrics:
+        enabled: false
+      # v3
+    EOT
+  }
+`
+	}
+	if v4 {
+		cfg += `
+  version {
+    configuration_content = <<-EOT
+      log:
+        level: error
+      metrics:
+        enabled: true
+        sample_rate: 60
+      # v4
+    EOT
+  }
+`
+	}
+	if v5 {
+		cfg += `
+  version {
+    configuration_content = <<-EOT
+      log:
+        level: trace
+      metrics:
+        enabled: true
+        sample_rate: 5
+      # v5
+    EOT
+  }
+`
+	}
+
+	cfg += "}\n"
+	return cfg
+}
+
+func testAccFleetConfigRollback(name string, contents []string) string {
+	cfg := fmt.Sprintf(`
+resource "newrelic_fleet_configuration" "rollback" {
+  name                = %q
+  agent_type          = "NRInfra"
+  managed_entity_type = "HOST"
+`, name)
+
+	for _, c := range contents {
+		cfg += fmt.Sprintf(`
+  version {
+    configuration_content = %q
+  }
+`, c)
+	}
+
+	cfg += "}\n"
+	return cfg
+}
+
+func testAccFleetConfigKubernetes(name string) string {
+	return fmt.Sprintf(`
+resource "newrelic_fleet_configuration" "k8s" {
+  name                = %q
+  agent_type          = "NRInfra"
+  managed_entity_type = "KUBERNETESCLUSTER"
+
+  version {
+    configuration_content = <<-EOT
+      cluster:
+        enabled: true
+      prometheus:
+        enabled: true
+      # v1
+    EOT
+  }
+}
+`, name)
+}

--- a/newrelic/resource_newrelic_fleet_test.go
+++ b/newrelic/resource_newrelic_fleet_test.go
@@ -147,7 +147,6 @@ func TestAccNewRelicFleet_WithTags(t *testing.T) {
 	})
 }
 
-
 // Error case tests
 
 func TestAccNewRelicFleet_MissingOperatingSystemForHost(t *testing.T) {
@@ -215,7 +214,6 @@ func testAccCheckNewRelicFleetExists(n string) resource.TestCheckFunc {
 		if !ok {
 			return fmt.Errorf("not found: %s", n)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no fleet ID is set")
 		}
@@ -223,13 +221,11 @@ func testAccCheckNewRelicFleetExists(n string) resource.TestCheckFunc {
 		client := testAccProvider.Meta().(*ProviderConfig).NewClient
 		entity, err := client.FleetControl.GetEntity(rs.Primary.ID)
 		if err != nil {
-			return err
+			return fmt.Errorf("error fetching fleet %s: %s", rs.Primary.ID, err)
 		}
-
 		if entity == nil {
-			return fmt.Errorf("fleet not found: %s", rs.Primary.ID)
+			return fmt.Errorf("fleet %s not found", rs.Primary.ID)
 		}
-
 		return nil
 	}
 }

--- a/website/docs/d/fleet_configuration.html.markdown
+++ b/website/docs/d/fleet_configuration.html.markdown
@@ -1,0 +1,122 @@
+---
+layout: "newrelic"
+page_title: "New Relic: newrelic_fleet_configuration"
+sidebar_current: "docs-newrelic-datasource-fleet-configuration"
+description: |-
+  Fetches the content of a New Relic fleet configuration and its version metadata.
+---
+
+# Data Source: newrelic\_fleet\_configuration
+
+Use this data source to fetch the content and version metadata of an existing New Relic fleet configuration. Three mutually exclusive lookup modes are supported: by **configuration GUID**, by **version entity GUID**, or by **name**.
+
+## Example Usage
+
+### Look Up by Configuration GUID
+
+Fetches the content of the **latest** version of the configuration identified by its entity GUID. Also returns the GUIDs of all versions.
+
+```hcl
+data "newrelic_fleet_configuration" "by_id" {
+  configuration_id = "NjQyNTg2NXxOR0VQ..."
+}
+
+output "latest_content" {
+  value = data.newrelic_fleet_configuration.by_id.configuration_content
+}
+
+output "all_version_guids" {
+  value = data.newrelic_fleet_configuration.by_id.version_entity_ids
+}
+```
+
+### Look Up by Version Entity GUID
+
+Fetches the content of a **specific version** identified by its version entity GUID. Also resolves and returns the parent configuration GUID.
+
+```hcl
+data "newrelic_fleet_configuration" "by_version" {
+  version_entity_id = "NjQyNTg2NXxOR0VQfEFHRU5UX0NPTkZJR1VSQVRJT05fVkVSU0lPTnw..."
+}
+
+output "version_content" {
+  value = data.newrelic_fleet_configuration.by_version.configuration_content
+}
+
+output "parent_config_guid" {
+  value = data.newrelic_fleet_configuration.by_version.configuration_id
+}
+```
+
+### Look Up by Name
+
+Fetches the content of the **latest** version of the configuration matching the given name. Also returns the GUIDs of all versions. The first matching configuration is returned if multiple share the same name.
+
+```hcl
+data "newrelic_fleet_configuration" "by_name" {
+  name = "Production Infrastructure Config"
+}
+
+output "latest_content" {
+  value = data.newrelic_fleet_configuration.by_name.configuration_content
+}
+```
+
+### Reference from a Managed Resource
+
+A common pattern is to use this data source alongside a `newrelic_fleet_configuration` resource to read version metadata:
+
+```hcl
+resource "newrelic_fleet_configuration" "infra" {
+  name                = "my-infra-config"
+  agent_type          = "NRInfra"
+  managed_entity_type = "HOST"
+
+  version {
+    configuration_content = file("${path.module}/config.yaml")
+  }
+}
+
+data "newrelic_fleet_configuration" "infra" {
+  configuration_id = newrelic_fleet_configuration.infra.configuration_id
+  depends_on       = [newrelic_fleet_configuration.infra]
+}
+
+output "all_version_guids" {
+  value = data.newrelic_fleet_configuration.infra.version_entity_ids
+}
+```
+
+## Argument Reference
+
+Exactly one of the following lookup inputs must be specified:
+
+* `configuration_id` - (Optional) The entity GUID of the fleet configuration. Returns the content of its **latest** version. This attribute is also populated as an output when looking up by `version_entity_id`.
+* `version_entity_id` - (Optional) The entity GUID of a specific configuration version. Returns the content of that exact version.
+* `name` - (Optional) The name of the fleet configuration. Returns the content of its **latest** version. The first matching configuration is returned if multiple share the same name.
+
+The following optional argument is supported in all modes:
+
+* `organization_id` - (Optional) The organization ID. Resolved automatically from the provider account when omitted.
+
+## Attributes Reference
+
+The following attributes are exported. Availability varies by lookup mode — see the table below.
+
+* `configuration_content` - The raw YAML/JSON content of the resolved version.
+* `configuration_id` - The entity GUID of the fleet configuration.
+* `organization_id` - The organization ID the configuration belongs to.
+* `latest_version_entity_id` - The entity GUID of the latest (highest-numbered) version.
+* `version_entity_ids` - Entity GUIDs of all versions ordered by version number, oldest first.
+
+### Attribute Availability by Lookup Mode
+
+| Attribute | `configuration_id` | `version_entity_id` | `name` |
+|---|---|---|---|
+| `configuration_content` | ✓ (latest version) | ✓ (exact version) | ✓ (latest version) |
+| `configuration_id` | ✓ (input) | ✓ (resolved from API) | ✓ (resolved from API) |
+| `organization_id` | ✓ | ✓ | ✓ |
+| `latest_version_entity_id` | ✓ | — | ✓ |
+| `version_entity_ids` | ✓ | — | ✓ |
+
+-> **NOTE:** `latest_version_entity_id` and `version_entity_ids` are not populated when looking up by `version_entity_id`, because a single version GUID does not carry the full version history of its parent configuration.

--- a/website/docs/r/fleet_configuration.html.markdown
+++ b/website/docs/r/fleet_configuration.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Use this resource to create and manage New Relic fleet configurations for centralized agent management.
 
-A fleet configuration defines versioned agent settings deployable to your fleets. Each configuration is specific to an agent type and managed entity type. Versions are immutable — their content cannot be modified after creation. To add a new configuration, add a `version` block; to remove one, delete its block.
+A fleet configuration defines versioned agent settings deployable to your fleets. Each configuration is specific to an agent type and managed entity type. Versions are immutable - their content cannot be modified after creation. To add a new configuration, add a `version` block; to remove one, delete its block.
 
 ## Example Usage
 
@@ -140,10 +140,10 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Version Immutability
 
-Version content is **immutable** — the API does not support updating the content of an existing version. If you attempt to modify `configuration_content` of an already-applied `version` block, Terraform will catch this at plan time and surface an error before any API call is made:
+Version content is **immutable** - the API does not support updating the content of an existing version. If you attempt to modify `configuration_content` of an already-applied `version` block, Terraform will catch this at plan time and surface an error before any API call is made:
 
 ```
-configuration_content cannot be modified in place — versions are immutable:
+configuration_content cannot be modified in place - versions are immutable:
   - index 0: content was changed (edit detected)
 ```
 
@@ -161,11 +161,11 @@ All `version` blocks within a resource must have distinct `configuration_content
 duplicate configuration_content detected across version blocks
 ```
 
-This also applies to rollback scenarios. If you previously had versions A → B and want to roll back by reintroducing A's content as a new version, add a new `version` block with A's content rather than restoring an old block — the new version will get a new version number from the API.
+This also applies to rollback scenarios. If you previously had versions A → B and want to roll back by reintroducing A's content as a new version, add a new `version` block with A's content rather than restoring an old block - the new version will get a new version number from the API.
 
 ### Version Numbering
 
-Version numbers are assigned sequentially by the API and are never reused or renumbered. When you remove a `version` block, the remaining versions keep their original numbers. For example, if you have versions 1, 2, and 3 and remove version 2, the configuration will have versions 1 and 3 — the API does not compact the sequence.
+Version numbers are assigned sequentially by the API and are never reused or renumbered. When you remove a `version` block, the remaining versions keep their original numbers. For example, if you have versions 1, 2, and 3 and remove version 2, the configuration will have versions 1 and 3 - the API does not compact the sequence.
 
 `latest_version_number` and `latest_version_entity_id` always reflect the highest-numbered version, regardless of how many versions exist.
 
@@ -186,12 +186,6 @@ The warning indicates that Terraform will recreate the missing version on the ne
 
 Fleet configurations can be imported using the configuration entity GUID:
 
-```
-$ terraform import newrelic_fleet_configuration.infra <configuration_guid>
-```
-
-Fleet configurations can be imported using the configuration entity GUID:
-
-```
+```bash
 $ terraform import newrelic_fleet_configuration.infra <configuration_guid>
 ```

--- a/website/docs/r/fleet_configuration.html.markdown
+++ b/website/docs/r/fleet_configuration.html.markdown
@@ -1,0 +1,197 @@
+---
+layout: "newrelic"
+page_title: "New Relic: newrelic_fleet_configuration"
+sidebar_current: "docs-newrelic-resource-fleet-configuration"
+description: |-
+  Create and manage New Relic fleet configurations for centralized agent management.
+---
+
+# Resource: newrelic\_fleet\_configuration
+
+Use this resource to create and manage New Relic fleet configurations for centralized agent management.
+
+A fleet configuration defines versioned agent settings deployable to your fleets. Each configuration is specific to an agent type and managed entity type. Versions are immutable — their content cannot be modified after creation. To add a new configuration, add a `version` block; to remove one, delete its block.
+
+## Example Usage
+
+### Basic Infrastructure Agent Configuration
+
+```hcl
+resource "newrelic_fleet_configuration" "infra" {
+  name                = "Production Infrastructure Config"
+  agent_type          = "NRInfra"
+  managed_entity_type = "HOST"
+
+  version {
+    configuration_content = <<-EOT
+      log:
+        level: info
+        file: /var/log/newrelic-infra/newrelic-infra.log
+      metrics:
+        enabled: true
+        system_sample_rate: 15
+    EOT
+  }
+}
+```
+
+### Loading Configuration from a File
+
+```hcl
+resource "newrelic_fleet_configuration" "infra" {
+  name                = "Production Infrastructure Config"
+  agent_type          = "NRInfra"
+  managed_entity_type = "HOST"
+
+  version {
+    configuration_content = file("${path.module}/configs/infra-v1.yaml")
+  }
+}
+```
+
+### Multiple Versions
+
+Add multiple `version` blocks to maintain several versions of the configuration simultaneously. Each version must have unique content.
+
+```hcl
+resource "newrelic_fleet_configuration" "infra" {
+  name                = "Production Infrastructure Config"
+  agent_type          = "NRInfra"
+  managed_entity_type = "HOST"
+
+  version {
+    configuration_content = file("${path.module}/configs/infra-v1.yaml")
+  }
+
+  version {
+    configuration_content = file("${path.module}/configs/infra-v2.yaml")
+  }
+}
+```
+
+### Kubernetes Configuration
+
+```hcl
+resource "newrelic_fleet_configuration" "k8s" {
+  name                = "Production K8s Config"
+  agent_type          = "NRDOT"
+  managed_entity_type = "KUBERNETESCLUSTER"
+
+  version {
+    configuration_content = file("${path.module}/configs/k8s-config.yaml")
+  }
+}
+```
+
+### Referencing Version Metadata in Outputs
+
+```hcl
+resource "newrelic_fleet_configuration" "infra" {
+  name                = "my-infra-config"
+  agent_type          = "NRInfra"
+  managed_entity_type = "HOST"
+
+  version {
+    configuration_content = file("${path.module}/config.yaml")
+  }
+}
+
+output "latest_version_guid" {
+  value = newrelic_fleet_configuration.infra.latest_version_entity_id
+}
+
+output "latest_version_number" {
+  value = newrelic_fleet_configuration.infra.latest_version_number
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the configuration.
+* `agent_type` - (Required, ForceNew) The type of agent this configuration is for. Valid values: `NRInfra`, `NRDOT`, `FluentBit`, `NRPrometheusAgent`. **Cannot be changed after creation.**
+* `managed_entity_type` - (Required, ForceNew) The type of entities this configuration manages. Valid values: `HOST`, `KUBERNETESCLUSTER`. **Cannot be changed after creation.**
+* `version` - (Required) One or more version blocks. At least one is required. See [Nested `version` blocks](#nested-version-blocks) below.
+* `organization_id` - (Optional, ForceNew) The organization ID. Auto-fetched from the account when not provided. **Cannot be changed after creation.**
+
+### Nested `version` blocks
+
+Each `version` block supports the following argument:
+
+* `configuration_content` - (Required) The YAML or JSON content for this version. Must be unique across all `version` blocks in the resource. Use `file()` to load content from a file: `file("${path.module}/config.yaml")`.
+
+The following attributes are exported from each `version` block:
+
+* `version_number` - The version number assigned by the API (1, 2, 3, …).
+* `version_entity_id` - The entity GUID of this version.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The entity GUID of the configuration (same as `configuration_id`).
+* `configuration_id` - The entity GUID of the configuration.
+* `latest_version_number` - The highest version number across all versions.
+* `latest_version_entity_id` - The entity GUID of the highest-numbered version.
+* `total_versions` - Total number of versions currently in the configuration.
+
+## Working with Versions
+
+### Version Immutability
+
+Version content is **immutable** — the API does not support updating the content of an existing version. If you attempt to modify `configuration_content` of an already-applied `version` block, Terraform will catch this at plan time and surface an error before any API call is made:
+
+```
+configuration_content cannot be modified in place — versions are immutable:
+  - index 0: content was changed (edit detected)
+```
+
+To update the configuration in use:
+- **Add** a new `version` block with the updated content.
+- **Remove** the old `version` block whose content you no longer need.
+
+Terraform applies removals (API deletes) before creates, so if you add and remove a block in the same `apply`, the old version is deleted first and the new one is created after.
+
+### Unique Content Requirement
+
+All `version` blocks within a resource must have distinct `configuration_content` values. Duplicate content is caught at plan time before any changes are applied:
+
+```
+duplicate configuration_content detected across version blocks
+```
+
+This also applies to rollback scenarios. If you previously had versions A → B and want to roll back by reintroducing A's content as a new version, add a new `version` block with A's content rather than restoring an old block — the new version will get a new version number from the API.
+
+### Version Numbering
+
+Version numbers are assigned sequentially by the API and are never reused or renumbered. When you remove a `version` block, the remaining versions keep their original numbers. For example, if you have versions 1, 2, and 3 and remove version 2, the configuration will have versions 1 and 3 — the API does not compact the sequence.
+
+`latest_version_number` and `latest_version_entity_id` always reflect the highest-numbered version, regardless of how many versions exist.
+
+### Externally Deleted Versions
+
+If a version is deleted outside of Terraform (for example, via the API or the New Relic UI), the next `terraform plan` will show a warning for the affected version:
+
+```
+Warning: version entity not found
+  version block at index N (version_entity_id = "...") no longer exists in the API.
+  Remove the block from your configuration if the deletion was intentional,
+  or run terraform apply to recreate it.
+```
+
+The warning indicates that Terraform will recreate the missing version on the next `apply`. If the deletion was intentional, remove the corresponding `version` block from your configuration before applying.
+
+## Import
+
+Fleet configurations can be imported using the configuration entity GUID:
+
+```
+$ terraform import newrelic_fleet_configuration.infra <configuration_guid>
+```
+
+Fleet configurations can be imported using the configuration entity GUID:
+
+```
+$ terraform import newrelic_fleet_configuration.infra <configuration_guid>
+```


### PR DESCRIPTION
## Resource: \`newrelic_fleet_configuration\`

- Implements CRUD for fleet configurations with versioned `version {}` blocks (TypeList)
- Versions are immutable; plan-time guards prevent in-place edits and duplicate content
- Externally deleted versions surface as warnings during `terraform plan`
- Computed outputs: `configuration_id`, `latest_version_number`, `latest_version_entity_id`, `total_versions`
- Integration tests cover create, add/remove versions, rollback, external deletion, and destroy

## Data Source: \`newrelic_fleet_configuration\`

- Three mutually exclusive lookup modes: `configuration_id`, `version_entity_id`, `name`
- Config/name modes return `latest_version_entity_id` and `version_entity_ids` (all versions, sorted)
- Version entity ID mode resolves and returns the parent `configuration_id`
- Name-based search works around entity management API limitation via client-side filtering

## Docs

- New data source doc with per-mode examples and an attribute availability table
- Resource doc rewritten to reflect actual schema, valid `agent_type` values, and version lifecycle behaviour