### PR TITLE
fix(dashboard): make variable nrql_query account_ids optional without drift

### DIFF
--- a/newrelic/resource_newrelic_one_dashboard.go
+++ b/newrelic/resource_newrelic_one_dashboard.go
@@ -150,7 +150,7 @@ func dashboardVariableSchemaElem() *schema.Resource {
 						"account_ids": {
 							Type:        schema.TypeList,
 							Optional:    true,
-							Description: "New Relic account ID(s) to issue the query against.",
+							Description: "New Relic account ID(s) to issue the query against. Defaults to the account ID specified in the provider configuration.",
 							Elem: &schema.Schema{
 								Type: schema.TypeInt,
 							},
@@ -934,7 +934,7 @@ func resourceNewRelicOneDashboardCreate(ctx context.Context, d *schema.ResourceD
 			return diag.FromErr(err)
 		}
 
-		return diag.FromErr(flattenDashboardUpdateResult(result, d))
+		return diag.FromErr(flattenDashboardUpdateResult(result, d, meta.(*ProviderConfig).AccountID))
 
 	}
 
@@ -959,7 +959,7 @@ func resourceNewRelicOneDashboardRead(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	return diag.FromErr(flattenDashboardEntity(dashboard, d))
+	return diag.FromErr(flattenDashboardEntity(dashboard, d, providerConfig.AccountID))
 }
 
 func resourceNewRelicOneDashboardUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -1030,7 +1030,7 @@ func resourceNewRelicOneDashboardUpdate(ctx context.Context, d *schema.ResourceD
 
 	// We have to use the Update Result, not a re-read of the entity as the changes take
 	// some amount of time to be re-indexed
-	return diag.FromErr(flattenDashboardUpdateResult(updated, d))
+	return diag.FromErr(flattenDashboardUpdateResult(updated, d, meta.(*ProviderConfig).AccountID))
 }
 
 func resourceNewRelicOneDashboardDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/newrelic/resource_newrelic_one_dashboard_test.go
+++ b/newrelic/resource_newrelic_one_dashboard_test.go
@@ -630,19 +630,120 @@ func TestAccNewRelicOneDashboard_VariablesEnum(t *testing.T) {
 	})
 }
 
-// TestAccNewRelicOneDashboard_VariableAccountIDsValidation tests that the validation function properly catches empty account_ids
-func TestAccNewRelicOneDashboard_VariableAccountIDsValidation(t *testing.T) {
+// TestAccNewRelicOneDashboard_VariableAccountIDsDriftDetection is a comprehensive
+// drift-detection test for account_ids in a variable nrql_query block.
+//
+// It covers all meaningful state→config transitions. account_ids is defaulted to the
+// provider account on write (expandVariableNRQLQuery) and normalised back to an empty
+// list on read when the upstream value equals that default (flattenVariableNRQLQuery),
+// so an empty configuration stays empty in state — no phantom "remove the default
+// account ID" drift — while any other upstream value still surfaces as drift.
+//
+//	No-drift (plan must be empty after apply): the configured form is unchanged, or it
+//	only toggles between omitted and an empty list (both normalise to an empty list):
+//	  S1.  state=omitted        → plan omitted              (same form)
+//	  S2.  state=omitted        → plan empty-list           (equivalent empty forms)
+//	  S3.  state=empty-list     → plan omitted              (equivalent empty forms)
+//	  S4.  state=empty-list     → plan empty-list           (same form)
+//	  S6.  state=explicit[sub]  → plan explicit[sub]        (no change to explicit value)
+//
+//	Drift (plan must be non-empty): the configured value changes — including replacing
+//	an empty/omitted account_ids with an explicit list (even one equal to the provider
+//	default, since the configured form itself changed), and any explicit change:
+//	  S5a. state=omitted        → plan explicit[pDef]       (adding explicit == default)
+//	  S5b. state=explicit[pDef] → plan omitted              (removing explicit == default)
+//	  S7.  state=omitted        → plan explicit[sub]        (adding non-default value)
+//	  S8.  state=empty-list     → plan explicit[sub]        (adding non-default via empty form)
+//	  S9.  state=explicit[sub]  → plan omitted              (removing explicit; resets to default)
+//	  S10. state=explicit[sub]  → plan empty-list           (removing explicit via empty-list form)
+//	  S11. state=explicit[sub]  → plan explicit[pDef]       (changing between explicit values)
+//	  S12. state=explicit[pDef] → plan explicit[sub]        (changing between explicit values)
+//
+// The scenarios that reference only the provider-default account run with the standard
+// acceptance-test credentials and validate the originally reported bug — an
+// omitted/empty account_ids must not drift after apply. The scenarios that reference a
+// second, distinct account (S6–S12) prove real changes still surface drift; they need
+// NEW_RELIC_SUBACCOUNT_ID and are appended only when it is set. The read-side
+// normalization that underpins this is also unit-tested in
+// TestFlattenVariableNRQLQuery_AccountIDsNormalization.
+func TestAccNewRelicOneDashboard_VariableAccountIDsDriftDetection(t *testing.T) {
 	rName := fmt.Sprintf("tf-test-%s", acctest.RandString(5))
+	omitted := testAccNewRelicOneDashboardConfigVariableAccountIDsOmitted(rName)
+	empty := testAccNewRelicOneDashboardConfigVariableAccountIDs(rName)
+	explicit := testAccNewRelicOneDashboardConfigVariableAccountIDsExplicit(rName)
+	pDef := testAccNewRelicOneDashboardConfigVariableAccountIDsProviderDefault(rName)
+
+	// Single-account scenarios (S1–S5): reference only omitted, empty and the
+	// provider-default account, so they run without a sub-account.
+	steps := []resource.TestStep{
+		// ── Apply: omitted → state=[providerDefault] ─────────────────────
+		{Config: omitted},
+		// S1: omitted → omitted
+		{Config: omitted, PlanOnly: true},
+		// S2: omitted → empty-list
+		{Config: empty, PlanOnly: true},
+		// S5a: omitted → explicit[pDef]  (adding an explicit value == default is a
+		// configured-form change, so the plan is non-empty; it converges on apply)
+		{Config: pDef, PlanOnly: true, ExpectNonEmptyPlan: true},
+
+		// ── Apply: empty-list → state=[providerDefault] ──────────────────
+		{Config: empty},
+		// S3: empty-list → omitted
+		{Config: omitted, PlanOnly: true},
+		// S4: empty-list → empty-list
+		{Config: empty, PlanOnly: true},
+
+		// ── Apply: explicit[pDef] → state=[providerDefault] ──────────────
+		{Config: pDef},
+		// S6 (single-account variant): explicit[pDef] → explicit[pDef]  (an unchanged
+		// explicit value must not drift — validates the "written through unchanged"
+		// read path without needing a second account)
+		{Config: pDef, PlanOnly: true},
+		// S5b: explicit[pDef] → omitted  (removing an explicit value == default is a
+		// configured-form change, so the plan is non-empty; it converges on apply)
+		{Config: omitted, PlanOnly: true, ExpectNonEmptyPlan: true},
+	}
+
+	// Cross-account scenarios (S6–S12) exercise a genuinely different account, so
+	// they need NEW_RELIC_SUBACCOUNT_ID. Without it, testSubAccountID is 0 and the
+	// explicit-account applies would fail; skip them and log rather than fail.
+	if testSubAccountID != 0 {
+		steps = append(steps, []resource.TestStep{
+			// ── Apply: omitted → state=[providerDefault] ─────────────────
+			{Config: omitted},
+			// S7: omitted → explicit[sub]
+			{Config: explicit, PlanOnly: true, ExpectNonEmptyPlan: true},
+
+			// ── Apply: empty-list → state=[providerDefault] ──────────────
+			{Config: empty},
+			// S8: empty-list → explicit[sub]
+			{Config: explicit, PlanOnly: true, ExpectNonEmptyPlan: true},
+
+			// ── Apply: explicit[sub] → state=[subAccount] ────────────────
+			{Config: explicit},
+			// S6: explicit[sub] → explicit[sub]
+			{Config: explicit, PlanOnly: true},
+			// S11: explicit[sub] → explicit[pDef]
+			{Config: pDef, PlanOnly: true, ExpectNonEmptyPlan: true},
+			// S9: explicit[sub] → omitted
+			{Config: omitted, PlanOnly: true, ExpectNonEmptyPlan: true},
+			// S10: explicit[sub] → empty-list
+			{Config: empty, PlanOnly: true, ExpectNonEmptyPlan: true},
+
+			// ── Apply: explicit[pDef] → state=[providerDefault] ──────────
+			{Config: pDef},
+			// S12: explicit[pDef] → explicit[sub]  (provider-default-change simulation)
+			{Config: explicit, PlanOnly: true, ExpectNonEmptyPlan: true},
+		}...)
+	} else {
+		t.Log("NEW_RELIC_SUBACCOUNT_ID not set: skipping value-change scenarios that need a second account (S11, S12); running provider-default-account scenarios (S1–S4, S5a, S5b, S6) only")
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNewRelicOneDashboardDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccNewRelicOneDashboardConfigVariableAccountIDs(rName),
-				ExpectError: regexp.MustCompile("`account_ids` cannot be empty for NRQL variables"),
-			},
-		},
+		Steps:        steps,
 	})
 }
 
@@ -1907,7 +2008,8 @@ resource "newrelic_one_dashboard" "bar" {
 }`
 }
 
-// Test configuration with variable account_ids explicitly set
+// testAccNewRelicOneDashboardConfigVariableAccountIDs creates a dashboard with an NRQL variable
+// that has an explicitly empty account_ids list. The provider should default to its account ID.
 func testAccNewRelicOneDashboardConfigVariableAccountIDs(dashboardName string) string {
 	return fmt.Sprintf(`
 resource "newrelic_one_dashboard" "bar" {
@@ -1930,14 +2032,130 @@ resource "newrelic_one_dashboard" "bar" {
   }
 
   variable {
-    name               = "test_variable"
-    title              = "Test Variable"
-    type               = "nrql"
+    name                 = "test_variable"
+    title                = "Test Variable"
+    type                 = "nrql"
     replacement_strategy = "default"
 
     nrql_query {
       account_ids = []
       query       = "FROM Transaction SELECT uniques(appName)"
+    }
+  }
+}
+`, dashboardName)
+}
+
+// testAccNewRelicOneDashboardConfigVariableAccountIDsProviderDefault creates a dashboard with
+// an NRQL variable whose account_ids is explicitly set to testAccountID, which is the same
+// value as the provider's configured account_id. Used to verify that an explicit value equal
+// to the provider default is treated identically to an omitted value (no drift).
+func testAccNewRelicOneDashboardConfigVariableAccountIDsProviderDefault(dashboardName string) string {
+	return fmt.Sprintf(`
+resource "newrelic_one_dashboard" "bar" {
+  name = "%[1]s"
+
+  page {
+    name = "Test Page"
+
+    widget_line {
+      title  = "Test Widget"
+      row    = 1
+      column = 1
+      width  = 6
+      height = 3
+
+      nrql_query {
+        query = "FROM Transaction SELECT average(duration) FACET appName TIMESERIES"
+      }
+    }
+  }
+
+  variable {
+    name                 = "test_variable"
+    title                = "Test Variable"
+    type                 = "nrql"
+    replacement_strategy = "default"
+
+    nrql_query {
+      account_ids = [%[2]d]
+      query       = "FROM Transaction SELECT uniques(appName)"
+    }
+  }
+}
+`, dashboardName, testAccountID)
+}
+
+// testAccNewRelicOneDashboardConfigVariableAccountIDsExplicit creates a dashboard with an NRQL
+// variable whose account_ids is set to testSubAccountID — a value distinct from the provider
+// default — so that switching back to an empty account_ids produces a detectable change.
+func testAccNewRelicOneDashboardConfigVariableAccountIDsExplicit(dashboardName string) string {
+	return fmt.Sprintf(`
+resource "newrelic_one_dashboard" "bar" {
+  name = "%[1]s"
+
+  page {
+    name = "Test Page"
+
+    widget_line {
+      title  = "Test Widget"
+      row    = 1
+      column = 1
+      width  = 6
+      height = 3
+
+      nrql_query {
+        query = "FROM Transaction SELECT average(duration) FACET appName TIMESERIES"
+      }
+    }
+  }
+
+  variable {
+    name                 = "test_variable"
+    title                = "Test Variable"
+    type                 = "nrql"
+    replacement_strategy = "default"
+
+    nrql_query {
+      account_ids = [%[2]d]
+      query       = "FROM Transaction SELECT uniques(appName)"
+    }
+  }
+}
+`, dashboardName, testSubAccountID)
+}
+
+// testAccNewRelicOneDashboardConfigVariableAccountIDsOmitted creates a dashboard with an NRQL
+// variable where account_ids is omitted entirely. The provider should default to its account ID.
+func testAccNewRelicOneDashboardConfigVariableAccountIDsOmitted(dashboardName string) string {
+	return fmt.Sprintf(`
+resource "newrelic_one_dashboard" "bar" {
+  name = "%[1]s"
+
+  page {
+    name = "Test Page"
+
+    widget_line {
+      title  = "Test Widget"
+      row    = 1
+      column = 1
+      width  = 6
+      height = 3
+
+      nrql_query {
+        query = "FROM Transaction SELECT average(duration) FACET appName TIMESERIES"
+      }
+    }
+  }
+
+  variable {
+    name                 = "test_variable"
+    title                = "Test Variable"
+    type                 = "nrql"
+    replacement_strategy = "default"
+
+    nrql_query {
+      query = "FROM Transaction SELECT uniques(appName)"
     }
   }
 }

--- a/newrelic/structures_newrelic_one_dashboard.go
+++ b/newrelic/structures_newrelic_one_dashboard.go
@@ -37,7 +37,8 @@ func expandDashboardInput(d *schema.ResourceData, meta interface{}, dashboardNam
 		return nil, err
 	}
 
-	dash.Variables, err = expandDashboardVariablesInput(d.Get("variable").([]interface{}))
+	providerAccountID := meta.(map[string]interface{})["account_id"].(int)
+	dash.Variables, err = expandDashboardVariablesInput(d.Get("variable").([]interface{}), providerAccountID)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +106,7 @@ func validateDashboardWidgetNRQLQueryAccountIDs(accountIDValue interface{}, key 
 	return
 }
 
-func expandDashboardVariablesInput(variables []interface{}) ([]dashboards.DashboardVariableInput, error) {
+func expandDashboardVariablesInput(variables []interface{}, providerAccountID int) ([]dashboards.DashboardVariableInput, error) {
 	if len(variables) < 1 {
 		return []dashboards.DashboardVariableInput{}, nil
 	}
@@ -139,7 +140,7 @@ func expandDashboardVariablesInput(variables []interface{}) ([]dashboards.Dashbo
 		}
 
 		if q, ok := v["nrql_query"]; ok && len(q.([]interface{})) > 0 {
-			variable.NRQLQuery = expandVariableNRQLQuery(q.([]interface{}))
+			variable.NRQLQuery = expandVariableNRQLQuery(q.([]interface{}), providerAccountID)
 		}
 
 		if r, ok := v["replacement_strategy"]; ok {
@@ -190,14 +191,19 @@ func expandVariableItems(in []interface{}) []dashboards.DashboardVariableEnumIte
 	return out
 }
 
-func expandVariableNRQLQuery(in []interface{}) *dashboards.DashboardVariableNRQLQueryInput {
+func expandVariableNRQLQuery(in []interface{}, providerAccountID int) *dashboards.DashboardVariableNRQLQueryInput {
 	var out dashboards.DashboardVariableNRQLQueryInput
 
 	for _, v := range in {
 		cfg := v.(map[string]interface{})
+		accountIDs := expandVariableAccountIDs(cfg["account_ids"].([]interface{}))
+		if len(accountIDs) == 0 {
+			accountIDs = []int{providerAccountID}
+		}
 		out = dashboards.DashboardVariableNRQLQueryInput{
-			AccountIDs: expandVariableAccountIDs(cfg["account_ids"].([]interface{})),
-			Query:      nrdb.NRQL(cfg["query"].(string))}
+			AccountIDs: accountIDs,
+			Query:      nrdb.NRQL(cfg["query"].(string)),
+		}
 	}
 
 	return &out
@@ -1181,7 +1187,7 @@ func expandVariableOptions(in []interface{}) *dashboards.DashboardVariableOption
 // Unpack the *dashboards.Dashboard variable and set resource data.
 //
 // Used by the newrelic_one_dashboard Read function (resourceNewRelicOneDashboardRead)
-func flattenDashboardEntity(dashboard *entities.DashboardEntity, d *schema.ResourceData) error {
+func flattenDashboardEntity(dashboard *entities.DashboardEntity, d *schema.ResourceData, providerAccountID int) error {
 	_ = d.Set("account_id", dashboard.AccountID)
 	_ = d.Set("guid", dashboard.GUID)
 	_ = d.Set("name", dashboard.Name)
@@ -1200,7 +1206,7 @@ func flattenDashboardEntity(dashboard *entities.DashboardEntity, d *schema.Resou
 	}
 
 	if dashboard.Variables != nil && len(dashboard.Variables) > 0 {
-		variables := flattenDashboardVariable(&dashboard.Variables, d)
+		variables := flattenDashboardVariable(&dashboard.Variables, d, providerAccountID)
 		if err := d.Set("variable", variables); err != nil {
 			return err
 		}
@@ -1211,7 +1217,7 @@ func flattenDashboardEntity(dashboard *entities.DashboardEntity, d *schema.Resou
 // Unpack the *dashboards.Dashboard variable and set resource data.
 //
 // Used by the newrelic_one_dashboard Read function (resourceNewRelicOneDashboardRead)
-func flattenDashboardUpdateResult(result *dashboards.DashboardUpdateResult, d *schema.ResourceData) error {
+func flattenDashboardUpdateResult(result *dashboards.DashboardUpdateResult, d *schema.ResourceData, providerAccountID int) error {
 	if result == nil {
 		return fmt.Errorf("can not flatten nil DashboardUpdateResult")
 	}
@@ -1235,7 +1241,7 @@ func flattenDashboardUpdateResult(result *dashboards.DashboardUpdateResult, d *s
 		}
 	}
 	if dashboard.Variables != nil && len(dashboard.Variables) > 0 {
-		variables := flattenDashboardVariable(&dashboard.Variables, d)
+		variables := flattenDashboardVariable(&dashboard.Variables, d, providerAccountID)
 		if err := d.Set("variable", variables); err != nil {
 			return err
 		}
@@ -1243,7 +1249,7 @@ func flattenDashboardUpdateResult(result *dashboards.DashboardUpdateResult, d *s
 	return nil
 }
 
-func flattenDashboardVariable(in *[]entities.DashboardVariable, d *schema.ResourceData) []interface{} {
+func flattenDashboardVariable(in *[]entities.DashboardVariable, d *schema.ResourceData, providerAccountID int) []interface{} {
 	out := make([]interface{}, len(*in))
 
 	for i, v := range *in {
@@ -1256,7 +1262,11 @@ func flattenDashboardVariable(in *[]entities.DashboardVariable, d *schema.Resour
 		m["item"] = flattenVariableItems(v.Items)
 		m["name"] = v.Name
 		if v.NRQLQuery != nil {
-			m["nrql_query"] = flattenVariableNRQLQuery(v.NRQLQuery)
+			// The configured account_ids for this variable (empty when the user
+			// omitted them). Used to decide whether an upstream value equal to the
+			// provider default should be normalised back to an empty list.
+			configAccountIDs, _ := d.Get(fmt.Sprintf("variable.%d.nrql_query.0.account_ids", i)).([]interface{})
+			m["nrql_query"] = flattenVariableNRQLQuery(v.NRQLQuery, configAccountIDs, providerAccountID)
 		}
 		m["replacement_strategy"] = strings.ToLower(string(v.ReplacementStrategy))
 		m["title"] = v.Title
@@ -1296,17 +1306,30 @@ func flattenVariableItems(in []entities.DashboardVariableEnumItem) []interface{}
 	return out
 }
 
-func flattenVariableNRQLQuery(in *entities.DashboardVariableNRQLQuery) []interface{} {
-	out := make([]interface{}, 1)
-
+// flattenVariableNRQLQuery writes an NRQL variable query back to state.
+//
+// account_ids is optional: when a user omits it (or sets an empty list),
+// expandVariableNRQLQuery defaults the query to the provider's account ID before
+// sending it upstream. On read the API therefore returns [providerAccountID] even
+// though the configuration is empty. To avoid perpetual drift ("plan wants to remove
+// the default account ID"), we normalise that specific case back to an empty list so
+// state matches the empty configuration.
+//
+// If the upstream value is anything else — a different account, multiple accounts, or
+// a value changed directly in the UI — it is written through unchanged so that a real
+// change still surfaces as drift. Likewise, when the user configured account_ids
+// explicitly (configAccountIDs non-empty) the upstream value is always written as-is.
+func flattenVariableNRQLQuery(in *entities.DashboardVariableNRQLQuery, configAccountIDs []interface{}, providerAccountID int) []interface{} {
 	n := make(map[string]interface{})
 
-	n["account_ids"] = in.AccountIDs
+	if len(configAccountIDs) == 0 && len(in.AccountIDs) == 1 && in.AccountIDs[0] == providerAccountID {
+		n["account_ids"] = []int{}
+	} else {
+		n["account_ids"] = in.AccountIDs
+	}
 	n["query"] = in.Query
 
-	out[0] = n
-
-	return out
+	return []interface{}{n}
 }
 
 func flattenVariableOptions(in *entities.DashboardVariableOptions, d *schema.ResourceData, index int) []interface{} {
@@ -1933,11 +1956,6 @@ func validateDashboardArguments(ctx context.Context, d *schema.ResourceDiff, met
 		errorsList = append(errorsList, err.Error())
 	}
 
-	err = validateDashboardVariableNRQLAccountIDs(d, meta)
-	if err != nil {
-		errorsList = append(errorsList, err.Error())
-	}
-
 	//adding a function to validate that the " to and "from" fields in "threshold" for table & line widget are a floating point number.
 	validateThresholdFields(d, &errorsList, "widget_table")
 	validateThresholdFields(d, &errorsList, "widget_line")
@@ -1992,54 +2010,6 @@ func validateDashboardVariableOptions(d *schema.ResourceDiff) error {
 					}
 				}
 
-			}
-		}
-	}
-
-	return nil
-}
-
-func validateDashboardVariableNRQLAccountIDs(d *schema.ResourceDiff, meta interface{}) error {
-
-	_, variablesListObtained := d.GetChange("variable")
-	vars := variablesListObtained.([]interface{})
-
-	// Get default account ID from provider metadata
-	var defaultAccountID int
-	if providerMeta, ok := meta.(*ProviderConfig); ok {
-		defaultAccountID = providerMeta.AccountID
-	}
-
-	for i, v := range vars {
-		variableMap := v.(map[string]interface{})
-
-		nrqlQuery, nrqlQueryOk := variableMap["nrql_query"]
-		if !nrqlQueryOk {
-			continue
-		}
-
-		nrqlQueryInterface := nrqlQuery.([]interface{})
-		if len(nrqlQueryInterface) == 0 {
-			continue
-		}
-
-		for _, query := range nrqlQueryInterface {
-			if query == nil {
-				continue
-			}
-
-			queryMap := query.(map[string]interface{})
-			accountIDs, accountIDsOk := queryMap["account_ids"]
-
-			// Check if account_ids is missing or empty
-			if !accountIDsOk {
-				return fmt.Errorf("variable[%d]: `account_ids` is required for NRQL variables. The default provider account ID is %d - consider setting `account_ids = [%d]`",
-					i, defaultAccountID, defaultAccountID)
-			}
-
-			if accountIDsSlice, ok := accountIDs.([]interface{}); ok && len(accountIDsSlice) == 0 {
-				return fmt.Errorf("variable[%d]: `account_ids` cannot be empty for NRQL variables. The default provider account ID is %d - consider setting `account_ids = [%d]`",
-					i, defaultAccountID, defaultAccountID)
 			}
 		}
 	}

--- a/newrelic/structures_newrelic_one_dashboard_test.go
+++ b/newrelic/structures_newrelic_one_dashboard_test.go
@@ -9,6 +9,95 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestExpandVariableNRQLQuery_DefaultsToProviderAccountID(t *testing.T) {
+	providerAccountID := 12345
+
+	// account_ids omitted (empty slice) — should default to provider account
+	in := []interface{}{
+		map[string]interface{}{
+			"account_ids": []interface{}{},
+			"query":       "FROM Transaction SELECT uniques(appName)",
+		},
+	}
+	out := expandVariableNRQLQuery(in, providerAccountID)
+	assert.Equal(t, []int{providerAccountID}, out.AccountIDs)
+}
+
+func TestExpandVariableNRQLQuery_ExplicitAccountIDs(t *testing.T) {
+	providerAccountID := 12345
+
+	in := []interface{}{
+		map[string]interface{}{
+			"account_ids": []interface{}{111, 222},
+			"query":       "FROM Transaction SELECT uniques(appName)",
+		},
+	}
+	out := expandVariableNRQLQuery(in, providerAccountID)
+	assert.Equal(t, []int{111, 222}, out.AccountIDs)
+}
+
+// TestFlattenVariableNRQLQuery_AccountIDsNormalization covers the read-side
+// normalization that prevents drift for a defaulted account_ids: when the user
+// leaves account_ids empty, the upstream value equal to the provider account ID is
+// written back as an empty list (matching the empty config), while any other upstream
+// value — or any explicitly configured value — is written through unchanged so real
+// changes still surface as drift.
+func TestFlattenVariableNRQLQuery_AccountIDsNormalization(t *testing.T) {
+	const providerAccountID = 111111
+	const subAccountID = 222222
+
+	tests := []struct {
+		name             string
+		apiAccountIDs    []int
+		configAccountIDs []interface{}
+		wantAccountIDs   interface{}
+	}{
+		{
+			name:             "empty config + upstream == provider default -> normalized to empty",
+			apiAccountIDs:    []int{providerAccountID},
+			configAccountIDs: nil,
+			wantAccountIDs:   []int{},
+		},
+		{
+			name:             "empty config + upstream differs (UI change) -> written through (drift)",
+			apiAccountIDs:    []int{subAccountID},
+			configAccountIDs: []interface{}{},
+			wantAccountIDs:   []int{subAccountID},
+		},
+		{
+			name:             "empty config + upstream has multiple accounts -> written through",
+			apiAccountIDs:    []int{providerAccountID, subAccountID},
+			configAccountIDs: nil,
+			wantAccountIDs:   []int{providerAccountID, subAccountID},
+		},
+		{
+			name:             "explicit config == provider default -> written through as-is",
+			apiAccountIDs:    []int{providerAccountID},
+			configAccountIDs: []interface{}{providerAccountID},
+			wantAccountIDs:   []int{providerAccountID},
+		},
+		{
+			name:             "explicit config sub-account -> written through",
+			apiAccountIDs:    []int{subAccountID},
+			configAccountIDs: []interface{}{subAccountID},
+			wantAccountIDs:   []int{subAccountID},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := &entities.DashboardVariableNRQLQuery{
+				AccountIDs: tt.apiAccountIDs,
+				Query:      "FROM Transaction SELECT uniques(appName)",
+			}
+			out := flattenVariableNRQLQuery(in, tt.configAccountIDs, providerAccountID)
+			assert.Len(t, out, 1)
+			block := out[0].(map[string]interface{})
+			assert.Equal(t, tt.wantAccountIDs, block["account_ids"])
+		})
+	}
+}
+
 func TestExpandDashboardBillboardThreshold(t *testing.T) {
 	dashboard := entities.DashboardWidget{
 		ID: "abcde",

--- a/website/docs/r/one_dashboard.html.markdown
+++ b/website/docs/r/one_dashboard.html.markdown
@@ -582,11 +582,14 @@ Nested `nrql_query` blocks in **variable** allow you to make NRQL queries to pop
 
 The following arguments are supported:
 
-  * `account_ids` - (Required) List of account IDs such as `[12345, 67890]`.
+  * `account_ids` - (Optional) List of account IDs to run the variable's NRQL query against, such as `[12345, 67890]`. If omitted, defaults to the account ID the provider is configured with.
   * `query` - (Required) Valid NRQL query string. See [Writing NRQL Queries](https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/using-nrql/introduction-nrql) for help.
+
+-> **NOTE:** While `account_ids` is optional and will default to the provider's configured account ID when left out, it is recommended to specify it explicitly wherever you can. This makes it clear which account the variable queries, helps Terraform detect genuine drift if the value is changed outside of Terraform (for example, via the UI), and avoids any ambiguity when the same configuration is applied across multiple accounts or environments. If you are importing an existing dashboard, check the account IDs the variable is querying against and specify them explicitly in your configuration after the import. This is particularly worth doing if they differ from the account your provider is configured with, as you may see unexpected drift on the first plan otherwise.
 
 Example usage:
 ```hcl
+# Variable querying multiple accounts explicitly
 variable {
     default_values     = ["value"]
     is_multi_selection = true
@@ -596,7 +599,6 @@ variable {
     }
     name = "variable"
     nrql_query {
-      # Multi-account query - specify multiple account IDs as list of integers
       account_ids = [12345, 67890]
       query       = "FROM Transaction SELECT average(duration) FACET appName"
     }
@@ -605,6 +607,7 @@ variable {
     type                 = "nrql"
 }
 
+# Variable querying a single account explicitly
 variable {
     default_values     = ["value"]
     is_multi_selection = true
@@ -614,9 +617,25 @@ variable {
     }
     name = "variable"
     nrql_query {
-      # Single account - use list format
       account_ids = [12345]
       query       = "FROM Transaction SELECT average(duration) FACET appName"
+    }
+    replacement_strategy = "default"
+    title                = "title"
+    type                 = "nrql"
+}
+
+# Variable with account_ids omitted - defaults to the provider's configured account ID
+variable {
+    default_values     = ["value"]
+    is_multi_selection = true
+    item {
+      title = "item"
+      value = "ITEM"
+    }
+    name = "variable"
+    nrql_query {
+      query = "FROM Transaction SELECT average(duration) FACET appName"
     }
     replacement_strategy = "default"
     title                = "title"
@@ -726,8 +745,8 @@ widget_area {
 
 | Block Type | Attribute Name | Format | Example |
 |------------|----------------|--------|---------|
-| **Widget** `nrql_query` | `account_id` | String/Number or JSON-encoded array | `12345` or `jsonencode([12345, 67890])` |
-| **Variable** `nrql_query` | `account_ids` | List of integers | `[12345, 67890]` |
+| **Widget** `nrql_query` | `account_id` | Optional. String/Number or JSON-encoded array | `12345` or `jsonencode([12345, 67890])` |
+| **Variable** `nrql_query` | `account_ids` | Optional. List of integers, defaults to provider account ID | `[12345, 67890]` |
 
 **Historical Context:** This difference exists because:
 - **Variables** were designed with multi-account support from the beginning (v3.9.0+).


### PR DESCRIPTION
## Make `account_ids` optional in a dashboard variable `nrql_query` block

### Summary

Allows `account_ids` to be omitted (or set to an empty list) in a dashboard variable's `nrql_query` block, defaulting to the provider's configured account ID. Critically, after `terraform apply` a subsequent `terraform plan` reports **no drift** — and in particular no drift proposing to discard the defaulted account ID — while genuine changes still surface as drift.

### Background / what changed since the initial review

The first iterations of this PR tried to default the value in `CustomizeDiff` with the attribute marked `Optional + Computed`. That approach cannot work, for a concrete SDK reason:

- `ResourceDiff.SetNew` (and `SetNewComputed`) only accept **top-level** schema keys — `checkKey` is called with `nested=false`. A nested list key like `variable.0.nrql_query.0.account_ids` is always rejected with `SetNew: invalid key`, which fails the plan at apply time.
- Marking the list `Computed` additionally causes an *omitted* value to be carried forward from prior state, which masks real drift (e.g. an account changed in the UI while the config stays empty).

This is the dead-end raised in earlier review. It has been replaced with **read-side normalization**, which needs neither `Computed` nor `CustomizeDiff`.

### Approach

`account_ids` is plain `Optional`:

- **Write (`expand`)**: an empty/omitted `account_ids` is defaulted to the provider account ID before being sent upstream.
- **Read (`flatten`)**: when the configuration is empty **and** the upstream value is exactly `[providerAccountID]`, the value is normalized back to an empty list, so state matches the empty config and no drift is reported. Any other upstream value — a different account, multiple accounts, or a value changed in the UI — is written through unchanged, so real changes still drift. Explicitly configured values are always written through as-is.

The provider account ID is threaded from `meta` through the flatten call chain.

### Behavior

| Config transition | Plan result |
|---|---|
| omitted → omitted / empty → empty / omitted ↔ empty | no drift |
| explicit `[X]` → explicit `[X]` (unchanged) | no drift |
| omitted/empty ↔ explicit (form change, incl. `[pDef]`) | drift (convergent — a real config change) |
| explicit `[A]` → explicit `[B]` | drift |
| upstream value ≠ provider default while config is empty (e.g. UI change) | drift |

### Testing

- **Acceptance** (`TestAccNewRelicOneDashboard_VariableAccountIDsDriftDetection`): passes against the live API for all provider-default-account scenarios (omitted/empty no-drift, explicit-value no-drift, and the convergent form-change drift cases). Cross-account *value-change* scenarios (S11/S12) require a second accessible account and are gated behind `NEW_RELIC_SUBACCOUNT_ID`.
- **Unit** (`TestFlattenVariableNRQLQuery_AccountIDsNormalization`): covers the read-side normalization directly, including the "written through unchanged" cases that back the value-change scenarios.

### Notes

- The branch was rebased onto `main`, so earlier inline review comments may show as outdated.