### PR TITLE
fix(monitor-downtime): experimental guard against nil-entity panic on Read

### DIFF
--- a/newrelic/resource_newrelic_monitor_downtime.go
+++ b/newrelic/resource_newrelic_monitor_downtime.go
@@ -241,16 +241,25 @@ func resourceNewRelicMonitorDowntimeRead(ctx context.Context, d *schema.Resource
 		if err != nil {
 			return resource.RetryableError(err)
 		}
-		entity = (*resp).(*entities.GenericEntity)
+		if resp == nil || *resp == nil {
+			return resource.RetryableError(fmt.Errorf("monitor downtime %q not yet indexed (or deleted out-of-band)", d.Id()))
+		}
+		ge, ok := (*resp).(*entities.GenericEntity)
+		if !ok {
+			return resource.RetryableError(fmt.Errorf("monitor downtime %q returned unexpected entity type %T", d.Id(), *resp))
+		}
+		entity = ge
 		tags = entity.GetTags()
 		if len(tags) < 4 {
-			return resource.RetryableError(fmt.Errorf("enough tags not found. retrying"))
+			return resource.RetryableError(fmt.Errorf("monitor downtime %q returned only %d tags, expected >=4", d.Id(), len(tags)))
 		}
 		return nil
 	})
 
 	if retryErr != nil {
-		log.Fatalf("Unable to find application entity: %s", retryErr)
+		log.Printf("[WARN] Monitor downtime %q not readable after retries; clearing state: %s", d.Id(), retryErr)
+		d.SetId("")
+		return nil
 	}
 
 	mode := setMonitorDowntimeMode(tags)


### PR DESCRIPTION
## What this is

**Experimental** patch for the intermittent panic in `resourceNewRelicMonitorDowntimeRead` that shows up in the acceptance-test suite as:

```
panic: interface conversion: entities.EntityInterface is nil, not *entities.GenericEntity

goroutine XXXXX [running]:
github.com/newrelic/terraform-provider-newrelic/v3/newrelic.resourceNewRelicMonitorDowntimeRead.func1()
    .../newrelic/resource_newrelic_monitor_downtime.go:244 +0x3f8
github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry.RetryContext.func1()
    .../helper/retry/wait.go:27 +0x4e
```

It typically fires on `TestAccNewRelicMonitorDowntime_Monthly` and neighbours, and because retry-exhaustion currently calls `log.Fatalf(...)`, a single flaky Read kills the whole test binary and takes every other test in the run with it.

## Theory

`Entities.GetEntityWithContext` returns `(&resp, nil)` where the underlying `EntityInterface` inside `*resp` is nil whenever NerdGraph replies with `entity: null` for the queried GUID. That mostly happens right after Create, before the downtime entity has been indexed into the entity graph. The existing retry body asserts `(*resp).(*entities.GenericEntity)` unconditionally, so the very first iteration panics and the retry loop never actually gets to retry.

Why "experimental": we cannot easily reproduce the panic outside CI without waiting on real indexing lag, so this PR treats retries as the primary hypothesis and only proves the fix if the flake stops. If the flake persists, the next iteration would touch timing (see "Not doing yet" below).

## What this does

Keeps the retry timing exactly as it is - same `context.Background()`, same hardcoded 30 s budget - and only:

- **nil-guards the entity**: if `resp == nil || *resp == nil`, return a `RetryableError` so the loop gets a real chance to see the indexed entity on a later iteration;
- **guards the type assertion** with a comma-ok form and, on mismatch, returns a `RetryableError` (an API-contract violation would still surface through retry exhaustion);
- **keeps the existing `len(tags) < 4` retryable check** but includes the observed count + GUID in the message for easier triage;
- **replaces `log.Fatalf` on retry exhaustion** with a `[WARN]` log + `d.SetId("")` + `return nil`, so a genuinely missing downtime just gets recreated on the next plan instead of aborting the process.

Net delta: 12 lines added, 3 removed, in one file.

## Not doing yet

Deliberately holding off on:

- switching the retry from `context.Background()` to the resource's `ctx`;
- swapping the hardcoded 30 s for `d.Timeout(schema.TimeoutRead)` and adding a `Timeouts` block to the schema.

The idea is to see whether the retries alone are enough before touching timing. If CI keeps flaking after this, those two knobs are the next things to turn.

## Test plan

- [ ] Merge, wait for a CI run that includes the acceptance suite, and observe whether `TestAccNewRelicMonitorDowntime_*` still panics.
- [ ] If it does, iterate: hook the retry into the resource `ctx` and `d.Timeout(schema.TimeoutRead)`.