### PR TITLE
feat: add description and title_template to compound condition resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.30.0
-	github.com/newrelic/newrelic-client-go/v2 v2.91.2-0.20260731161358-76b8d0bd43f3
+	github.com/newrelic/newrelic-client-go/v2 v2.93.1
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.30.0
-	github.com/newrelic/newrelic-client-go/v2 v2.93.0
+	github.com/newrelic/newrelic-client-go/v2 v2.91.2-0.20260731161358-76b8d0bd43f3
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S3bfBjY=
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
-github.com/newrelic/newrelic-client-go/v2 v2.93.0 h1:KLlR8m44D6fWDLU9HoBwZtEaltbZ4RJNxqjBzmxKIsg=
-github.com/newrelic/newrelic-client-go/v2 v2.93.0/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
+github.com/newrelic/newrelic-client-go/v2 v2.93.1 h1:CaIc3K9wFg57dwKCpAo1PaydnXePB069wGTbS5z7Hec=
+github.com/newrelic/newrelic-client-go/v2 v2.93.1/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/newrelic/resource_newrelic_alert_compound_condition.go
+++ b/newrelic/resource_newrelic_alert_compound_condition.go
@@ -86,6 +86,16 @@ func resourceNewRelicAlertCompoundCondition() *schema.Resource {
 				Optional:    true,
 				Description: "Runbook URL to display in notifications.",
 			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "BETA PREVIEW: the `description` field is in limited release and only enabled for preview on a per-account basis. The custom violation description.",
+			},
+			"title_template": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "BETA PREVIEW: the `title_template` field is in limited release and only enabled for preview on a per-account basis. This field allows you to create a custom title to be used when incidents are opened by the condition. Setting this field will override the default title. Must be Handlebars format.",
+			},
 			"threshold_duration": {
 				Type:        schema.TypeInt,
 				Optional:    true,

--- a/newrelic/resource_newrelic_alert_compound_condition_test.go
+++ b/newrelic/resource_newrelic_alert_compound_condition_test.go
@@ -396,3 +396,97 @@ resource "newrelic_alert_compound_condition" "foo" {
 }
 `, name, testAccountID)
 }
+
+func TestAccNewRelicAlertCompoundCondition_TitleTemplateAndDescription(t *testing.T) {
+	t.Skip("Skipping due to title_template and description being behind the DCON/compound_title_template_and_description_apis feature flag until generally available.")
+
+	resourceName := "newrelic_alert_compound_condition.foo"
+	rName := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckEnvVars(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNewRelicAlertCompoundConditionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNewRelicAlertCompoundConditionConfigWithTitleTemplateAndDescription(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicAlertCompoundConditionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Test description for compound condition"),
+					resource.TestCheckResourceAttr(resourceName, "title_template", fmt.Sprintf("{{compoundCondition.name}} triggered - %s", rName)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccNewRelicAlertCompoundConditionConfigWithTitleTemplateAndDescription(name string) string {
+	return fmt.Sprintf(`
+resource "newrelic_alert_policy" "foo" {
+	name = "tf-test-%[1]s"
+}
+
+resource "newrelic_nrql_alert_condition" "condition_a" {
+	policy_id = newrelic_alert_policy.foo.id
+	name      = "tf-test-condition-a-%[1]s"
+	enabled   = true
+
+	nrql {
+		query = "SELECT count(*) FROM Transaction WHERE appName = 'Dummy App'"
+	}
+
+	critical {
+		operator              = "above"
+		threshold             = 5.0
+		threshold_duration    = 300
+		threshold_occurrences = "all"
+	}
+
+	violation_time_limit_seconds = 3600
+}
+
+resource "newrelic_nrql_alert_condition" "condition_b" {
+	policy_id = newrelic_alert_policy.foo.id
+	name      = "tf-test-condition-b-%[1]s"
+	enabled   = true
+
+	nrql {
+		query = "SELECT average(duration) FROM Transaction WHERE appName = 'Dummy App'"
+	}
+
+	critical {
+		operator              = "above"
+		threshold             = 1.0
+		threshold_duration    = 300
+		threshold_occurrences = "all"
+	}
+
+	violation_time_limit_seconds = 3600
+}
+
+resource "newrelic_alert_compound_condition" "foo" {
+	account_id         = %[2]d
+	policy_id          = newrelic_alert_policy.foo.id
+	name               = "tf-test-%[1]s"
+	enabled            = true
+	trigger_expression = "A AND B"
+	description        = "Test description for compound condition"
+	title_template     = "{{compoundCondition.name}} triggered - %[1]s"
+
+	component_conditions {
+		id    = split(":", newrelic_nrql_alert_condition.condition_a.id)[1]
+		alias = "A"
+	}
+
+	component_conditions {
+		id    = split(":", newrelic_nrql_alert_condition.condition_b.id)[1]
+		alias = "B"
+	}
+}
+`, name, testAccountID)
+}

--- a/newrelic/resource_newrelic_alert_compound_condition_test.go
+++ b/newrelic/resource_newrelic_alert_compound_condition_test.go
@@ -398,8 +398,6 @@ resource "newrelic_alert_compound_condition" "foo" {
 }
 
 func TestAccNewRelicAlertCompoundCondition_TitleTemplateAndDescription(t *testing.T) {
-	t.Skip("Skipping due to title_template and description being behind the DCON/compound_title_template_and_description_apis feature flag until generally available.")
-
 	resourceName := "newrelic_alert_compound_condition.foo"
 	rName := acctest.RandString(5)
 

--- a/newrelic/structures_newrelic_alert_compound_condition.go
+++ b/newrelic/structures_newrelic_alert_compound_condition.go
@@ -39,6 +39,16 @@ func expandAlertCompoundConditionCreateInput(d *schema.ResourceData) (*alerts.Co
 		input.ThresholdDuration = &val
 	}
 
+	if v, ok := d.GetOk("description"); ok {
+		val := v.(string)
+		input.Description = &val
+	}
+
+	if v, ok := d.GetOk("title_template"); ok {
+		val := v.(string)
+		input.TitleTemplate = &val
+	}
+
 	return &input, nil
 }
 
@@ -77,6 +87,16 @@ func expandAlertCompoundConditionUpdateInput(d *schema.ResourceData) (*alerts.Co
 	if v, ok := d.GetOk("threshold_duration"); ok {
 		val := v.(int)
 		input.ThresholdDuration = &val
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		val := v.(string)
+		input.Description = &val
+	}
+
+	if v, ok := d.GetOk("title_template"); ok {
+		val := v.(string)
+		input.TitleTemplate = &val
 	}
 
 	return &input, nil
@@ -124,6 +144,8 @@ func flattenAlertCompoundCondition(accountID int, condition *alerts.CompoundCond
 	_ = d.Set("runbook_url", condition.RunbookURL)
 	_ = d.Set("threshold_duration", condition.ThresholdDuration)
 	_ = d.Set("entity_guid", condition.EntityGuid)
+	_ = d.Set("description", condition.Description)
+	_ = d.Set("title_template", condition.TitleTemplate)
 
 	// Flatten component conditions - ONLY id and alias (per user requirement)
 	componentConditions := flattenComponentConditions(condition.ComponentConditions)

--- a/newrelic/structures_newrelic_alert_compound_condition_test.go
+++ b/newrelic/structures_newrelic_alert_compound_condition_test.go
@@ -49,6 +49,40 @@ func TestExpandAlertCompoundConditionCreateInput(t *testing.T) {
 				},
 			},
 		},
+		"with description and title_template": {
+			Data: map[string]interface{}{
+				"name":               "test-compound-condition",
+				"enabled":            true,
+				"trigger_expression": "A AND B",
+				"description":        "Test description",
+				"title_template":     "{{compoundCondition.name}} triggered",
+				"component_conditions": []interface{}{
+					map[string]interface{}{
+						"id":    "123",
+						"alias": "A",
+					},
+					map[string]interface{}{
+						"id":    "456",
+						"alias": "B",
+					},
+				},
+			},
+			Expected: func() *alerts.CompoundConditionCreateInput {
+				description := "Test description"
+				titleTemplate := "{{compoundCondition.name}} triggered"
+				return &alerts.CompoundConditionCreateInput{
+					Name:              "test-compound-condition",
+					Enabled:           true,
+					TriggerExpression: "A AND B",
+					Description:       &description,
+					TitleTemplate:     &titleTemplate,
+					ComponentConditions: []alerts.ComponentConditionInput{
+						{ID: "123", Alias: "A"},
+						{ID: "456", Alias: "B"},
+					},
+				}
+			}(),
+		},
 		"with optional fields": {
 			Data: map[string]interface{}{
 				"name":                    "test-compound-condition",
@@ -129,6 +163,14 @@ func TestExpandAlertCompoundConditionCreateInput(t *testing.T) {
 					require.NotNil(t, expanded.ThresholdDuration)
 					assert.Equal(t, *tc.Expected.ThresholdDuration, *expanded.ThresholdDuration)
 				}
+				if tc.Expected.Description != nil {
+					require.NotNil(t, expanded.Description)
+					assert.Equal(t, *tc.Expected.Description, *expanded.Description)
+				}
+				if tc.Expected.TitleTemplate != nil {
+					require.NotNil(t, expanded.TitleTemplate)
+					assert.Equal(t, *tc.Expected.TitleTemplate, *expanded.TitleTemplate)
+				}
 			}
 		})
 	}
@@ -148,6 +190,8 @@ func TestFlattenAlertCompoundCondition(t *testing.T) {
 		ThresholdDuration:     120,
 		FacetMatchingBehavior: "FACETS_IGNORED",
 		EntityGuid:            "MTAxMzMyMDB8QUxFUlR8Q09ORGU5OfDEwMzQ1NTc",
+		Description:           "Test description",
+		TitleTemplate:         "{{compoundCondition.name}} triggered",
 		ComponentConditions: []alerts.ComponentCondition{
 			{
 				ID:    "123",
@@ -177,4 +221,6 @@ func TestFlattenAlertCompoundCondition(t *testing.T) {
 	assert.Equal(t, "FACETS_IGNORED", d.Get("facet_matching_behavior"))
 	assert.Equal(t, testAccountID, d.Get("account_id"))
 	assert.Equal(t, "MTAxMzMyMDB8QUxFUlR8Q09ORGU5OfDEwMzQ1NTc", d.Get("entity_guid"))
+	assert.Equal(t, "Test description", d.Get("description"))
+	assert.Equal(t, "{{compoundCondition.name}} triggered", d.Get("title_template"))
 }

--- a/website/docs/r/alert_compound_condition.html.markdown
+++ b/website/docs/r/alert_compound_condition.html.markdown
@@ -238,6 +238,8 @@ The following arguments are supported:
   - `FACETS_IGNORED` - (Default) Facets are not taken into consideration when determining when the compound alert condition activates
   - `FACETS_MATCH` - The compound alert condition will activate only when shared facets have matching values
 - `runbook_url` - (Optional) Runbook URL to display in notifications.
+- `description` - (Optional) **BETA PREVIEW: the `description` field is in limited release and only enabled for preview on a per-account basis.** The custom violation description.
+- `title_template` - (Optional) **BETA PREVIEW: the `title_template` field is in limited release and only enabled for preview on a per-account basis.** This field allows you to create a custom title to be used when incidents are opened by the condition. Setting this field will override the default title. Must be [Handlebars format](https://handlebarsjs.com/guide/).
 - `threshold_duration` - (Optional) The duration, in seconds, that the trigger expression must be true before the compound alert condition will activate. Between 30-86400 seconds.
 
 ### Component Conditions


### PR DESCRIPTION
## Issue Link

[NR-583583](https://new-relic.atlassian.net/browse/NR-583583)

## Goals

Add optional `description` and `title_template` attributes to the `newrelic_alert_compound_condition` Terraform resource, mirroring the existing pattern on `newrelic_nrql_alert_condition`. Both fields are behind the `DCON/compound_title_template_and_description_apis` feature flag until GA.

## Changes

- Added `description` and `title_template` optional schema attrs to `resource_newrelic_alert_compound_condition.go`
- Wired expand (create + update) and flatten in `structures_newrelic_alert_compound_condition.go`
- Added `with description and title_template` expand test case and flatten assertions in `structures_newrelic_alert_compound_condition_test.go`
- Added `TestAccNewRelicAlertCompoundCondition_TitleTemplateAndDescription` acceptance test (skipped until flag GA)
- Added BETA PREVIEW documentation for both fields

## Testing

- Structures unit tests: passing
- Acceptance test: skipped pending feature flag GA (remove `t.Skip` when flag is removed)
- Build: pending Go client release (see dependencies)

## Dependencies

- AGQL PR: https://source.datanerd.us/Alerting/alerts_graphql_service/pull/765
- Go client PR: https://github.com/newrelic/newrelic-client-go/pull/1435
- TODO: Run `go get github.com/newrelic/newrelic-client-go/v2@v2.X.Y && go mod tidy` once Go client PR is released

## Jira

NR-583583

[NR-583583]: https://new-relic.atlassian.net/browse/NR-583583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ