### PR TITLE
feat(oci): add JP production region support to metrics onboarding modules (NR-540244)

### DIFF
--- a/examples/modules/cloud-integrations/oci/metrics-integration/locals.tf
+++ b/examples/modules/cloud-integrations/oci/metrics-integration/locals.tf
@@ -20,6 +20,7 @@ locals {
   newrelic_graphql_endpoint = {
     US = "https://api.newrelic.com/graphql"
     EU = "https://api.eu.newrelic.com/graphql"
+    JP = "https://api.jp.newrelic.com/graphql"
   }[var.newrelic_endpoint]
 
   updateLinkAccount_graphql_query = <<EOF

--- a/examples/modules/cloud-integrations/oci/metrics-integration/variables.tf
+++ b/examples/modules/cloud-integrations/oci/metrics-integration/variables.tf
@@ -22,10 +22,10 @@ variable "region" {
 variable "newrelic_endpoint" {
   type        = string
   default     = "US"
-  description = "The endpoint to hit for sending the metrics. Varies by region [US|EU]"
+  description = "The endpoint to hit for sending the metrics. Varies by region [US|EU|JP]"
   validation {
-    condition     = contains(["US", "EU"], var.newrelic_endpoint)
-    error_message = "Valid values for var: newrelic_endpoint are (US, EU)."
+    condition     = contains(["US", "EU", "JP"], var.newrelic_endpoint)
+    error_message = "Valid values for var: newrelic_endpoint are (US, EU, JP)."
   }
 }
 

--- a/examples/modules/cloud-integrations/oci/policy-setup/provider.tf
+++ b/examples/modules/cloud-integrations/oci/policy-setup/provider.tf
@@ -20,7 +20,7 @@ provider "oci" {
 }
 
 provider "newrelic" {
-  region     = var.newrelic_provider_region # US or EU
+  region     = var.newrelic_provider_region # US, EU or JP
   account_id = var.newrelic_account_id
   api_key    = local.user_api_key
 }

--- a/examples/modules/cloud-integrations/oci/wif-setup/README.md
+++ b/examples/modules/cloud-integrations/oci/wif-setup/README.md
@@ -36,7 +36,7 @@ Both flows are backward-compatible. Existing UPST customers can adopt RPST by se
 |----------|------|---------|----------|-------|
 | `tenancy_ocid` | string | — | yes | Your OCI tenancy OCID |
 | `identity_domain_name` | string | `"Default"` | no | Identity Domain to use |
-| `newrelic_region` | string | `"US"` | yes | `US` or `EU` |
+| `newrelic_region` | string | `"US"` | yes | `US`, `EU`, or `JP` |
 | `home_region` | string | — | yes | OCI home region (e.g. `us-ashburn-1`) |
 | `fingerprint` | string | — | yes | OCI API key fingerprint |
 | `private_key` | string (sensitive) | — | yes | OCI API key PEM content |

--- a/examples/modules/cloud-integrations/oci/wif-setup/main.tf
+++ b/examples/modules/cloud-integrations/oci/wif-setup/main.tf
@@ -22,19 +22,29 @@ locals {
   # New Relic configuration based on region. UPST and RPST share the same JWKS endpoint
   # (NR reuses the existing UPST signing key for RPST) but use different issuer/subject strings
   # because OCI enforces one Identity Propagation Trust per issuer per Identity Domain.
-  newrelic_config = var.newrelic_region == "US" ? {
-    issuer_name       = "newrelic-oci-us-production-issuer"
-    subject_name      = "newrelic-oci-us-production-user"
-    rpst_issuer_name  = "newrelic-oci-us-production-rpst-issuer"
-    rpst_subject_name = "newrelic-oci-us-production-rpst-user"
-    public_jwks_url   = "https://publickeys.newrelic.com/r/oci-cmp/us/c5623ba5-1cc7-491a-8ec3-eeee809374f7/jwks.json"
-    } : {
-    issuer_name       = "newrelic-oci-eu-production-issuer"
-    subject_name      = "newrelic-oci-eu-production-user"
-    rpst_issuer_name  = "newrelic-oci-eu-production-rpst-issuer"
-    rpst_subject_name = "newrelic-oci-eu-production-rpst-user"
-    public_jwks_url   = "https://publickeys.eu.newrelic.com/r/oci-cmp/eu/f923dba9-84a8-491c-b714-6c0e61b90c5b/jwks.json"
-  }
+  newrelic_config = {
+    US = {
+      issuer_name       = "newrelic-oci-us-production-issuer"
+      subject_name      = "newrelic-oci-us-production-user"
+      rpst_issuer_name  = "newrelic-oci-us-production-rpst-issuer"
+      rpst_subject_name = "newrelic-oci-us-production-rpst-user"
+      public_jwks_url   = "https://publickeys.newrelic.com/r/oci-cmp/us/c5623ba5-1cc7-491a-8ec3-eeee809374f7/jwks.json"
+    }
+    EU = {
+      issuer_name       = "newrelic-oci-eu-production-issuer"
+      subject_name      = "newrelic-oci-eu-production-user"
+      rpst_issuer_name  = "newrelic-oci-eu-production-rpst-issuer"
+      rpst_subject_name = "newrelic-oci-eu-production-rpst-user"
+      public_jwks_url   = "https://publickeys.eu.newrelic.com/r/oci-cmp/eu/f923dba9-84a8-491c-b714-6c0e61b90c5b/jwks.json"
+    }
+    JP = {
+      issuer_name       = "newrelic-oci-jp-production-issuer"
+      subject_name      = "newrelic-oci-jp-production-user"
+      rpst_issuer_name  = "newrelic-oci-jp-production-rpst-issuer"
+      rpst_subject_name = "newrelic-oci-jp-production-rpst-user"
+      public_jwks_url   = "https://publickeys.jp.newrelic.com/r/oci-cmp/jp/89625529-5f3e-47b8-a13a-25229f85989d/jwks.json"
+    }
+  }[var.newrelic_region]
 
   # NR-562518: static value pasted into the OCI trust as `impersonatingResource` and sent by NR
   # as `res_type` during token exchange. Same string for every NR-OCI integration.

--- a/examples/modules/cloud-integrations/oci/wif-setup/terraform.tfvars.example
+++ b/examples/modules/cloud-integrations/oci/wif-setup/terraform.tfvars.example
@@ -32,7 +32,7 @@ compartment_id = ""
 # Your NR account ID. Find at: one.newrelic.com → bottom-left account name → Account ID
 newrelic_account_id = "2222222"
 
-# NR region: "US" or "EU"
+# NR region: "US", "EU", or "JP"
 newrelic_region = "US"
 
 # Optional: prefix for resource names (default: "newrelic")

--- a/examples/modules/cloud-integrations/oci/wif-setup/variables.tf
+++ b/examples/modules/cloud-integrations/oci/wif-setup/variables.tf
@@ -15,12 +15,12 @@ variable "identity_domain_name" {
 
 # New Relic Configuration
 variable "newrelic_region" {
-  description = "New Relic region (US or EU)"
+  description = "New Relic region (US, EU or JP)"
   type        = string
   default     = "US"
   validation {
-    condition     = contains(["US", "EU"], var.newrelic_region)
-    error_message = "New Relic region must be either 'US' or 'EU'."
+    condition     = contains(["US", "EU", "JP"], var.newrelic_region)
+    error_message = "New Relic region must be 'US', 'EU', or 'JP'."
   }
 }
 


### PR DESCRIPTION
# Description

Adds New Relic **JP (Japan)** region support to the OCI **metrics** onboarding Terraform example modules so customers in the JP data center can complete the OCI metrics integration. JP routing already exists at the provider/client layer; this fills the gap in the standalone onboarding modules, which only recognized `US`/`EU`.

Changes (per module):
- **wif-setup**: refactored the binary `US ? {} : {}` `newrelic_config` into a region-keyed map and added the JP entry (JP issuer/subject names + JP `public_jwks_url`). This also fixes a latent bug where any non-`US` region silently fell through to the EU config. Region validation, `variables.tf` description, `terraform.tfvars.example`, and `README.md` updated to include `JP`.
- **metrics-integration**: added `JP = https://api.jp.newrelic.com/graphql` to the `newrelic_graphql_endpoint` map; extended `newrelic_endpoint` validation + description to include `JP`.
- **policy-setup**: corrected the region comment to `# US, EU or JP` (no functional gate existed there).

**logs-integration is intentionally out of scope** (JP already handled in #3080).

Fixes NR-540244

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt) (Terraform `fmt` applied to changed files)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works (N/A — HCL example modules; validated via `terraform validate` + live JP apply)
- [x] New and existing unit tests pass locally with my changes (`go build ./...` clean; no Go changes)

## How to test this change?

Static:
- `terraform fmt` + `terraform init -backend=false` + `terraform validate` in each of `wif-setup`, `policy-setup`, `metrics-integration` → `Success! The configuration is valid.`

Live (JP production):
- Step 1: `terraform apply` **wif-setup** with `newrelic_region = "JP"`; confirm the identity propagation trust uses issuer `newrelic-oci-jp-production-issuer` and the JP `public_jwks_url`.
- Step 2: `terraform apply` **policy-setup** with `instrumentation_type = "METRICS"` and `newrelic_provider_region = "JP"`; confirm metrics IAM policies + vault created.
- Step 3: `terraform apply` **metrics-integration** with `newrelic_endpoint = "JP"`; confirm `null_resource.newrelic_update_account` calls `https://api.jp.newrelic.com/graphql`, the linked account updates without error, and OCI metrics appear in the JP New Relic account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)