### PR TITLE
docs(region): add JP region support to docs 

### DIFF
--- a/examples/modules/cloud-integrations/aws/variables.tf
+++ b/examples/modules/cloud-integrations/aws/variables.tf
@@ -7,8 +7,8 @@ variable "newrelic_account_region" {
   default = "US"
 
   validation {
-    condition     = contains(["US", "EU"], var.newrelic_account_region)
-    error_message = "Valid values for region are 'US' or 'EU'."
+    condition     = contains(["US", "EU", "JP"], var.newrelic_account_region)
+    error_message = "Valid values for region are 'US', 'EU', or 'JP'."
   }
 }
 

--- a/website/docs/guides/aws_auto_discovery_integration_with_terraform.html.markdown
+++ b/website/docs/guides/aws_auto_discovery_integration_with_terraform.html.markdown
@@ -18,7 +18,7 @@ The below integration process presumes that the client has already integrated wi
 ## Variables -
 * **New Relic Region** ```new_relic_region``` - The region where your New Relic account is hosted
  *  **Type** - String
- *  **Allowed Values** - US or EU
+ *  **Allowed Values** - US, EU, or JP
 
 * **New Relic Account Id** ```new_relic_account_id``` - The account id associated with your organisation's New Relic Account.
  * **Type** - Integer

--- a/website/docs/guides/cloud_integrations_guide.html.markdown
+++ b/website/docs/guides/cloud_integrations_guide.html.markdown
@@ -78,7 +78,7 @@ module "newrelic-aws-cloud-integrations" {
 Variables:
 
 * `newrelic_account_id`: The New Relic account you want to link to AWS. This account will receive all the data observability from your AWS environment.
-* `newrelic_account_region` (Optional): The region of your New Relic account, this can be `US` for United States or `EU` for Europe. (Default `US`)
+* `newrelic_account_region` (Optional): The region of your New Relic account, this can be `US` for United States, `EU` for Europe, or `JP` for Japan. (Default `US`)
 * `name` (Optional): A unique name used throughout the module to name the resources. (Default `production`)
 * `output_format` (Optional): The output format for telemetry data. Supported values are `opentelemetry0.7` and `opentelemetry1.0`. (Default `opentelemetry0.7`)
 * `exclude_metric_filters` (Optional): a map of namespaces and metric names to exclude from the Cloudwatch metric stream. `Conflicts with include_metric_filters`.
@@ -471,7 +471,7 @@ Key variables:
   ]
   ```
 * `ingest_api_secret_ocid` / `user_api_secret_ocid` – Vault secret OCIDs for ingest and user API keys (avoid embedding plain‑text keys).
-* `newrelic_endpoint` – Logical endpoint selector; the module maps this value to the actual metric ingest URL (use the EU or JP variant for EU or JP accounts).
+* `newrelic_endpoint` – Logical endpoint selector; the module maps this value to the actual metric ingest URL (`US`, `EU`, or `JP`).
 * `region` – OCI region key (short code) where resources for this module are created (for example: `iad`, `phx`, `fra`). Provide ONLY the region key, not the full region identifier (so use `iad` instead of `us-ashburn-1`).
 * `image_version` / `image_bucket` – Docker image configuration for the New Relic function (optional, defaults to latest version).
 
@@ -522,7 +522,7 @@ Key variables:
 > If you want to use an existing private subnet, make sure it has required route rules and gateways with internet and all OCI services access. 
 - function application environment variables configuration:
   - `debug_enabled`: Boolean to enable or disable function debug logs.
-  - `new_relic_region`: The New Relic region (US, EU, or JP).
+  - `new_relic_region`: The New Relic region (`US`, `EU`, or `JP`).
   - `secret_ocid`: The OCID of the secret in OCI Vault containing New Relic License Key.
   - `user_api_secret_ocid`: The OCID of the secret in OCI Vault containing New Relic User API Key.
   - `image_version`: Docker image version for the logging function (defaults to "latest").


### PR DESCRIPTION
## Summary

Adds Japan (JP) as a valid region to documentation and module configuration that previously listed only `US` and `EU`.

- **`examples/modules/cloud-integrations/aws/variables.tf`**: Added `JP` to the `newrelic_account_region` variable validation. The JP CloudWatch endpoint URL was already present in `main.tf` but the variable validation was rejecting `JP` as an input, making the module unusable for JP accounts.
- **`website/docs/guides/cloud_integrations_guide.html.markdown`**: Updated backtick formatting on two OCI module variable descriptions (`newrelic_endpoint` and `new_relic_region`) to consistently show `US`, `EU`, or `JP`.
- **`website/docs/guides/aws_auto_discovery_integration_with_terraform.html.markdown`**: Added `JP` to the allowed values for the `new_relic_region` variable.

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation

## How to test this change?

Documentation-only change (plus a variable validation fix). To verify the AWS module fix, set `newrelic_account_region = "JP"` when calling the `cloud-integrations/aws` module — it should now pass validation instead of erroring.