### PR TITLE
chore(federated-logs): suspend federated logs and aws_connection tests

### DIFF
--- a/newrelic/resource_newrelic_aws_connection_test.go
+++ b/newrelic/resource_newrelic_aws_connection_test.go
@@ -1,4 +1,4 @@
-//go:build integration || LOGGING_INTEGRATIONS
+//go:build TEMPORARILY_SUSPENDED
 
 package newrelic
 

--- a/newrelic/resource_newrelic_federated_logs_partition_test.go
+++ b/newrelic/resource_newrelic_federated_logs_partition_test.go
@@ -1,4 +1,4 @@
-//go:build LOGGING_INTEGRATIONS
+//go:build TEMPORARILY_SUSPENDED
 
 // NOTE: Removed the "integration" tag so these tests no longer run under
 // the standard `make test-integration-all` (-tags=integration) CI job.

--- a/newrelic/resource_newrelic_federated_logs_setup_test.go
+++ b/newrelic/resource_newrelic_federated_logs_setup_test.go
@@ -1,4 +1,4 @@
-//go:build LOGGING_INTEGRATIONS
+//go:build TEMPORARILY_SUSPENDED
 
 // NOTE: Removed the "integration" tag so these tests no longer run under
 // the standard `make test-integration-all` (-tags=integration) CI job.

--- a/newrelic/structures_newrelic_federated_logs_test.go
+++ b/newrelic/structures_newrelic_federated_logs_test.go
@@ -1,5 +1,5 @@
-//go:build unit_fedlogs_skip
-// +build unit_fedlogs_skip
+//go:build TEMPORARILY_SUSPENDED
+// +build TEMPORARILY_SUSPENDED
 
 // NOTE: These unit tests are temporarily disabled. The federated-logs flow
 // in newrelic-client-go is gated behind an account entitlement that the


### PR DESCRIPTION
## Summary

- Replaces the build constraint on every test file introduced by #3088 with a single `//go:build TEMPORARILY_SUSPENDED` tag, so they are excluded from `integration`, `unit`, and `LOGGING_INTEGRATIONS` runs alike — covering the gaps left by #3106.
- Affects four files: `resource_newrelic_aws_connection_test.go` (was `integration || LOGGING_INTEGRATIONS`, fully live until now), `resource_newrelic_federated_logs_partition_test.go` and `resource_newrelic_federated_logs_setup_test.go` (were `LOGGING_INTEGRATIONS`, still firing whenever the tag-mapper picked them up), and `structures_newrelic_federated_logs_test.go` (renames the prior `unit_fedlogs_skip` to the same shared tag for consistency).
- `TEMPORARILY_SUSPENDED` is intentionally NOT registered as a product mapping in `integration_test_utilities` — it's a parking tag, not a CI capability. Reactivation is a single-line change per file.
- No production code touched; YAML mappings unchanged.

## Test plan

- [ ] `go test -c -tags=integration -o /dev/null ./newrelic/` compiles
- [ ] `go test -c -tags=unit -o /dev/null ./newrelic/` compiles
- [ ] `go test -c -tags=LOGGING_INTEGRATIONS -o /dev/null ./newrelic/` compiles
- [ ] CI's `test-integration` and `test-unit` jobs both go green without running any of the four suspended files