### PR TITLE
fix(api-access-key): add data source

### DIFF
--- a/integration_test_utilities/integration_test_mappings.yaml
+++ b/integration_test_utilities/integration_test_mappings.yaml
@@ -16,6 +16,12 @@ data_source_newrelic_alert_policy.go:
 data_source_newrelic_alert_policy_test.go:
   test: true
   product_mapping: ALERTS
+data_source_newrelic_api_access_key.go:
+  test: false
+  product_mapping: APIKS
+data_source_newrelic_api_access_key_test.go:
+  test: true
+  product_mapping: APIKS
 data_source_newrelic_application.go:
   test: false
   product_mapping: APM

--- a/newrelic/data_source_newrelic_api_access_key.go
+++ b/newrelic/data_source_newrelic_api_access_key.go
@@ -1,0 +1,199 @@
+package newrelic
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/apiaccess"
+)
+
+func dataSourceNewRelicAPIAccessKey() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceNewRelicAPIAccessKeyRead,
+		Schema: map[string]*schema.Schema{
+			"account_id": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: "The New Relic account ID the key belongs to. Defaults to the account ID configured on the provider when not specified.",
+			},
+			"key_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The ID of the key. When specified, the key is fetched directly by its ID instead of searching by other attributes.",
+			},
+			"key_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: fmt.Sprintf("The type of the key, one of %s or %s.", keyTypeIngest, keyTypeUser),
+			},
+			"ingest_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: fmt.Sprintf("The type of the ingest key, one of %s or %s. Only applies when `key_type` is %s.", keyTypeIngestLicense, keyTypeIngestBrowser, keyTypeIngest),
+			},
+			"user_id": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: fmt.Sprintf("The ID of the user that owns the key. Only applies when `key_type` is %s.", keyTypeUser),
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The name of the key. Used to narrow down the search when `key_id` is not specified.",
+			},
+			"notes": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Any notes attached to the key.",
+			},
+			"key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Sensitive:   true,
+				Description: "The value of the key.",
+			},
+		},
+	}
+}
+
+func dataSourceNewRelicAPIAccessKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+
+	keyType := strings.ToUpper(d.Get("key_type").(string))
+	if keyType != keyTypeIngest && keyType != keyTypeUser {
+		return diag.Errorf("the `key_type` attribute must be set to either %s or %s", keyTypeIngest, keyTypeUser)
+	}
+
+	var key *apiaccess.APIKey
+	var err error
+
+	// When a `key_id` is provided, fetch the key directly by its ID. Otherwise, search for a
+	// matching key using the other attributes provided in the configuration.
+	if keyID, ok := d.GetOk("key_id"); ok {
+		key, err = client.APIAccess.GetAPIAccessKeyWithContext(ctx, keyID.(string), apiaccess.APIAccessKeyType(keyType))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if key == nil {
+			return diag.FromErr(fmt.Errorf("no New Relic API access key found with id %s and type %s", keyID, keyType))
+		}
+	} else {
+		key, err = searchNewRelicAPIAccessKey(ctx, providerConfig, d, keyType)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return setNewRelicAPIAccessKeyDataSourceAttributes(d, key)
+}
+
+// searchNewRelicAPIAccessKey searches for a single API access key matching the attributes
+// provided in the configuration. It returns an error when no key or more than one key matches.
+func searchNewRelicAPIAccessKey(ctx context.Context, providerConfig *ProviderConfig, d *schema.ResourceData, keyType string) (*apiaccess.APIKey, error) {
+	client := providerConfig.NewClient
+	accountID := selectAccountID(providerConfig, d)
+
+	query := apiaccess.APIAccessKeySearchQuery{
+		Types: []apiaccess.APIAccessKeyType{apiaccess.APIAccessKeyType(keyType)},
+		Scope: apiaccess.APIAccessKeySearchScope{
+			AccountIDs: []int{accountID},
+		},
+	}
+
+	ingestType, ingestTypeOk := d.GetOk("ingest_type")
+	if ingestTypeOk {
+		query.Scope.IngestTypes = []apiaccess.APIAccessIngestKeyType{apiaccess.APIAccessIngestKeyType(strings.ToUpper(ingestType.(string)))}
+	}
+
+	userID, userIDOk := d.GetOk("user_id")
+	if userIDOk {
+		query.Scope.UserIDs = []int{userID.(int)}
+	}
+
+	keys, err := client.APIAccess.SearchAPIAccessKeysWithContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	name, nameOk := d.GetOk("name")
+
+	matches := make([]apiaccess.APIKey, 0, len(keys))
+	for _, k := range keys {
+		// The search is scoped on the server side, but `name` is matched here as the API does
+		// not support filtering by name.
+		if nameOk && k.Name != name.(string) {
+			continue
+		}
+		matches = append(matches, k)
+	}
+
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("no New Relic API access key found matching the given criteria; try specifying `key_id`, `name`, `ingest_type` or `user_id` to narrow down the search")
+	}
+
+	if len(matches) > 1 {
+		return nil, fmt.Errorf("found %d New Relic API access keys matching the given criteria; please specify additional attributes such as `key_id`, `name`, `ingest_type` or `user_id` to narrow down the search to a single key", len(matches))
+	}
+
+	return &matches[0], nil
+}
+
+func setNewRelicAPIAccessKeyDataSourceAttributes(d *schema.ResourceData, key *apiaccess.APIKey) diag.Diagnostics {
+	d.SetId(key.ID)
+
+	if err := d.Set("key_id", key.ID); err != nil {
+		return diag.FromErr(err)
+	}
+	if key.AccountID != nil {
+		if err := d.Set("account_id", *key.AccountID); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if err := d.Set("key_type", key.Type); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("ingest_type", key.IngestType); err != nil {
+		return diag.FromErr(err)
+	}
+	if key.UserID != nil {
+		if err := d.Set("user_id", *key.UserID); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if err := d.Set("name", key.Name); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("notes", key.Notes); err != nil {
+		return diag.FromErr(err)
+	}
+
+	// NerdGraph returns a truncated key value (suffixed with "...") when the key belongs to a user
+	// that is not associated with the API key used by the provider. In that case the actual key
+	// value cannot be retrieved, so emit a warning instead of setting a truncated value.
+	if strings.HasSuffix(key.Key, "...") {
+		return diag.Diagnostics{
+			diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary: "The API access key value could not be retrieved as it belongs to a user that is not associated " +
+					"with the API key used by the provider. NerdGraph only returns a truncated key value in such a case, for " +
+					"security reasons.\n" +
+					"Please see this article for more information: " +
+					"https://docs.newrelic.com/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys/#query-keys",
+			}}
+	}
+
+	if err := d.Set("key", key.Key); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/newrelic/data_source_newrelic_api_access_key.go
+++ b/newrelic/data_source_newrelic_api_access_key.go
@@ -137,11 +137,11 @@ func searchNewRelicAPIAccessKey(ctx context.Context, providerConfig *ProviderCon
 	}
 
 	if len(matches) == 0 {
-		return nil, fmt.Errorf("no New Relic API access key found matching the given criteria; try specifying `key_id`, `name`, `ingest_type` or `user_id` to narrow down the search")
+		return nil, fmt.Errorf("no New Relic API access key found matching the given criteria; try adjusting `name`, `ingest_type` or `user_id`, or specify `key_id` to look up a key directly")
 	}
 
 	if len(matches) > 1 {
-		return nil, fmt.Errorf("found %d New Relic API access keys matching the given criteria; please specify additional attributes such as `key_id`, `name`, `ingest_type` or `user_id` to narrow down the search to a single key", len(matches))
+		return nil, fmt.Errorf("found %d New Relic API access keys matching the given criteria; add or refine `name`, `ingest_type` or `user_id` to narrow the result to a single key, or specify `key_id` to look up a key directly", len(matches))
 	}
 
 	return &matches[0], nil

--- a/newrelic/data_source_newrelic_api_access_key_test.go
+++ b/newrelic/data_source_newrelic_api_access_key_test.go
@@ -1,0 +1,94 @@
+//go:build integration || APIKS
+
+package newrelic
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccNewRelicAPIAccessKeyDataSource_ByKeyID(t *testing.T) {
+	keyName := fmt.Sprintf("tftest-keyname-%s", acctest.RandString(10))
+	keyNotes := fmt.Sprintf("tftest-keynotes-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNewRelicAPIAccessKeyDataSourceConfigByKeyID(testSubAccountID, keyTypeIngestLicense, keyName, keyNotes),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.newrelic_api_access_key.foobar", "account_id", fmt.Sprintf("%d", testSubAccountID)),
+					resource.TestCheckResourceAttr("data.newrelic_api_access_key.foobar", "key_type", keyTypeIngest),
+					resource.TestCheckResourceAttr("data.newrelic_api_access_key.foobar", "ingest_type", keyTypeIngestLicense),
+					resource.TestCheckResourceAttr("data.newrelic_api_access_key.foobar", "name", keyName),
+					resource.TestCheckResourceAttr("data.newrelic_api_access_key.foobar", "notes", keyNotes),
+					resource.TestCheckResourceAttrSet("data.newrelic_api_access_key.foobar", "key_id"),
+					resource.TestCheckResourceAttrSet("data.newrelic_api_access_key.foobar", "key"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNewRelicAPIAccessKeyDataSource_ByName(t *testing.T) {
+	keyName := fmt.Sprintf("tftest-keyname-%s", acctest.RandString(10))
+	keyNotes := fmt.Sprintf("tftest-keynotes-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNewRelicAPIAccessKeyDataSourceConfigByName(testSubAccountID, keyTypeIngestLicense, keyName, keyNotes),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.newrelic_api_access_key.foobar", "account_id", fmt.Sprintf("%d", testSubAccountID)),
+					resource.TestCheckResourceAttr("data.newrelic_api_access_key.foobar", "key_type", keyTypeIngest),
+					resource.TestCheckResourceAttr("data.newrelic_api_access_key.foobar", "ingest_type", keyTypeIngestLicense),
+					resource.TestCheckResourceAttr("data.newrelic_api_access_key.foobar", "name", keyName),
+					resource.TestCheckResourceAttrSet("data.newrelic_api_access_key.foobar", "key_id"),
+					resource.TestCheckResourceAttrSet("data.newrelic_api_access_key.foobar", "key"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNewRelicAPIAccessKeyDataSourceConfigByKeyID(accountID int, ingestType, name, notes string) string {
+	return fmt.Sprintf(`
+resource "newrelic_api_access_key" "foobar" {
+	account_id  = %d
+	key_type    = "INGEST"
+	ingest_type = "%s"
+	name        = "%s"
+	notes       = "%s"
+}
+
+data "newrelic_api_access_key" "foobar" {
+	key_id   = newrelic_api_access_key.foobar.id
+	key_type = "INGEST"
+}
+`, accountID, ingestType, name, notes)
+}
+
+func testAccNewRelicAPIAccessKeyDataSourceConfigByName(accountID int, ingestType, name, notes string) string {
+	return fmt.Sprintf(`
+resource "newrelic_api_access_key" "foobar" {
+	account_id  = %d
+	key_type    = "INGEST"
+	ingest_type = "%s"
+	name        = "%s"
+	notes       = "%s"
+}
+
+data "newrelic_api_access_key" "foobar" {
+	account_id  = newrelic_api_access_key.foobar.account_id
+	key_type    = "INGEST"
+	ingest_type = "%s"
+	name        = newrelic_api_access_key.foobar.name
+}
+`, accountID, ingestType, name, notes, ingestType)
+}

--- a/newrelic/provider_newrelic.go
+++ b/newrelic/provider_newrelic.go
@@ -123,6 +123,7 @@ func Provider() *schema.Provider {
 			"newrelic_account":                      dataSourceNewRelicAccount(),
 			"newrelic_alert_channel":                dataSourceNewRelicAlertChannel(),
 			"newrelic_alert_policy":                 dataSourceNewRelicAlertPolicy(),
+			"newrelic_api_access_key":               dataSourceNewRelicAPIAccessKey(),
 			"newrelic_application":                  dataSourceNewRelicApplication(),
 			"newrelic_authentication_domain":        dataSourceNewRelicAuthenticationDomain(),
 			"newrelic_cloud_account":                dataSourceNewRelicCloudAccount(),

--- a/website/docs/d/api_access_key.html.markdown
+++ b/website/docs/d/api_access_key.html.markdown
@@ -1,0 +1,78 @@
+---
+layout: 'newrelic'
+page_title: 'New Relic: newrelic_api_access_key'
+sidebar_current: 'docs-newrelic-datasource-api-access-key'
+description: |-
+  Look up the value of an existing New Relic API access key.
+---
+
+# Data Source: newrelic\_api\_access\_key
+
+Use this data source to retrieve the value of an existing New Relic API access key (an [Ingest/License key](https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/license-key) or a [User API key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key)). This is useful, for instance, to fetch the default license key that New Relic creates for every account and inject it into other resources, without having to manage the key with the [`newrelic_api_access_key`](../resources/api_access_key) resource.
+
+A key may be looked up either directly by its `key_id`, or by searching with a combination of `account_id`, `key_type`, `ingest_type`, `user_id` and `name`.
+
+Refer to the New Relic article ['Use NerdGraph to manage license keys and User API keys'](https://docs.newrelic.com/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys) for detailed information.
+
+## Example Usage
+
+### Example: Look up the default license key of an account
+
+```hcl
+data "newrelic_api_access_key" "default" {
+  account_id  = 1234567
+  key_type    = "INGEST"
+  ingest_type = "LICENSE"
+  name        = "License Key for <Account name>"
+}
+```
+
+### Example: Look up a key directly by its ID
+
+```hcl
+data "newrelic_api_access_key" "by_id" {
+  key_id   = "131313133A331313130B5F13DF01313FDB13B13133EE5E133D13EAAB3A3C13D3"
+  key_type = "INGEST"
+}
+```
+
+### Example: Inject a license key into another resource
+
+```hcl
+data "newrelic_api_access_key" "ingest" {
+  account_id  = 1234567
+  key_type    = "INGEST"
+  ingest_type = "LICENSE"
+}
+
+output "license_key" {
+  value     = data.newrelic_api_access_key.ingest.key
+  sensitive = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `key_type` - (Required) The type of the key to look up. Valid options are `INGEST` or `USER` (case-sensitive).
+- `key_id` - (Optional) The ID of the key to look up. When specified, the key is fetched directly by its ID and the other search arguments are ignored.
+- `account_id` - (Optional) The New Relic account ID to search for keys in. Defaults to the `account_id` in the `provider{}` block (or `NEW_RELIC_ACCOUNT_ID` in your environment) if not specified.
+- `ingest_type` - (Optional) Filters the search to ingest keys of the given type. Valid options are `LICENSE` or `BROWSER` (case-sensitive). Only applies when `key_type` is `INGEST`.
+- `user_id` - (Optional) Filters the search to user keys owned by the given New Relic user ID. Only applies when `key_type` is `USER`.
+- `name` - (Optional) Filters the search to keys with the given name.
+
+-> **NOTE** When `key_id` is not specified, the search must narrow down to a single key. If more than one key matches the given criteria, the data source returns an error; in that case, provide additional arguments (such as `name`, `ingest_type`, `user_id` or `key_id`) to identify a unique key.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- `id` - The ID of the API key.
+- `key_id` - The ID of the API key.
+- `key` - The value of the API key.
+  - <span style="color:tomato;">It is important to exercise caution when exporting the value of `key`, as it is sensitive information</span>. Avoid logging or exposing it inappropriately.
+- `name` - The name of the API key.
+- `notes` - Any notes attached to the API key.
+
+-> **NOTE** If the key being fetched was created for a user other than the one whose API key is being used to run Terraform, the New Relic API returns a truncated key value for security reasons. In such a case, the `key` attribute is not populated and a warning is emitted. For more details, see [Use NerdGraph to manage license keys and User API keys](https://docs.newrelic.com/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys/#query-keys).

--- a/website/docs/d/api_access_key.html.markdown
+++ b/website/docs/d/api_access_key.html.markdown
@@ -8,11 +8,13 @@ description: |-
 
 # Data Source: newrelic\_api\_access\_key
 
-Use this data source to retrieve the value of an existing New Relic API access key (an [Ingest/License key](https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/license-key) or a [User API key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key)). This is useful, for instance, to fetch the default license key that New Relic creates for every account and inject it into other resources, without having to manage the key with the [`newrelic_api_access_key`](../resources/api_access_key) resource.
+Use this data source to retrieve details of an existing New Relic API access key, which can be either an [Ingest (license) key](https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/license-key) or a [User API key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key). A common use case is to fetch the default license key that New Relic creates for every account (for instance, via the [`newrelic_account_management`](../resources/account_management) resource) and inject its value into other resources, without having to manage the key itself with the [`newrelic_api_access_key`](../resources/api_access_key) resource.
 
-A key may be looked up either directly by its `key_id`, or by searching with a combination of `account_id`, `key_type`, `ingest_type`, `user_id` and `name`.
+A key may be looked up in one of two ways: directly by its `key_id`, or by searching with a combination of `account_id`, `key_type`, `ingest_type`, `user_id` and `name`.
 
 Refer to the New Relic article ['Use NerdGraph to manage license keys and User API keys'](https://docs.newrelic.com/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys) for detailed information.
+
+-> **WARNING:** If the key being fetched was created for a user other than the one whose API key is being used to run Terraform, the New Relic API returns a <span style="color:tomato;">truncated key value</span> for security reasons. In such a case, the `key` attribute is not populated in state and a warning is emitted. See the [Attributes Reference](#attributes-reference) section below, and the New Relic article ['Use NerdGraph to manage license keys and User API keys'](https://docs.newrelic.com/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys/#query-keys) for further details.
 
 ## Example Usage
 
@@ -56,23 +58,26 @@ output "license_key" {
 The following arguments are supported:
 
 - `key_type` - (Required) The type of the key to look up. Valid options are `INGEST` or `USER` (case-sensitive).
-- `key_id` - (Optional) The ID of the key to look up. When specified, the key is fetched directly by its ID and the other search arguments are ignored.
-- `account_id` - (Optional) The New Relic account ID to search for keys in. Defaults to the `account_id` in the `provider{}` block (or `NEW_RELIC_ACCOUNT_ID` in your environment) if not specified.
+- `key_id` - (Optional) The ID of the key to look up. When specified, the key is fetched directly by its ID and all other search arguments are ignored.
+- `account_id` - (Optional) The New Relic account ID to search for keys in. Defaults to the `account_id` set in the `provider{}` block (or the `NEW_RELIC_ACCOUNT_ID` environment variable) if not specified.
 - `ingest_type` - (Optional) Filters the search to ingest keys of the given type. Valid options are `LICENSE` or `BROWSER` (case-sensitive). Only applies when `key_type` is `INGEST`.
 - `user_id` - (Optional) Filters the search to user keys owned by the given New Relic user ID. Only applies when `key_type` is `USER`.
 - `name` - (Optional) Filters the search to keys with the given name.
 
--> **NOTE** When `key_id` is not specified, the search must narrow down to a single key. If more than one key matches the given criteria, the data source returns an error; in that case, provide additional arguments (such as `name`, `ingest_type`, `user_id` or `key_id`) to identify a unique key.
+-> **NOTE:** When `key_id` is not specified, the search must resolve to exactly one key. If zero or more than one key matches the given criteria, the data source returns an error. In such a case, provide additional arguments (such as `name`, `ingest_type` or `user_id`) to identify a unique key, or specify `key_id` directly to bypass the search.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-- `id` - The ID of the API key.
+- `id` - The ID of the API key. Identical in value to `key_id`.
 - `key_id` - The ID of the API key.
-- `key` - The value of the API key.
+- `key` - The value of the API key. This attribute is marked as **sensitive**.
   - <span style="color:tomato;">It is important to exercise caution when exporting the value of `key`, as it is sensitive information</span>. Avoid logging or exposing it inappropriately.
+  - Not populated when the New Relic API returns a truncated key value; see the warning at the top of this page.
+- `account_id` - The New Relic account ID the key belongs to.
+- `key_type` - The type of the key (`INGEST` or `USER`).
+- `ingest_type` - The type of the ingest key (`LICENSE` or `BROWSER`). Populated only when `key_type` is `INGEST`.
+- `user_id` - The New Relic user ID that owns the key. Populated only when `key_type` is `USER`.
 - `name` - The name of the API key.
 - `notes` - Any notes attached to the API key.
-
--> **NOTE** If the key being fetched was created for a user other than the one whose API key is being used to run Terraform, the New Relic API returns a truncated key value for security reasons. In such a case, the `key` attribute is not populated and a warning is emitted. For more details, see [Use NerdGraph to manage license keys and User API keys](https://docs.newrelic.com/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys/#query-keys).


### PR DESCRIPTION
# Description

Adds a `newrelic_api_access_key` **data source** to retrieve the value of an existing API access key. A resource already exists for *creating* keys, but there was no way to *read* an existing key — e.g. the default Ingest/License key New Relic creates for every account — so it could be injected into other resources.

The data source supports two lookup modes:

- **Direct by ID** — provide `key_id` (+ `key_type`); fetched via `GetAPIAccessKey`.
- **By search** — provide `account_id`, `key_type` and optionally `ingest_type`, `user_id`, `name`; fetched via `SearchAPIAccessKeys` and filtered. If zero or more than one key matches, an error is returned asking to narrow the search.

The `key` attribute is marked sensitive. When NerdGraph returns a truncated key (a key owned by a different user), the value is omitted and a warning is emitted, mirroring the resource's behavior.

Fixes #2424

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes.

## How to test this change?

Acceptance tests (`TestAccNewRelicAPIAccessKeyDataSource_ByKeyID`, `TestAccNewRelicAPIAccessKeyDataSource_ByName`) cover both lookup modes:

```sh
make test-integration TESTARGS='-run TestAccNewRelicAPIAccessKeyDataSource'
```

Or manually:

```hcl
# Look up an account's default license key by attributes
data "newrelic_api_access_key" "default" {
  account_id  = 1234567
  key_type    = "INGEST"
  ingest_type = "LICENSE"
  name        = "License Key for <Account name>"
}

# Or look up a key directly by its ID
data "newrelic_api_access_key" "by_id" {
  key_id   = "131313133A331313130B5F13DF01313FDB13B13133EE5E133D13EAAB3A3C13D3"
  key_type = "INGEST"
}

output "license_key" {
  value     = data.newrelic_api_access_key.default.key
  sensitive = true
}
```
