### PR TITLE
fix(monitor_downtime): don't crash the plugin on read (log.Fatalf → diag error, guard entity assertion)

### DIFF
--- a/newrelic/resource_newrelic_monitor_downtime.go
+++ b/newrelic/resource_newrelic_monitor_downtime.go
@@ -241,7 +241,13 @@ func resourceNewRelicMonitorDowntimeRead(ctx context.Context, d *schema.Resource
 		if err != nil {
 			return resource.RetryableError(err)
 		}
-		entity = (*resp).(*entities.GenericEntity)
+		// The entity may be nil or a different concrete type if it isn't indexed yet; guard the
+		// type assertion so a transient nil response retries instead of panicking the plugin.
+		genericEntity, ok := (*resp).(*entities.GenericEntity)
+		if !ok || genericEntity == nil {
+			return resource.RetryableError(fmt.Errorf("monitor downtime %s not found yet, retrying", d.Id()))
+		}
+		entity = genericEntity
 		tags = entity.GetTags()
 		if len(tags) < 4 {
 			return resource.RetryableError(fmt.Errorf("enough tags not found. retrying"))
@@ -249,8 +255,10 @@ func resourceNewRelicMonitorDowntimeRead(ctx context.Context, d *schema.Resource
 		return nil
 	})
 
+	// Never call log.Fatal* from a provider: it os.Exit()s the plugin process, which Terraform
+	// reports as an opaque "Plugin did not respond" crash. Surface a normal error instead.
 	if retryErr != nil {
-		log.Fatalf("Unable to find application entity: %s", retryErr)
+		return diag.FromErr(fmt.Errorf("error reading monitor downtime %s: %w", d.Id(), retryErr))
 	}
 
 	mode := setMonitorDowntimeMode(tags)


### PR DESCRIPTION
## Summary

`resourceNewRelicMonitorDowntimeRead` can crash the provider process. On read it retries fetching the entity for up to 30s and, on timeout, calls `log.Fatalf`:

```go
entity = (*resp).(*entities.GenericEntity)   // unguarded assertion
tags = entity.GetTags()
if len(tags) < 4 {
    return resource.RetryableError(fmt.Errorf("enough tags not found. retrying"))
}
// ...
if retryErr != nil {
    log.Fatalf("Unable to find application entity: %s", retryErr)   // os.Exit(1)
}
```

`log.Fatalf` calls `os.Exit(1)`, killing the plugin — Terraform reports it as an opaque **`Error: Plugin did not respond`** (`plugin process exited: exit status 1`).

This is reliably triggered when the entity never reaches the `>= 4` tags the retry waits for. A `MONITOR_DOWNTIME` entity that only carries the `account` / `accountId` / `trustedAccountId` system tags (e.g. importing/refreshing one created in the UI) never satisfies `len(tags) < 4`, so the retry always times out and the plugin is `os.Exit`-ed. Reproduced on **v3.93.1**, EU region. See #3117 for full trace/repro.

The unguarded `(*resp).(*entities.GenericEntity)` assertion is also the nil-interface panic from #2559 (`interface conversion: entities.EntityInterface is nil, not *entities.GenericEntity`), so this guards it too.

## Change

- Replace `log.Fatalf(...)` with `return diag.FromErr(...)` — a provider must never `os.Exit`; surface a normal error so Terraform reports a real diagnostic instead of a crash.
- Use a comma-ok + nil check on the type assertion so a transient nil/other-typed response retries instead of panicking.

No change to the happy path (entity with the expected tags still reads exactly as before).

## Testing

- `go build ./newrelic/` and `gofmt` pass.
- The success path is covered by the existing `TestAccNewRelicMonitorDowntime_*` acceptance tests (unchanged behavior).
- The crash path is awkward to exercise without mocking `client.Entities` — happy to add a test in whatever style you prefer.

## Note / possible follow-up

This PR is scoped to **stop the plugin crash**. Fully *importing* a downtime whose configuration isn't exposed via the tags the read expects (the `len(tags) < 4` case) would need a separate change to how the read reconstructs config; with this fix that scenario returns a clear error instead of crashing.

Refs #3117, #2559