### PR TITLE
feat(alerts): add entity_guid computed attribute to compound condition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.30.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.84.0
+	github.com/newrelic/newrelic-client-go/v2 v2.84.1-0.20260519215331-99335df83022
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.30.0
 	github.com/newrelic/go-insights v1.0.3
-	github.com/newrelic/newrelic-client-go/v2 v2.84.1-0.20260519215331-99335df83022
+	github.com/newrelic/newrelic-client-go/v2 v2.85.0
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,8 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.84.1-0.20260519215331-99335df83022 h1:E64ewQjYd+Lobd/s/U5hyQPwNpVWlui80EYYMuWvC/U=
-github.com/newrelic/newrelic-client-go/v2 v2.84.1-0.20260519215331-99335df83022/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
+github.com/newrelic/newrelic-client-go/v2 v2.85.0 h1:j30OuVuergzjBnljDnBlwpJuqEd8qdHJ2YCHMBEL3iI=
+github.com/newrelic/newrelic-client-go/v2 v2.85.0/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,8 @@ github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
 github.com/newrelic/go-insights v1.0.3 h1:zSNp1CEZnXktzSIEsbHJk8v6ZihdPFP2WsO/fzau3OQ=
 github.com/newrelic/go-insights v1.0.3/go.mod h1:A20BoT8TNkqPGX2nS/Z2fYmKl3Cqa3iKZd4whzedCY4=
-github.com/newrelic/newrelic-client-go/v2 v2.84.0 h1:Lz2UoStIecCQrERnrDKKnRRRwc8LwsMgTUxg9slAY1o=
-github.com/newrelic/newrelic-client-go/v2 v2.84.0/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
+github.com/newrelic/newrelic-client-go/v2 v2.84.1-0.20260519215331-99335df83022 h1:E64ewQjYd+Lobd/s/U5hyQPwNpVWlui80EYYMuWvC/U=
+github.com/newrelic/newrelic-client-go/v2 v2.84.1-0.20260519215331-99335df83022/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/newrelic/resource_newrelic_alert_compound_condition.go
+++ b/newrelic/resource_newrelic_alert_compound_condition.go
@@ -92,6 +92,11 @@ func resourceNewRelicAlertCompoundCondition() *schema.Resource {
 				Computed:    true,
 				Description: "The duration, in seconds, that the trigger expression must be true before the compound alert condition will activate. Between 30-86400 seconds.",
 			},
+			"entity_guid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The unique entity identifier of the compound alert condition in New Relic.",
+			},
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Second),

--- a/newrelic/resource_newrelic_alert_compound_condition_test.go
+++ b/newrelic/resource_newrelic_alert_compound_condition_test.go
@@ -34,6 +34,7 @@ func TestAccNewRelicAlertCompoundCondition_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "facet_matching_behavior", "FACETS_IGNORED"),
 					resource.TestCheckResourceAttr(resourceName, "runbook_url", "https://example.com/runbook"),
 					resource.TestCheckResourceAttr(resourceName, "threshold_duration", "120"),
+					resource.TestCheckResourceAttrSet(resourceName, "entity_guid"),
 				),
 			},
 			// Test: Update to OR expression

--- a/newrelic/resource_newrelic_alert_compound_condition_test.go
+++ b/newrelic/resource_newrelic_alert_compound_condition_test.go
@@ -70,6 +70,7 @@ func TestAccNewRelicAlertCompoundCondition_ThreeComponents(t *testing.T) {
 					testAccCheckNewRelicAlertCompoundConditionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "trigger_expression", "(A AND B) OR C"),
 					resource.TestCheckResourceAttr(resourceName, "component_conditions.#", "3"),
+					resource.TestCheckResourceAttrSet(resourceName, "entity_guid"),
 				),
 			},
 		},
@@ -90,6 +91,7 @@ func TestAccNewRelicAlertCompoundCondition_FacetMatching(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicAlertCompoundConditionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "facet_matching_behavior", "FACETS_MATCH"),
+					resource.TestCheckResourceAttrSet(resourceName, "entity_guid"),
 				),
 			},
 		},

--- a/newrelic/structures_newrelic_alert_compound_condition.go
+++ b/newrelic/structures_newrelic_alert_compound_condition.go
@@ -123,6 +123,7 @@ func flattenAlertCompoundCondition(accountID int, condition *alerts.CompoundCond
 	_ = d.Set("facet_matching_behavior", condition.FacetMatchingBehavior)
 	_ = d.Set("runbook_url", condition.RunbookURL)
 	_ = d.Set("threshold_duration", condition.ThresholdDuration)
+	_ = d.Set("entity_guid", condition.EntityGuid)
 
 	// Flatten component conditions - ONLY id and alias (per user requirement)
 	componentConditions := flattenComponentConditions(condition.ComponentConditions)

--- a/newrelic/structures_newrelic_alert_compound_condition_test.go
+++ b/newrelic/structures_newrelic_alert_compound_condition_test.go
@@ -147,6 +147,7 @@ func TestFlattenAlertCompoundCondition(t *testing.T) {
 		RunbookURL:            "https://example.com/runbook",
 		ThresholdDuration:     120,
 		FacetMatchingBehavior: "FACETS_IGNORED",
+		EntityGuid:            "MTAxMzMyMDB8QUxFUlR8Q09ORGU5OfDEwMzQ1NTc",
 		ComponentConditions: []alerts.ComponentCondition{
 			{
 				ID:    "123",
@@ -175,4 +176,5 @@ func TestFlattenAlertCompoundCondition(t *testing.T) {
 	assert.Equal(t, 120, d.Get("threshold_duration"))
 	assert.Equal(t, "FACETS_IGNORED", d.Get("facet_matching_behavior"))
 	assert.Equal(t, testAccountID, d.Get("account_id"))
+	assert.Equal(t, "MTAxMzMyMDB8QUxFUlR8Q09ORGU5OfDEwMzQ1NTc", d.Get("entity_guid"))
 }

--- a/website/docs/r/alert_compound_condition.html.markdown
+++ b/website/docs/r/alert_compound_condition.html.markdown
@@ -252,6 +252,7 @@ The `component_conditions` block supports the following arguments:
 In addition to all arguments above, the following attributes are exported:
 
 - `id` - The ID of the compound alert condition.
+- `entity_guid` - The unique entity identifier of the compound alert condition in New Relic.
 
 ## Import
 


### PR DESCRIPTION
Note: go.mod will be updated to the new newrelic-client-go version once the Go client PR is merged and released.

# Description

Adds entity_guid as a read-only (Computed) attribute to the newrelic_alert_compound_condition resource. This field is populated from the API response and cannot be set by users.

- Added entity_guid Computed schema attribute to resource
- Added entity_guid to flattenAlertCompoundCondition
- Updated unit test to assert entity_guid is correctly flattened
- Updated documentation with entity_guid in Attributes Reference

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Step 1
- Step 2
- etc
