### PR TITLE
feat(workloads): add intelligent workload support with dynamic_flows and status_config_alert_policy

### DIFF
--- a/newrelic/resource_newrelic_workload.go
+++ b/newrelic/resource_newrelic_workload.go
@@ -45,14 +45,14 @@ func resourceNewRelicWorkload() *schema.Resource {
 				Optional:     true,
 				Computed:     true,
 				Description:  "A list of entity GUIDs manually assigned to this workload.",
-				AtLeastOneOf: []string{"entity_guids", "entity_search_query"},
+				AtLeastOneOf: []string{"entity_guids", "entity_search_query", "dynamic_flows"},
 				Elem:         &schema.Schema{Type: schema.TypeString},
 			},
 			"entity_search_query": {
 				Type:         schema.TypeSet,
 				Optional:     true,
 				Description:  "A list of search queries that define a dynamic workload.",
-				AtLeastOneOf: []string{"entity_guids", "entity_search_query"},
+				AtLeastOneOf: []string{"entity_guids", "entity_search_query", "dynamic_flows"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"query": {
@@ -64,6 +64,26 @@ func resourceNewRelicWorkload() *schema.Resource {
 								validation.StringIsNotWhiteSpace,
 								validation.NoZeroValues,
 							),
+						},
+					},
+				},
+			},
+			"dynamic_flows": {
+				Type:         schema.TypeSet,
+				Optional:     true,
+				Description:  "A list of dynamic flow entries that define an intelligent workload. If it is set alongside entity_guids or entity_search_query, dynamic_flows takes precedence and an intelligent workload is created.",
+				AtLeastOneOf: []string{"entity_guids", "entity_search_query", "dynamic_flows"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"entity_guid": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The unique entity identifier of the dynamic flow entry.",
+						},
+						"transaction_name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The transaction name associated with the dynamic flow entry.",
 						},
 					},
 				},
@@ -176,6 +196,22 @@ func resourceNewRelicWorkload() *schema.Resource {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "A short description of the status of the workload.",
+						},
+					},
+				},
+			},
+			"status_config_alert_policy": {
+				Type:         schema.TypeSet,
+				Optional:     true,
+				MaxItems:     1,
+				Description:  "An alert policy status configuration for intelligent workloads. Requires dynamic_flows to be set.",
+				RequiredWith: []string{"dynamic_flows"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:        schema.TypeBool,
+							Required:    true,
+							Description: "Whether the alert policy status configuration is enabled or not.",
 						},
 					},
 				},

--- a/newrelic/resource_newrelic_workload_test.go
+++ b/newrelic/resource_newrelic_workload_test.go
@@ -846,3 +846,88 @@ resource "newrelic_workload" "foo" {
 }
 `, testAccountID, name, testAccExpectedApplicationName)
 }
+
+func TestAccNewRelicWorkload_IntelligentWorkload(t *testing.T) {
+	resourceName := "newrelic_workload.foo"
+	rName := generateNameForIntegrationTestResource()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicWorkloadDestroy,
+		Steps: []resource.TestStep{
+			// Test: Create intelligent workload with dynamic_flows and status_config_alert_policy
+			{
+				Config: testAccNewRelicWorkloadIntelligentConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicWorkloadExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "dynamic_flows.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "status_config_alert_policy.#", "1"),
+				),
+			},
+			// Test: Update intelligent workload (change transaction_name, disable alert_policy)
+			{
+				Config: testAccNewRelicWorkloadIntelligentConfigUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicWorkloadExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"-updated"),
+					resource.TestCheckResourceAttr(resourceName, "dynamic_flows.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "status_config_alert_policy.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNewRelicWorkloadIntelligentConfig(name string) string {
+	return fmt.Sprintf(`
+data "newrelic_entity" "app" {
+	name   = "%[3]s"
+	domain = "APM"
+	type   = "APPLICATION"
+}
+
+resource "newrelic_workload" "foo" {
+	name       = "%[2]s"
+	account_id = %[1]d
+
+	dynamic_flows {
+		entity_guid      = data.newrelic_entity.app.guid
+		transaction_name = "WebTransaction/Action/index"
+	}
+
+	scope_account_ids = [%[1]d]
+
+	status_config_alert_policy {
+		enabled = true
+	}
+}
+`, testAccountID, name, testAccExpectedApplicationName)
+}
+
+func testAccNewRelicWorkloadIntelligentConfigUpdated(name string) string {
+	return fmt.Sprintf(`
+data "newrelic_entity" "app" {
+	name   = "%[3]s"
+	domain = "APM"
+	type   = "APPLICATION"
+}
+
+resource "newrelic_workload" "foo" {
+	name       = "%[2]s-updated"
+	account_id = %[1]d
+
+	dynamic_flows {
+		entity_guid      = data.newrelic_entity.app.guid
+		transaction_name = "WebTransaction/Action/show"
+	}
+
+	scope_account_ids = [%[1]d]
+
+	status_config_alert_policy {
+		enabled = false
+	}
+}
+`, testAccountID, name, testAccExpectedApplicationName)
+}

--- a/newrelic/structures_newrelic_workload.go
+++ b/newrelic/structures_newrelic_workload.go
@@ -36,6 +36,14 @@ func expandWorkloadCreateInput(d *schema.ResourceData) workloads.WorkloadCreateI
 		createInput.StatusConfig.Automatic = expandWorkloadStatusConfigAutomaticInput(e.(*schema.Set).List())
 	}
 
+	if e, ok := d.GetOk("dynamic_flows"); ok {
+		createInput.DynamicFlows = expandWorkloadDynamicFlowInputs(e.(*schema.Set).List())
+	}
+
+	if e, ok := d.GetOk("status_config_alert_policy"); ok {
+		createInput.StatusConfig.AlertPolicy = expandWorkloadAlertPolicyInput(e.(*schema.Set).List())
+	}
+
 	return createInput
 }
 
@@ -68,6 +76,14 @@ func expandWorkloadUpdateInput(d *schema.ResourceData) workloads.WorkloadUpdateI
 
 	if e, ok := d.GetOk("status_config_automatic"); ok {
 		updateInput.StatusConfig.Automatic = expandWorkloadStatusConfigUpdateAutomaticInput(e.(*schema.Set).List())
+	}
+
+	if e, ok := d.GetOk("dynamic_flows"); ok {
+		updateInput.DynamicFlows = expandWorkloadUpdateDynamicFlowInputs(e.(*schema.Set).List())
+	}
+
+	if e, ok := d.GetOk("status_config_alert_policy"); ok {
+		updateInput.StatusConfig.AlertPolicy = expandWorkloadUpdateAlertPolicyInput(e.(*schema.Set).List())
 	}
 
 	return updateInput
@@ -402,6 +418,18 @@ func flattenWorkload(workload *workloads.WorkloadCollection, d *schema.ResourceD
 		}
 	}
 
+	if len(workload.DynamicFlows) > 0 {
+		if err := d.Set("dynamic_flows", flattenWorkloadDynamicFlows(workload.DynamicFlows)); err != nil {
+			return err
+		}
+	}
+
+	if v, ok := d.GetOk("status_config_alert_policy"); (ok && v.(*schema.Set).Len() > 0) || workload.StatusConfig.AlertPolicy.Enabled {
+		if err := d.Set("status_config_alert_policy", flattenWorkloadAlertPolicy(workload.StatusConfig.AlertPolicy)); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -442,4 +470,79 @@ func flattenWorkloadEntitySearchQueries(in []workloads.WorkloadEntitySearchQuery
 		out[i] = m
 	}
 	return out
+}
+
+// expandWorkloadDynamicFlowInputs converts Terraform schema list to WorkloadDynamicFlowInput slice for create.
+func expandWorkloadDynamicFlowInputs(cfg []interface{}) []workloads.WorkloadDynamicFlowInput {
+	if len(cfg) == 0 {
+		return []workloads.WorkloadDynamicFlowInput{}
+	}
+
+	out := make([]workloads.WorkloadDynamicFlowInput, len(cfg))
+	for i, raw := range cfg {
+		m := raw.(map[string]interface{})
+		out[i] = workloads.WorkloadDynamicFlowInput{
+			EntityGUID:      common.EntityGUID(m["entity_guid"].(string)),
+			TransactionName: m["transaction_name"].(string),
+		}
+	}
+	return out
+}
+
+// expandWorkloadUpdateDynamicFlowInputs converts Terraform schema list to WorkloadUpdateDynamicFlowInput slice for update.
+func expandWorkloadUpdateDynamicFlowInputs(cfg []interface{}) []workloads.WorkloadUpdateDynamicFlowInput {
+	if len(cfg) == 0 {
+		return []workloads.WorkloadUpdateDynamicFlowInput{}
+	}
+
+	out := make([]workloads.WorkloadUpdateDynamicFlowInput, len(cfg))
+	for i, raw := range cfg {
+		m := raw.(map[string]interface{})
+		out[i] = workloads.WorkloadUpdateDynamicFlowInput{
+			EntityGUID:      common.EntityGUID(m["entity_guid"].(string)),
+			TransactionName: m["transaction_name"].(string),
+		}
+	}
+	return out
+}
+
+// flattenWorkloadDynamicFlows converts a WorkloadDynamicFlow slice to Terraform schema list.
+func flattenWorkloadDynamicFlows(in []workloads.WorkloadDynamicFlow) []interface{} {
+	out := make([]interface{}, len(in))
+	for i, e := range in {
+		m := make(map[string]interface{})
+		m["entity_guid"] = string(e.EntityGUID)
+		m["transaction_name"] = e.TransactionName
+		out[i] = m
+	}
+	return out
+}
+
+// expandWorkloadAlertPolicyInput converts Terraform schema set to WorkloadAlertPolicyInput for create.
+func expandWorkloadAlertPolicyInput(cfg []interface{}) *workloads.WorkloadAlertPolicyInput {
+	if len(cfg) == 0 {
+		return nil
+	}
+	m := cfg[0].(map[string]interface{})
+	return &workloads.WorkloadAlertPolicyInput{
+		Enabled: m["enabled"].(bool),
+	}
+}
+
+// expandWorkloadUpdateAlertPolicyInput converts Terraform schema set to WorkloadUpdateAlertPolicyInput for update.
+func expandWorkloadUpdateAlertPolicyInput(cfg []interface{}) *workloads.WorkloadUpdateAlertPolicyInput {
+	if len(cfg) == 0 {
+		return nil
+	}
+	m := cfg[0].(map[string]interface{})
+	return &workloads.WorkloadUpdateAlertPolicyInput{
+		Enabled: m["enabled"].(bool),
+	}
+}
+
+// flattenWorkloadAlertPolicy converts a WorkloadAlertPolicy to Terraform schema list.
+func flattenWorkloadAlertPolicy(in workloads.WorkloadAlertPolicy) []interface{} {
+	m := make(map[string]interface{})
+	m["enabled"] = in.Enabled
+	return []interface{}{m}
 }

--- a/website/docs/r/workload.html.markdown
+++ b/website/docs/r/workload.html.markdown
@@ -3,71 +3,63 @@ layout: "newrelic"
 page_title: "New Relic: newrelic_workload"
 sidebar_current: "docs-newrelic-resource-workload"
 description: |-
-  Create and manage a New Relic One workload.
+  Create and manage New Relic One workloads. Supports standard workloads (entity GUIDs and search queries) and intelligent workloads powered by Transaction 360 auto-discovery via dynamic flows.
 ---
 
 # Resource: newrelic\_workload
 
 Use this resource to create, update, and delete a New Relic One workload.
 
-A New Relic User API key is required to provision this resource.  Set the `api_key`
+Workloads let you group related entities — services, hosts, databases, browser apps, and more — into a single operational view to monitor health and triage incidents across a business domain.
+
+This resource supports two workload modes:
+
+- **Standard workload** — define membership using entity GUIDs (`entity_guids`) and/or dynamic search queries (`entity_search_query`). Membership updates automatically as query results change. Cannot be used together with `dynamic_flows`.
+- **Intelligent workload** *(Public Preview)* — use `dynamic_flows` to anchor the workload to a transaction entry point. If it is set alongside `entity_guids` or `entity_search_query`, `dynamic_flows` takes precedence and an intelligent workload is created. New Relic auto-discovers and refreshes related entities every five minutes using Transaction 360 distributed tracing data. Supports `status_config_alert_policy` in addition to the standard `status_config_automatic` and `status_config_static` options.
+
+A New Relic User API key is required to provision this resource. Set the `api_key`
 attribute in the `provider` block or the `NEW_RELIC_API_KEY` environment
 variable with your User API key.
 
 ## Example Usage
 
+**Standard Workload**
+
 Include entities with a certain string on the name.
 ```hcl
 resource "newrelic_workload" "foo" {
-	name = "Example workload"
-	account_id = 12345678
+  name       = "Example workload"
+  account_id = 12345678
 
-	entity_guids = ["MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1"]
+  entity_guids = ["MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1"]
 
-	entity_search_query {
-		query = "name like '%Example application%'"
-	}
+  entity_search_query {
+    query = "name like '%Example application%'"
+  }
 
-	scope_account_ids =  [12345678]
+  scope_account_ids = [12345678]
 }
 ```
 
 Include entities with a set of tags.
 ```hcl
 resource "newrelic_workload" "foo" {
-	name = "Example workload with tags"
-	account_id = 12345678
+  name       = "Example workload with tags"
+  account_id = 12345678
 
-	entity_guids = ["MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1"]
+  entity_guids = ["MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1"]
 
-	entity_search_query {
-		query = "tags.accountId = '12345678' AND tags.environment='production' AND tags.language='java'"
-	}
+  entity_search_query {
+    query = "tags.accountId = '12345678' AND tags.environment='production' AND tags.language='java'"
+  }
 
-	scope_account_ids =  [12345678]
-}
-```
-
-Include entities with a set of tags.
-```hcl
-resource "newrelic_workload" "foo" {
-	name = "Example workload with tags"
-	account_id = 12345678
-
-	entity_guids = ["MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1"]
-
-	entity_search_query {
-		query = "tags.accountId = '12345678' AND tags.environment='production' AND tags.language='java'"
-	}
-
-	scope_account_ids =  [12345678]
+  scope_account_ids = [12345678]
 }
 ```
 
 Include automatic status
 
 -> The global status of your workload is a quick indicator of the workload health. You can configure it to be calculated automatically, and you can also set an alert and get a notification whenever the workload stops being operational. Alternatively, you can communicate a certain status of the workload by setting up a static value and a description. [See our docs](https://docs.newrelic.com/docs/workloads/use-workloads/workloads/workload-status)
-
 
 ```hcl
 resource "newrelic_workload" "foo" {
@@ -137,18 +129,67 @@ resource "newrelic_workload" "foo" {
 }
 ```
 
+**Intelligent Workload**
+
+-> An intelligent workload uses `dynamic_flows` to anchor the workload to a transaction entry point. New Relic automatically discovers and refreshes the related entities using Transaction 360 distributed tracing data — no manual entity selection required. If it is set alongside `entity_guids` or `entity_search_query`, `dynamic_flows` takes precedence and an intelligent workload is created. The `status_config_alert_policy` block derives workload health from the alert state of its entities and requires `dynamic_flows` to be set; `status_config_automatic` and `status_config_static` remain available. [See our docs](https://docs.newrelic.com/docs/new-relic-solutions/new-relic-one/workloads/workloads-overview/#intelligent-workloads)
+
+```hcl
+resource "newrelic_workload" "intelligent" {
+  name       = "Example intelligent workload"
+  account_id = 12345678
+
+  # Intelligent workloads use dynamic_flows to define the transaction entry point.
+  # New Relic auto-discovers all related entities via distributed tracing (Transaction 360).
+  # If it is set alongside entity_guids or entity_search_query, dynamic_flows takes precedence.
+  dynamic_flows {
+    entity_guid      = "MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM3Nzk1"
+    transaction_name = "WebTransaction/Action/index"
+  }
+
+  scope_account_ids = [12345678]
+
+  # status_config_alert_policy is exclusive to intelligent workloads.
+  # It rolls up workload health from the alert states of all discovered entities.
+  status_config_alert_policy {
+    enabled = true
+  }
+
+  # status_config_automatic and status_config_static are also supported on intelligent workloads.
+  # Uncomment one of the blocks below if you prefer rule-based or manual status control.
+
+  # status_config_automatic {
+  #   enabled = true
+  # }
+
+  # status_config_static {
+  #   enabled = true
+  #   status  = "OPERATIONAL"
+  #   summary = "All systems operational"
+  # }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
   * `name` - (Required) The workload's name.
   * `account_id` - (Required) The New Relic account ID where you want to create the workload.
-  * `entity_guids` - (Optional) A list of entity GUIDs manually assigned to this workload. At least one of either `entity_guids` or `entity_search_query` is required.
-  * `entity_search_query` - (Optional) A list of search queries that define a dynamic workload. At least one of either `entity_guids` or `entity_search_query` is required. See [Nested entity_search_query blocks](#nested-entity_search_query-blocks) below for details.
+  * `entity_guids` - (Optional) A list of entity GUIDs manually assigned to this workload. At least one of `entity_guids`, `entity_search_query`, or `dynamic_flows` must be specified.
+  * `entity_search_query` - (Optional) A list of search queries that define a dynamic workload. At least one of `entity_guids`, `entity_search_query`, or `dynamic_flows` must be specified. See [Nested entity_search_query blocks](#nested-entity_search_query-blocks) below for details.
+  * `dynamic_flows` - (Optional) A list of dynamic flow entries that define an **intelligent workload**. If it is set alongside `entity_guids` or `entity_search_query`, `dynamic_flows` takes precedence and an intelligent workload is created. At least one of `entity_guids`, `entity_search_query`, or `dynamic_flows` must be specified. See [Nested dynamic_flows blocks](#nested-dynamic_flows-blocks) below for details.
   * `scope_account_ids` - (Optional) A list of account IDs that will be used to get entities from.
   * `description` - (Optional) Relevant information about the workload.
-  * `status_config_automatic` - (Optional) An input object used to represent an automatic status configuration.See [Nested status_config_automatic blocks](#nested-status_config_automatic-blocks) below for details.
-  * `status_config_static` - (Optional) A list of static status configurations. You can only configure one static status for a workload.See [Nested status_config_static blocks](#nested-status_config_static-blocks) below for details.
+  * `status_config_automatic` - (Optional) An input object used to represent an automatic status configuration. See [Nested status_config_automatic blocks](#nested-status_config_automatic-blocks) below for details.
+  * `status_config_static` - (Optional) A list of static status configurations. You can only configure one static status for a workload. See [Nested status_config_static blocks](#nested-status_config_static-blocks) below for details.
+  * `status_config_alert_policy` - (Optional) An alert policy status configuration for intelligent workloads. Requires `dynamic_flows` to be set. See [Nested status_config_alert_policy blocks](#nested-status_config_alert_policy-blocks) below for details.
+
+### Nested `dynamic_flows` blocks
+
+All nested `dynamic_flows` blocks support the following arguments:
+
+  * `entity_guid` - (Required) The unique entity identifier of the dynamic flow entry.
+  * `transaction_name` - (Required) The transaction name associated with the dynamic flow entry.
 
 ### Nested `entity_search_query` blocks
 
@@ -163,12 +204,16 @@ All nested `entity_search_query` blocks support the following common arguments:
   * `rule` - (Optional) The input object used to represent a rollup strategy. See [Nested rule blocks](#nested-rule-blocks) below for details.
 
 ### Nested `status_config_static` blocks
-  
+
   * `description` - (Optional) A description that provides additional details about the status of the workload.
   * `enabled` - (Required) Whether the static status configuration is enabled or not.
   * `status` - (Required) The status of the workload.
   * `summary` - (Optional) A short description of the status of the workload.
 
+
+### Nested `status_config_alert_policy` blocks
+
+  * `enabled` - (Required) Whether the alert policy status configuration is enabled or not.
 
 ### Nested `remaining_entities_rule` blocks
 


### PR DESCRIPTION
# Description

Adds support for intelligent workloads to the newrelic_workload resource. Intelligent workloads use dynamic_flows to anchor the workload to a transaction entry point — New Relic auto-discovers and refreshes related entities every five minutes using Transaction 360 distributed tracing data. If dynamic_flows is set alongside entity_guids or entity_search_query, dynamic_flows takes precedence, others will be ignored, and an intelligent workload is created.

This PR also adds status_config_alert_policy, which derives workload health from the alert state of all discovered entities and is exclusive to intelligent workloads (requires dynamic_flows to be set).

Depends on: [newrelic/newrelic-client-go#1408](https://github.com/newrelic/newrelic-client-go/pull/1408)

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [ ] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Create an intelligent workload:

  ```
resource "newrelic_workload" "intelligent" {
    name       = "my-intelligent-workload"
    account_id = <your_account_id>

    dynamic_flows {
      entity_guid      = "<apm_application_entity_guid>"
      transaction_name = "WebTransaction/Action/index"
    }

    scope_account_ids = [<your_account_id>]

    status_config_alert_policy {
      enabled = true
    }
  } 
```

  - Step 1: Configure the provider with a valid NEW_RELIC_API_KEY and NEW_RELIC_ACCOUNT_ID
  - Step 2: Replace entity_guid with a valid APM application entity GUID from your account
  - Step 3: Run terraform plan — verify no errors and the plan shows creation of 1 resource
  - Step 4: Run terraform apply — verify the intelligent workload appears in the New Relic UI under **All Entities → Workloads**
  - Step 5: Update transaction_name or set status_config_alert_policy { enabled = false } and run terraform apply again — verify the workload updates correctly with no diff after apply
  - Step 6: Run terraform destroy — verify the workload is removed from the UI

  **Verify standard workload is unaffected:**

  - Step 7: Apply an existing standard workload config using entity_guids or entity_search_query — verify it still creates and updates correctly without requiring dynamic_flows