### PR TITLE
fix(synthetics): add shared parameter to newrelic_synthetics_private_location resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.30.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.83.4
+	github.com/newrelic/newrelic-client-go/v2 v2.84.0
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,8 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.83.4 h1:CHOti8ElIlh4/q7Bu81cfKstNa5RgzrNVDxew4/J2iQ=
-github.com/newrelic/newrelic-client-go/v2 v2.83.4/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
+github.com/newrelic/newrelic-client-go/v2 v2.84.0 h1:Lz2UoStIecCQrERnrDKKnRRRwc8LwsMgTUxg9slAY1o=
+github.com/newrelic/newrelic-client-go/v2 v2.84.0/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/newrelic/data_source_newrelic_synthetics_private_location_test.go
+++ b/newrelic/data_source_newrelic_synthetics_private_location_test.go
@@ -32,6 +32,7 @@ func TestAccNewRelicSyntheticsPrivateLocationDataSource_Basic(t *testing.T) {
 				"created via TF integration tests",
 				privateLocationName,
 				false,
+				false,
 			)
 
 			if err != nil {

--- a/newrelic/resource_newrelic_synthetics_private_location.go
+++ b/newrelic/resource_newrelic_synthetics_private_location.go
@@ -41,6 +41,12 @@ func resourceNewRelicSyntheticsPrivateLocation() *schema.Resource {
 				ForceNew:    true,
 				Required:    true,
 			},
+			"shared": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Specifies whether the private location is shared across the organization.",
+			},
 			"verified_script_execution": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -79,8 +85,9 @@ func resourceNewRelicSyntheticsPrivateLocationCreate(ctx context.Context, d *sch
 
 	description := d.Get("description").(string)
 	name := d.Get("name").(string)
+	shared := d.Get("shared").(bool)
 	verifiedScriptExecution := d.Get("verified_script_execution").(bool)
-	res, err := client.Synthetics.SyntheticsCreatePrivateLocationWithContext(ctx, accountID, description, name, verifiedScriptExecution)
+	res, err := client.Synthetics.SyntheticsCreatePrivateLocationWithContext(ctx, accountID, description, name, shared, verifiedScriptExecution)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -104,6 +111,7 @@ func resourceNewRelicSyntheticsPrivateLocationCreate(ctx context.Context, d *sch
 	_ = d.Set("key", res.Key)
 	_ = d.Set("location_id", res.LocationId)
 	_ = d.Set("guid", string(res.GUID))
+	_ = d.Set("shared", res.Shared)
 
 	return resourceNewRelicSyntheticsPrivateLocationRead(ctx, d, meta)
 }
@@ -152,9 +160,10 @@ func resourceNewRelicSyntheticsPrivateLocationUpdate(ctx context.Context, d *sch
 
 	description := d.Get("description").(string)
 	guid := synthetics.EntityGUID(d.Id())
+	shared := d.Get("shared").(bool)
 	verifiedScriptExecution := d.Get("verified_script_execution").(bool)
 
-	res, err := client.Synthetics.SyntheticsUpdatePrivateLocationWithContext(ctx, description, guid, verifiedScriptExecution)
+	res, err := client.Synthetics.SyntheticsUpdatePrivateLocationWithContext(ctx, description, guid, shared, verifiedScriptExecution)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -176,6 +185,7 @@ func resourceNewRelicSyntheticsPrivateLocationUpdate(ctx context.Context, d *sch
 	_ = d.Set("key", res.Key)
 	_ = d.Set("location_id", res.LocationId)
 	_ = d.Set("guid", string(res.GUID))
+	_ = d.Set("shared", res.Shared)
 
 	return resourceNewRelicSyntheticsPrivateLocationRead(ctx, d, meta)
 }

--- a/newrelic/resource_newrelic_synthetics_private_location_test.go
+++ b/newrelic/resource_newrelic_synthetics_private_location_test.go
@@ -12,6 +12,26 @@ import (
 	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
 )
 
+func TestAccNewRelicSyntheticsPrivateLocation_Shared(t *testing.T) {
+	resourceName := "newrelic_synthetics_private_location.bar"
+	rName := generateNameForIntegrationTestResource()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// Test: Create with shared=true
+			{
+				Config: testAccNewRelicSyntheticsPrivateLocationConfigShared(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicSyntheticsPrivateLocationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "shared", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccNewRelicSyntheticsPrivateLocation_Basic(t *testing.T) {
 	resourceName := "newrelic_synthetics_private_location.bar"
 	rName := generateNameForIntegrationTestResource()
@@ -39,7 +59,7 @@ func TestAccNewRelicSyntheticsPrivateLocation_Basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"description", "domain_id", "key", "location_id", "verified_script_execution"},
+				ImportStateVerifyIgnore: []string{"description", "domain_id", "key", "location_id", "shared", "verified_script_execution"},
 			},
 		},
 	})
@@ -109,6 +129,17 @@ func testAccNewRelicSyntheticsPrivateLocationConfigUpdated(name string) string {
 	resource "newrelic_synthetics_private_location" "bar" {
 		description               = "Test Description-Updated"
 		name                      = "%[1]s"
+		verified_script_execution = false
+}
+`, name)
+}
+
+func testAccNewRelicSyntheticsPrivateLocationConfigShared(name string) string {
+	return fmt.Sprintf(`
+	resource "newrelic_synthetics_private_location" "bar" {
+		description               = "Test Description"
+		name                      = "%[1]s"
+		shared                    = true
 		verified_script_execution = false
 }
 `, name)

--- a/website/docs/r/synthetics_private_location.html.markdown
+++ b/website/docs/r/synthetics_private_location.html.markdown
@@ -26,6 +26,7 @@ The following arguments are supported:
 * `account_id` - (Optional) The account in which the private location will be created.
 * `description` - (Required) The private location description.
 * `name` - (Required) The name of the private location.
+* `shared` - (Optional) Specifies whether the private location is shared across the organization. Defaults to `false`. **Note:** If a location is shared and used by other accounts in your organization to run synthetic monitors, you cannot unshare this private location until those monitors are disabled.
 * `verified_script_execution` - (Optional) The private location requires a password to edit if value is true. Defaults to `false`
 
 ## Attributes Reference


### PR DESCRIPTION
# Description

Adds the `shared` argument to the `newrelic_synthetics_private_location` resource,                                                                                
  allowing users to specify whether a private location is shared across the organization.                                                                           
  Previously this could only be managed outside of Terraform.    

Fixes # ([3058](https://github.com/newrelic/terraform-provider-newrelic/issues/3058))

## Type of change
 - [x] New feature (non-breaking change which adds functionality)                                                                                                  
 - [x] This change requires a documentation update

## Checklist:
- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)                                                            
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code                                                                                                               
- [x] I have made corresponding changes to the documentation                                                                                                      
- [x] I have added tests that prove my fix is effective or that my feature works                                                                                  
- [x] New and existing unit tests pass locally with my changes.            

## How to test this change?

1. Configure the provider with a valid New Relic account and API key.                                                                                             
  
2. Apply a config with `shared = true` and verify the location is created as shared:                                                                              
                  
  ```hcl                                                                                                                                                         
  resource "newrelic_synthetics_private_location" "shared" {
    name        = "Test Shared Location"                                                                                                                         
    description = "shared=true test"                                                                                                                             
    shared      = true                                                                                                                                           
  }                                                                                                                                                              
 ```
                                                                                                                                                                
3. Apply a config with shared = false (or omitting shared, which defaults to false)                                                                               
  and verify the location is created as non-shared:

  ```hcl                                                                                                                                                      
  resource "newrelic_synthetics_private_location" "private" {                                                                                                       
    name        = "Test Private Location"                                                                                                                           
    description = "shared=false test"                                                                                                                               
    shared      = false                                                                                                                                             
  }
```

4. Update the shared value on an existing resource and confirm terraform apply                                                                                    
  updates the location without destroying and recreating it.                                                                                                        
                                                                                                                                                                    
## Notes                                                                                                                                                             
This PR depends on a [corresponding change](https://github.com/newrelic/newrelic-client-go/pull/1406) to  newrelic-client-go to expose  the shared parameter in the NerdGraph mutation functions.
