### PR TITLE
feat(oci): add japan region support

### DIFF
--- a/examples/modules/cloud-integrations/oci/logs-integration/locals.tf
+++ b/examples/modules/cloud-integrations/oci/logs-integration/locals.tf
@@ -36,6 +36,7 @@ locals {
   newrelic_graphql_endpoint = {
     US = "https://api.newrelic.com/graphql"
     EU = "https://api.eu.newrelic.com/graphql"
+    JP = "https://api.jp.newrelic.com/graphql"
   }[var.new_relic_region]
 
   updateLinkAccount_graphql_query = <<EOF

--- a/examples/modules/cloud-integrations/oci/logs-integration/variables.tf
+++ b/examples/modules/cloud-integrations/oci/logs-integration/variables.tf
@@ -67,7 +67,7 @@ variable "debug_enabled" {
 variable "new_relic_region" {
   type        = string
   default     = "US"
-  description = "New Relic Region. US or EU"
+  description = "New Relic Region. US, EU or JP"
 }
 
 variable "secret_ocid" {


### PR DESCRIPTION
# Description

Add japan new relic region support to OCI terraform logs-integration module

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [X] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Step 1
- Step 2
- etc
