### PR TITLE
fix(deps): bump newrelic-client-go to v2.83.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.30.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.83.3
+	github.com/newrelic/newrelic-client-go/v2 v2.83.4
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,8 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.83.3 h1:K7ZICbj40uBSjwf8L2XpqBlYV9oqb95jV9HxWWC6Wfs=
-github.com/newrelic/newrelic-client-go/v2 v2.83.3/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
+github.com/newrelic/newrelic-client-go/v2 v2.83.4 h1:CHOti8ElIlh4/q7Bu81cfKstNa5RgzrNVDxew4/J2iQ=
+github.com/newrelic/newrelic-client-go/v2 v2.83.4/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=


### PR DESCRIPTION
Bumps `github.com/newrelic/newrelic-client-go/v2` from v2.83.3 to v2.83.4. This picks up the fix for `EntityAlertViolationInt` being typed as `int` (32-bit on 32-bit platforms) instead of `int64`, which caused `json.Unmarshal` to crash with an overflow error when the Alerts backend returned 16-digit violation IDs in `recentAlertViolations`. The crash surfaced during `terraform plan`/`apply` state refresh for any resource that fetches entity data (e.g. `newrelic_synthetics_monitor`) on 32-bit Terraform binaries (windows_386).

This is a dependency-only change — no provider logic is modified. `go build` and `go vet` both pass cleanly.

Fixes: NR-561784
