### PR TITLE
fix(api-access-key): don't reject known-after-apply account_id/user_id at plan time

### DIFF
--- a/newrelic/structures_newrelic_api_access_key.go
+++ b/newrelic/structures_newrelic_api_access_key.go
@@ -55,11 +55,6 @@ var ResourceNewRelicAPIAccessKeyAttributeLabels = struct {
 func validateAPIAccessKeyAttributes(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
 	var errorsList []error
 
-	accountIDInConfiguration := getAPIAccessKeyAttributeValueFromConfiguration(
-		d,
-		ResourceNewRelicAPIAccessKeyAttributeLabels.AccountID,
-	)
-
 	keyTypeInConfiguration := getAPIAccessKeyAttributeValueFromConfiguration(
 		d,
 		ResourceNewRelicAPIAccessKeyAttributeLabels.KeyType,
@@ -70,15 +65,18 @@ func validateAPIAccessKeyAttributes(ctx context.Context, d *schema.ResourceDiff,
 		ResourceNewRelicAPIAccessKeyAttributeLabels.IngestType,
 	)
 
-	userIDInConfiguration := getAPIAccessKeyAttributeValueFromConfiguration(
-		d,
-		ResourceNewRelicAPIAccessKeyAttributeLabels.UserID,
-	)
-
 	// this is not needed since the attribute is required in the schema
 	// however, this is being added as a double check, if the attribute were to support some sort of defaulting in the future
-	// so the author would need to disable this check too, which would be a conscious decision
-	if accountIDInConfiguration == 0 {
+	// so the author would need to disable this check too, which would be a conscious decision.
+	//
+	// Use the raw cty value here rather than the plan-time int value: when the config
+	// wires account_id from another resource that has not been applied yet (e.g.
+	// `account_id = newrelic_account_management.this.id`), d.GetChange returns the int
+	// zero value and this check would falsely trip. The raw value is only "null" when
+	// the attribute is truly absent from the configuration; an unknown (known-after-apply)
+	// value is neither null nor zero and is skipped here so it can be validated when it
+	// materialises during apply.
+	if d.GetRawConfig().GetAttr(ResourceNewRelicAPIAccessKeyAttributeLabels.AccountID).IsNull() {
 		errorsList = append(errorsList, fmt.Errorf("the `account_id` attribute is required, please specify a non-null account ID"))
 	}
 
@@ -103,7 +101,9 @@ func validateAPIAccessKeyAttributes(ctx context.Context, d *schema.ResourceDiff,
 		if !d.GetRawConfig().GetAttr(ResourceNewRelicAPIAccessKeyAttributeLabels.IngestType).IsNull() {
 			errorsList = append(errorsList, fmt.Errorf("the `ingest_type` attribute cannot be set when `key_type` is set to USER, please remove the `ingest_type` attribute from the configuration, or change `key_type` to INGEST"))
 		}
-		if userIDInConfiguration == 0 {
+		// Same reasoning as for account_id above: check the raw cty null-ness so a
+		// known-after-apply user_id reference does not trip this at plan time.
+		if d.GetRawConfig().GetAttr(ResourceNewRelicAPIAccessKeyAttributeLabels.UserID).IsNull() {
 			errorsList = append(errorsList, fmt.Errorf("the `user_id` attribute is required when `key_type` is set to USER, please specify a valid user ID"))
 		}
 	}
@@ -112,7 +112,7 @@ func validateAPIAccessKeyAttributes(ctx context.Context, d *schema.ResourceDiff,
 		return nil
 	}
 
-	errorsString := "the following validation errors have been identified with the configuration of the synthetic monitor: \n"
+	errorsString := "the following validation errors have been identified with the configuration of the API access key resource: \n"
 
 	for index, val := range errorsList {
 		errorsString += fmt.Sprintf("(%d): %s\n", index+1, val)


### PR DESCRIPTION
## Summary

Fixes #3128.

`resourceNewRelicAPIAccessKey`'s `CustomizeDiff` validator (introduced in #2931) falsely rejected any plan that wired `account_id` — or `user_id` when `key_type = \"USER\"` — from another resource whose value was still *known after apply*. The classic reproducer from the linked issue chains a fresh subaccount into an API key:

```hcl
resource \"newrelic_account_management\" \"sub\" {
  name   = \"foo Subaccount\"
  region = \"us01\"
}

resource \"newrelic_api_access_key\" \"ingest\" {
  account_id  = newrelic_account_management.sub.id
  key_type    = \"INGEST\"
  ingest_type = \"LICENSE\"
  name        = \"foo APM Ingest License Key\"
}
```

`terraform plan` (against the current `main`) errors with:

```
Error: the following validation errors have been identified with the configuration of the synthetic monitor:
(1): the `account_id` attribute is required, please specify a non-null account ID
```

...even though the value would be perfectly valid once the subaccount is applied.

## Root cause

The validator read `account_id` via `d.GetChange(name)`, which returns the type's Go zero value (`0` for `TypeInt`) whenever the config value is unknown at plan time. That is indistinguishable from the attribute being genuinely unset, so the `== 0` guard fired unconditionally. Same shape at `user_id` when `key_type = \"USER\"`.

Notably, the same validator already used `d.GetRawConfig().GetAttr(name).IsNull()` for the sibling *\"cannot be set\"* checks on `user_id`/`ingest_type` — the fix is to apply that same cty-aware pattern to the *\"must be set\"* checks too.

## Fix

- `account_id` \"required\" check → `d.GetRawConfig().GetAttr(...).IsNull()`.
- `user_id` \"required when key_type is USER\" check → `d.GetRawConfig().GetAttr(...).IsNull()`.
- Drive-by: the aggregated error prefix read `\"the configuration of the synthetic monitor\"` (a copy-paste artifact) — corrected to `\"the configuration of the API access key resource\"`.

`cty.Value.IsNull()` semantics are exactly what we need:

| Config state | `IsNull()` | Behavior |
|---|---|---|
| Attribute absent from config | `true` | Validator errors (correct) |
| Concrete literal / variable | `false` | Validator passes (correct) |
| Known-after-apply reference | `false` | Validator passes; API validates during apply (correct) |

## Verification

Ran locally in a worktree with a `dev_overrides`-pointed binary against the reporter's minimal config:

- **Reporter's scenario** (`newrelic_account_management.sub.id` → `newrelic_api_access_key.ingest`) — plan now succeeds:

  ```
  Plan: 2 to add, 0 to change, 0 to destroy.
      # newrelic_account_management.sub will be created
      # newrelic_api_access_key.ingest will be created
          + account_id = (known after apply)
  ```

- **Negative: `account_id` genuinely omitted** — still correctly rejected with:

  ```
  Error: the following validation errors have been identified with the configuration of the API access key resource:
  (1): the `account_id` attribute is required, please specify a non-null account ID
  ```

- **Negative: `key_type = \"USER\"` with no `user_id`** — still correctly rejected with the parallel diagnostic.

## Scope

Focused fix to unblock the reported regression. No schema changes, no docs changes, no behavior change on the happy path — only the plan-time false rejection is addressed.