### PR TITLE
fix(cloud): remove gcp_v2 provider slug dependency and add GKE 1-min polling

### DIFF
--- a/examples/modules/cloud-integrations/gcp-dimensional-metrics-folder-iam/README.md
+++ b/examples/modules/cloud-integrations/gcp-dimensional-metrics-folder-iam/README.md
@@ -78,5 +78,5 @@ module "newrelic_gcp_dm" {
 
 ## Notes
 
-- **1-minute polling (Limited Preview):** `metrics_polling_interval` defaults to `300` s. A 60-second floor is in Limited Preview for `alloy_db`, `big_query`, `data_flow`, `data_proc`, `load_balancing`, `managed_kafka`, `pub_sub`, and `spanner`; set `metrics_polling_interval = 60` to enable it. All other services require `300`.
+- **1-minute polling (Limited Preview):** `metrics_polling_interval` defaults to `300` s. A 60-second floor is in Limited Preview for `alloy_db`, `big_query`, `data_flow`, `data_proc`, `kubernetes`, `load_balancing`, `managed_kafka`, `pub_sub`, and `spanner`; set `metrics_polling_interval = 60` to enable it. All other services require `300`.
 - **Write-only credential fields:** `audience` and `service_account_email` on `newrelic_cloud_gcp_link_account` are `ForceNew` and never returned by the API; changing them replaces the linked account.

--- a/examples/modules/cloud-integrations/gcp-dimensional-metrics-folder-iam/main.tf
+++ b/examples/modules/cloud-integrations/gcp-dimensional-metrics-folder-iam/main.tf
@@ -133,7 +133,7 @@ resource "newrelic_cloud_gcp_dm_integrations" "this" {
 
   # All services use metrics_polling_interval (default 300 s / 5 min).
   # 1-minute polling is in Limited Preview (LP) for the following services:
-  #   alloy_db, big_query, data_flow, data_proc, load_balancing,
+  #   alloy_db, big_query, data_flow, data_proc, kubernetes, load_balancing,
   #   managed_kafka, pub_sub, spanner
   # To enable 1-minute polling for those services, set:
   #   metrics_polling_interval = 60

--- a/examples/modules/cloud-integrations/gcp-dimensional-metrics-folder-iam/variables.tf
+++ b/examples/modules/cloud-integrations/gcp-dimensional-metrics-folder-iam/variables.tf
@@ -59,7 +59,7 @@ variable "metrics_polling_interval" {
   description = <<-EOT
     Polling interval in seconds applied to all enabled services. Default: 300 (5 minutes).
     Limited Preview (LP) note: 1-minute polling is in LP and available only for the following services:
-      alloy_db, big_query, data_flow, data_proc, load_balancing, managed_kafka, pub_sub, spanner
+      alloy_db, big_query, data_flow, data_proc, kubernetes, load_balancing, managed_kafka, pub_sub, spanner
     Set this variable to 60 to enable 1-minute polling across all services.
   EOT
 }
@@ -78,7 +78,7 @@ variable "enabled_services" {
       virtual_machines, vpc_access
 
     Services where 1-minute polling is in LP (set metrics_polling_interval = 60):
-      alloy_db, big_query, data_flow, data_proc, load_balancing,
+      alloy_db, big_query, data_flow, data_proc, kubernetes, load_balancing,
       managed_kafka, pub_sub, spanner
   EOT
 }

--- a/examples/modules/cloud-integrations/gcp-dimensional-metrics-multi-service/README.md
+++ b/examples/modules/cloud-integrations/gcp-dimensional-metrics-multi-service/README.md
@@ -61,7 +61,7 @@ module "newrelic_gcp_dm" {
 | `gcp_sa_project_id` | string | — | GCP project where the service account and WIF pool are created. |
 | `gcp_folder_id` | string | — | Numeric GCP folder ID (no `folders/` prefix). Folder-level IAM covers all projects in both groups. |
 | `analytics_projects` | map(string) | — | `display-name => project ID` for analytics projects (monitored for BigQuery, PubSub, Spanner, Storage, Dataflow, Dataproc). |
-| `compute_projects` | map(string) | — | `display-name => project ID` for compute projects (monitored for VMs, SQL, Cloud Run, Load Balancing, Functions, Kubernetes — Kubernetes is metrics only). |
+| `compute_projects` | map(string) | — | `display-name => project ID` for compute projects (monitored for VMs, SQL, Cloud Run, Load Balancing, Functions, Kubernetes — Kubernetes is metrics only, no entity support; also supports 1-minute polling in Limited Preview). |
 | `wif_pool_id` | string | — | ID for the Workload Identity Federation pool. |
 | `wif_provider_id` | string | — | ID for the OIDC provider inside the pool. |
 | `newrelic_sa_name` | string | — | Name for the impersonated GCP service account. |
@@ -79,6 +79,6 @@ module "newrelic_gcp_dm" {
 
 ## Notes
 
-- **1-minute polling (Limited Preview):** `metrics_polling_interval` defaults to `300` s. A 60-second floor is in Limited Preview for `big_query`, `data_flow`, `data_proc`, `load_balancing`, `pub_sub`, and `spanner`; set `metrics_polling_interval = 60` to enable it. All other services require `300`.
+- **1-minute polling (Limited Preview):** `metrics_polling_interval` defaults to `300` s. A 60-second floor is in Limited Preview for `big_query`, `data_flow`, `data_proc`, `kubernetes`, `load_balancing`, `pub_sub`, and `spanner`; set `metrics_polling_interval = 60` to enable it. All other services require `300`.
 - **Write-only credential fields:** `audience` and `service_account_email` on `newrelic_cloud_gcp_link_account` are `ForceNew` and never returned by the API; changing them replaces the linked account.
 - To change which services each group monitors, edit the `dm_integrations` blocks in `main.tf` for the analytics and compute resources.

--- a/examples/modules/cloud-integrations/gcp-dimensional-metrics-multi-service/main.tf
+++ b/examples/modules/cloud-integrations/gcp-dimensional-metrics-multi-service/main.tf
@@ -4,7 +4,8 @@
 # and folder-level IAM) used across two distinct project groups that each have
 # different monitoring needs:
 #   - analytics_projects: BigQuery, PubSub, Spanner, Storage, DataFlow, DataProc
-#   - compute_projects:   VMs, SQL, Cloud Run, Load Balancing, Functions, Kubernetes (metrics only, no entity support)
+#   - compute_projects:   VMs, SQL, Cloud Run, Load Balancing, Functions, Kubernetes (metrics only, no
+#                         entity support; also supports 1-minute polling in Limited Preview)
 #
 # Use this when: your GCP projects serve different workloads and you want to
 # enable only the relevant GCP services in New Relic per group, while sharing
@@ -147,7 +148,8 @@ resource "newrelic_cloud_gcp_dm_integrations" "analytics" {
 }
 
 # ── Group 2: Compute Projects ─────────────────────────────────────────────────
-# Enabled: VMs, SQL, Cloud Run, Load Balancing, Cloud Functions, Kubernetes (metrics only, no entity support)
+# Enabled: VMs, SQL, Cloud Run, Load Balancing, Cloud Functions, Kubernetes (metrics only, no entity
+# support; also supports 1-minute polling in Limited Preview)
 
 resource "newrelic_cloud_gcp_link_account" "compute" {
   for_each = var.compute_projects

--- a/examples/modules/cloud-integrations/gcp-dimensional-metrics-multi-service/variables.tf
+++ b/examples/modules/cloud-integrations/gcp-dimensional-metrics-multi-service/variables.tf
@@ -58,7 +58,8 @@ variable "compute_projects" {
   description = <<-EOT
     Map of display-name => GCP project ID for compute projects.
     New Relic will monitor VMs, SQL, Cloud Run, Load Balancing, Functions,
-    and Kubernetes (metrics only — no entity support).
+    and Kubernetes (metrics only — no entity support; also supports 1-minute
+    polling in Limited Preview).
     Example:
       {
         "compute-prod" = "my-compute-project-456"
@@ -72,7 +73,7 @@ variable "metrics_polling_interval" {
   description = <<-EOT
     Polling interval in seconds applied to all enabled services. Default: 300 (5 minutes).
     Limited Preview (LP) note: 1-minute polling is in LP and available only for the following services:
-      big_query, data_flow, data_proc, load_balancing, pub_sub, spanner
+      big_query, data_flow, data_proc, kubernetes, load_balancing, pub_sub, spanner
     Set this variable to 60 to enable 1-minute polling.
   EOT
 }

--- a/examples/modules/cloud-integrations/gcp-dimensional-metrics-project-iam/README.md
+++ b/examples/modules/cloud-integrations/gcp-dimensional-metrics-project-iam/README.md
@@ -76,5 +76,5 @@ module "newrelic_gcp_dm" {
 
 ## Notes
 
-- **1-minute polling (Limited Preview):** `metrics_polling_interval` defaults to `300` s. A 60-second floor is in Limited Preview for `alloy_db`, `big_query`, `data_flow`, `data_proc`, `load_balancing`, `managed_kafka`, `pub_sub`, and `spanner`; set `metrics_polling_interval = 60` to enable it. All other services require `300`.
+- **1-minute polling (Limited Preview):** `metrics_polling_interval` defaults to `300` s. A 60-second floor is in Limited Preview for `alloy_db`, `big_query`, `data_flow`, `data_proc`, `kubernetes`, `load_balancing`, `managed_kafka`, `pub_sub`, and `spanner`; set `metrics_polling_interval = 60` to enable it. All other services require `300`.
 - **Write-only credential fields:** `audience` and `service_account_email` on `newrelic_cloud_gcp_link_account` are `ForceNew` and never returned by the API; changing them replaces the linked account.

--- a/examples/modules/cloud-integrations/gcp-dimensional-metrics-project-iam/main.tf
+++ b/examples/modules/cloud-integrations/gcp-dimensional-metrics-project-iam/main.tf
@@ -137,7 +137,7 @@ resource "newrelic_cloud_gcp_dm_integrations" "this" {
 
   # All services use metrics_polling_interval (default 300 s / 5 min).
   # 1-minute polling is in Limited Preview (LP) for the following services:
-  #   alloy_db, big_query, data_flow, data_proc, load_balancing,
+  #   alloy_db, big_query, data_flow, data_proc, kubernetes, load_balancing,
   #   managed_kafka, pub_sub, spanner
   # To enable 1-minute polling for those services, set:
   #   metrics_polling_interval = 60

--- a/examples/modules/cloud-integrations/gcp-dimensional-metrics-project-iam/variables.tf
+++ b/examples/modules/cloud-integrations/gcp-dimensional-metrics-project-iam/variables.tf
@@ -55,7 +55,7 @@ variable "metrics_polling_interval" {
   description = <<-EOT
     Polling interval in seconds applied to all enabled services. Default: 300 (5 minutes).
     Limited Preview (LP) note: 1-minute polling is in LP and available only for the following services:
-      alloy_db, big_query, data_flow, data_proc, load_balancing, managed_kafka, pub_sub, spanner
+      alloy_db, big_query, data_flow, data_proc, kubernetes, load_balancing, managed_kafka, pub_sub, spanner
     Set this variable to 60 to enable 1-minute polling across all services.
   EOT
 }
@@ -74,7 +74,7 @@ variable "enabled_services" {
       virtual_machines, vpc_access
 
     Services where 1-minute polling is in LP (set metrics_polling_interval = 60):
-      alloy_db, big_query, data_flow, data_proc, load_balancing,
+      alloy_db, big_query, data_flow, data_proc, kubernetes, load_balancing,
       managed_kafka, pub_sub, spanner
   EOT
 }

--- a/examples/modules/cloud-integrations/gcp-dimensional-metrics-quickstart/README.md
+++ b/examples/modules/cloud-integrations/gcp-dimensional-metrics-quickstart/README.md
@@ -61,5 +61,5 @@ terraform apply
 
 ## Notes
 
-- **1-minute polling (Limited Preview):** `metrics_polling_interval` defaults to `300` s. A 60-second floor is in Limited Preview for `alloy_db`, `big_query`, `data_flow`, `data_proc`, `load_balancing`, `managed_kafka`, `pub_sub`, and `spanner`; set `metrics_polling_interval = 60` to enable it. All other services require `300`.
+- **1-minute polling (Limited Preview):** `metrics_polling_interval` defaults to `300` s. A 60-second floor is in Limited Preview for `alloy_db`, `big_query`, `data_flow`, `data_proc`, `kubernetes`, `load_balancing`, `managed_kafka`, `pub_sub`, and `spanner`; set `metrics_polling_interval = 60` to enable it. All other services require `300`.
 - **Write-only credential fields:** `audience` and `service_account_email` on `newrelic_cloud_gcp_link_account` are write-only, `ForceNew` fields — they're used to construct the WIF credential internally and are never returned by the API. To import an existing linked account, run `terraform import newrelic_cloud_gcp_link_account.main <linked_account_id>` and then `terraform apply` to reconcile those fields (the resource is replaced).

--- a/examples/modules/cloud-integrations/gcp-dimensional-metrics-quickstart/main.tf
+++ b/examples/modules/cloud-integrations/gcp-dimensional-metrics-quickstart/main.tf
@@ -126,7 +126,7 @@ resource "newrelic_cloud_gcp_dm_integrations" "main" {
   linked_account_id = newrelic_cloud_gcp_link_account.main.id
 
   # All GCP services default to 300 s polling. 1-minute polling is in Limited Preview (LP)
-  # and available only for: alloy_db, big_query, data_flow, data_proc, load_balancing,
+  # and available only for: alloy_db, big_query, data_flow, data_proc, kubernetes, load_balancing,
   # managed_kafka, pub_sub, spanner — set metrics_polling_interval = 60 to enable.
   ai_platform { metrics_polling_interval = var.metrics_polling_interval }
   alloy_db { metrics_polling_interval = var.metrics_polling_interval }
@@ -145,7 +145,7 @@ resource "newrelic_cloud_gcp_dm_integrations" "main" {
   functions { metrics_polling_interval = var.metrics_polling_interval }
   interconnect { metrics_polling_interval = var.metrics_polling_interval }
   istio { metrics_polling_interval = var.metrics_polling_interval }      # DM only, metrics only
-  kubernetes { metrics_polling_interval = var.metrics_polling_interval } # metrics only, no entity support
+  kubernetes { metrics_polling_interval = var.metrics_polling_interval } # metrics only, no entity support; supports 1m polling (LP)
   load_balancing { metrics_polling_interval = var.metrics_polling_interval }
   mem_cache { metrics_polling_interval = var.metrics_polling_interval }
   pub_sub { metrics_polling_interval = var.metrics_polling_interval }

--- a/examples/modules/cloud-integrations/gcp-dimensional-metrics-quickstart/variables.tf
+++ b/examples/modules/cloud-integrations/gcp-dimensional-metrics-quickstart/variables.tf
@@ -55,7 +55,7 @@ variable "metrics_polling_interval" {
   description = <<-EOT
     How often (in seconds) New Relic polls each service for metrics. Default: 300 (5 minutes).
     1-minute polling is in Limited Preview (LP) and available only for:
-      alloy_db, big_query, data_flow, data_proc, load_balancing, managed_kafka, pub_sub, spanner
+      alloy_db, big_query, data_flow, data_proc, kubernetes, load_balancing, managed_kafka, pub_sub, spanner
     Set to 60 to enable 1-minute polling for those services.
   EOT
 }

--- a/go.mod
+++ b/go.mod
@@ -69,3 +69,8 @@ require (
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 )
+
+// TEMPORARY: points at unmerged https://github.com/newrelic/newrelic-client-go/pull/1441
+// (adds CloudLinkedAccount.HasDimensionalMetrics). Remove this replace and bump the
+// require above to the official release once #1441 merges and is tagged.
+replace github.com/newrelic/newrelic-client-go/v2 => github.com/sarvetiNr/newrelic-client-go/v2 v2.0.0-20260804112544-60d23544cccd

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,6 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S3bfBjY=
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
-github.com/newrelic/newrelic-client-go/v2 v2.92.0 h1:uuouhT5vEflJ0uwLkL4kNoBP+1JXV1yBbll4f3lkPh4=
-github.com/newrelic/newrelic-client-go/v2 v2.92.0/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
@@ -179,6 +177,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/robertkrimen/otto v0.5.1 h1:avDI4ToRk8k1hppLdYFTuuzND41n37vPGJU7547dGf0=
 github.com/robertkrimen/otto v0.5.1/go.mod h1:bS433I4Q9p+E5pZLu7r17vP6FkE6/wLxBdmKjoqJXF8=
+github.com/sarvetiNr/newrelic-client-go/v2 v2.0.0-20260804112544-60d23544cccd h1:Rpls8PfrFlXtIHMd7HVaPMpTJnhP6A3xYcrOZQ7hNDM=
+github.com/sarvetiNr/newrelic-client-go/v2 v2.0.0-20260804112544-60d23544cccd/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/integration_test_utilities/integration_test_mappings.yaml
+++ b/integration_test_utilities/integration_test_mappings.yaml
@@ -40,6 +40,9 @@ data_source_newrelic_cloud_account.go:
 data_source_newrelic_cloud_account_test.go:
   test: true
   product_mapping: CLOUD
+data_source_newrelic_cloud_account_unit_test.go:
+  test: true
+  product_mapping: CLOUD
 data_source_newrelic_entity.go:
   test: false
   product_mapping: ENTITY

--- a/newrelic/data_source_newrelic_cloud_account.go
+++ b/newrelic/data_source_newrelic_cloud_account.go
@@ -55,7 +55,7 @@ func dataSourceNewRelicCloudAccountRead(ctx context.Context, d *schema.ResourceD
 
 	// is_dimensional_metrics only applies to GCP. Data sources do not run
 	// CustomizeDiff, so this relationship is validated here.
-	if isDM && !strings.EqualFold(provider, "gcp") {
+	if !isDimensionalMetricsProviderValid(provider, isDM) {
 		return diag.Errorf("`is_dimensional_metrics` can only be set when `cloud_provider` is \"gcp\"")
 	}
 
@@ -67,13 +67,7 @@ func dataSourceNewRelicCloudAccountRead(ctx context.Context, d *schema.ResourceD
 	// GCP linked accounts are returned together regardless of whether they use
 	// Dimensional Metrics; HasDimensionalMetrics disambiguates them so a lookup
 	// for one kind never matches an account of the other kind.
-	var account *cloud.CloudLinkedAccount
-	for _, a := range *accounts {
-		if a.NrAccountId == accountID && strings.EqualFold(a.Name, name) && a.HasDimensionalMetrics == isDM {
-			account = &a
-			break
-		}
-	}
+	account := findCloudLinkedAccount(*accounts, accountID, name, isDM)
 
 	if account == nil {
 		if isDM {
@@ -85,6 +79,25 @@ func dataSourceNewRelicCloudAccountRead(ctx context.Context, d *schema.ResourceD
 	d.SetId(strconv.Itoa(account.ID))
 
 	return diag.FromErr(flattenCloudAccount(account, d))
+}
+
+// isDimensionalMetricsProviderValid reports whether is_dimensional_metrics may be
+// set for the given cloud_provider value; it can only be true for GCP.
+func isDimensionalMetricsProviderValid(provider string, isDM bool) bool {
+	return !isDM || strings.EqualFold(provider, "gcp")
+}
+
+// findCloudLinkedAccount returns the linked account matching accountID and name
+// whose HasDimensionalMetrics flag equals isDM, so a Dimensional Metrics lookup
+// never matches a legacy account of the same name (and vice versa). Returns nil
+// if there is no such match.
+func findCloudLinkedAccount(accounts []cloud.CloudLinkedAccount, accountID int, name string, isDM bool) *cloud.CloudLinkedAccount {
+	for _, a := range accounts {
+		if a.NrAccountId == accountID && strings.EqualFold(a.Name, name) && a.HasDimensionalMetrics == isDM {
+			return &a
+		}
+	}
+	return nil
 }
 
 func flattenCloudAccount(account *cloud.CloudLinkedAccount, d *schema.ResourceData) error {

--- a/newrelic/data_source_newrelic_cloud_account.go
+++ b/newrelic/data_source_newrelic_cloud_account.go
@@ -36,7 +36,7 @@ func dataSourceNewRelicCloudAccount() *schema.Resource {
 				Optional: true,
 				Default:  false,
 				Description: "Set to true when looking up a GCP Dimensional Metrics linked account " +
-					"(cloud_provider must be \"gcp\"). Internally uses the gcp_v2 provider slug.",
+					"(cloud_provider must be \"gcp\").",
 			},
 		},
 	}
@@ -53,14 +53,10 @@ func dataSourceNewRelicCloudAccountRead(ctx context.Context, d *schema.ResourceD
 	accountID := selectAccountID(cfg, d)
 	isDM := d.Get("is_dimensional_metrics").(bool)
 
-	// is_dimensional_metrics only applies to GCP; it selects the "gcp_v2" provider
-	// slug under which GCP Dimensional Metrics linked accounts are stored. Data
-	// sources do not run CustomizeDiff, so this relationship is validated here.
-	if isDM {
-		if !strings.EqualFold(provider, "gcp") {
-			return diag.Errorf("`is_dimensional_metrics` can only be set when `cloud_provider` is \"gcp\"")
-		}
-		provider = "gcp_v2"
+	// is_dimensional_metrics only applies to GCP. Data sources do not run
+	// CustomizeDiff, so this relationship is validated here.
+	if isDM && !strings.EqualFold(provider, "gcp") {
+		return diag.Errorf("`is_dimensional_metrics` can only be set when `cloud_provider` is \"gcp\"")
 	}
 
 	accounts, err := client.Cloud.GetLinkedAccountsWithContext(ctx, provider)
@@ -68,9 +64,12 @@ func dataSourceNewRelicCloudAccountRead(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
+	// GCP linked accounts are returned together regardless of whether they use
+	// Dimensional Metrics; HasDimensionalMetrics disambiguates them so a lookup
+	// for one kind never matches an account of the other kind.
 	var account *cloud.CloudLinkedAccount
 	for _, a := range *accounts {
-		if a.NrAccountId == accountID && strings.EqualFold(a.Name, name) {
+		if a.NrAccountId == accountID && strings.EqualFold(a.Name, name) && a.HasDimensionalMetrics == isDM {
 			account = &a
 			break
 		}

--- a/newrelic/data_source_newrelic_cloud_account_unit_test.go
+++ b/newrelic/data_source_newrelic_cloud_account_unit_test.go
@@ -1,0 +1,75 @@
+//go:build unit
+
+package newrelic
+
+import (
+	"testing"
+
+	"github.com/newrelic/newrelic-client-go/v2/pkg/cloud"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsDimensionalMetricsProviderValid(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		provider string
+		isDM     bool
+		expected bool
+	}{
+		{name: "not DM, any provider is valid", provider: "aws", isDM: false, expected: true},
+		{name: "DM with gcp provider is valid", provider: "gcp", isDM: true, expected: true},
+		{name: "DM with gcp provider is valid case-insensitive", provider: "GCP", isDM: true, expected: true},
+		{name: "DM with non-gcp provider is invalid", provider: "aws", isDM: true, expected: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, isDimensionalMetricsProviderValid(tc.provider, tc.isDM))
+		})
+	}
+}
+
+func TestFindCloudLinkedAccount(t *testing.T) {
+	t.Parallel()
+
+	accounts := []cloud.CloudLinkedAccount{
+		{ID: 1, NrAccountId: 100, Name: "legacy-account", HasDimensionalMetrics: false},
+		{ID: 2, NrAccountId: 100, Name: "dm-account", HasDimensionalMetrics: true},
+		{ID: 3, NrAccountId: 200, Name: "dm-account", HasDimensionalMetrics: true},
+	}
+
+	t.Run("matches legacy account when isDM is false", func(t *testing.T) {
+		result := findCloudLinkedAccount(accounts, 100, "legacy-account", false)
+		require.NotNil(t, result)
+		require.Equal(t, 1, result.ID)
+	})
+
+	t.Run("matches dimensional metrics account when isDM is true", func(t *testing.T) {
+		result := findCloudLinkedAccount(accounts, 100, "dm-account", true)
+		require.NotNil(t, result)
+		require.Equal(t, 2, result.ID)
+	})
+
+	t.Run("does not match a same-named account of the wrong kind", func(t *testing.T) {
+		result := findCloudLinkedAccount(accounts, 100, "dm-account", false)
+		require.Nil(t, result)
+	})
+
+	t.Run("matches name case-insensitively", func(t *testing.T) {
+		result := findCloudLinkedAccount(accounts, 200, "DM-Account", true)
+		require.NotNil(t, result)
+		require.Equal(t, 3, result.ID)
+	})
+
+	t.Run("returns nil when account id does not match", func(t *testing.T) {
+		result := findCloudLinkedAccount(accounts, 999, "dm-account", true)
+		require.Nil(t, result)
+	})
+
+	t.Run("returns nil for empty account list", func(t *testing.T) {
+		result := findCloudLinkedAccount(nil, 100, "dm-account", true)
+		require.Nil(t, result)
+	})
+}

--- a/newrelic/resource_newrelic_cloud_gcp_link_account.go
+++ b/newrelic/resource_newrelic_cloud_gcp_link_account.go
@@ -42,7 +42,7 @@ func resourceNewRelicCloudGcpLinkAccount() *schema.Resource {
 			},
 			// use_workload_identity_federation explicitly selects GCP Dimensional Metrics (v2)
 			// keyless linking via Workload Identity Federation (WIF). When true, the
-			// resource authenticates via WIF and links under the gcp_v2 provider, and
+			// resource authenticates via WIF and links the account for Dimensional Metrics, and
 			// audience + service_account_email are required. When false (the default),
 			// the account is linked using the legacy service-account-key flow.
 			"use_workload_identity_federation": {
@@ -241,7 +241,7 @@ func resourceNewRelicCloudGcpLinkAccountRead(ctx context.Context, d *schema.Reso
 		return diag.FromErr(convErr)
 	}
 
-	// Both WIF (gcp_v2) and legacy accounts are read through the Go Client. For
+	// Both WIF (Dimensional Metrics) and legacy accounts are read through the Go Client. For
 	// WIF-linked accounts, audience and service_account_email are write-only
 	// (ForceNew) and never returned by the API, so they are retained from state.
 	linkedAccount, err := client.Cloud.GetLinkedAccountWithContext(ctx, accountID, linkedAccountID)

--- a/newrelic/structures_newrelic_cloud_gcp_dm_integrations.go
+++ b/newrelic/structures_newrelic_cloud_gcp_dm_integrations.go
@@ -14,7 +14,7 @@ import (
 // The schema, the configure input, the disable input, AND the read/flatten are
 // all derived from this one table, so adding a service is a one-line change.
 //
-// On a GCP Dimensional Metrics (gcp_v2) linked account, the backend returns every
+// On a GCP Dimensional Metrics linked account, the backend returns every
 // integration as a CloudGcpGenericIntegration identified by its service `slug`
 // (e.g. "gcp_bigquery"); the `slug` field below is how the read maps a returned
 // integration back to its Terraform block.
@@ -30,7 +30,7 @@ type gcpDmServiceValues struct {
 // gcpDmService describes one GCP service block.
 type gcpDmService struct {
 	key         string // Terraform schema block key, e.g. "big_query"
-	slug        string // backend CloudService.Slug on gcp_v2 accounts, e.g. "gcp_bigquery"
+	slug        string // backend CloudService.Slug on Dimensional Metrics accounts, e.g. "gcp_bigquery"
 	description string
 	// configure sets this service's typed input slice on the configure payload.
 	configure func(in *cloud.CloudGcpIntegrationsInput, values gcpDmServiceValues)
@@ -421,7 +421,7 @@ func expandCloudGcpDmIntegrationsInput(d *schema.ResourceData, linkedAccountID i
 }
 
 // flattenGcpDmIntegrations writes the backend state back into the resource so drift
-// is detected. On a gcp_v2 linked account every integration is returned as a
+// is detected. On a Dimensional Metrics linked account every integration is returned as a
 // *cloud.CloudGcpGenericIntegration identified by its service slug; each is mapped
 // back to its Terraform block. Blocks with no matching integration are cleared so an
 // integration removed outside Terraform surfaces as drift.

--- a/website/docs/d/cloud_account.html.markdown
+++ b/website/docs/d/cloud_account.html.markdown
@@ -23,7 +23,7 @@ data "newrelic_cloud_account" "account" {
 
 ### GCP Dimensional Metrics account lookup
 
-To look up a GCP account linked for **GCP Dimensional Metrics** (keyless / Workload Identity Federation), set `cloud_provider = "gcp"` and `is_dimensional_metrics = true`. These accounts are stored internally under the `gcp_v2` provider slug, and this flag tells the data source to look them up there instead of under the legacy `gcp` provider.
+To look up a GCP account linked for **GCP Dimensional Metrics** (keyless / Workload Identity Federation), set `cloud_provider = "gcp"` and `is_dimensional_metrics = true`. This flag tells the data source to match only Dimensional Metrics linked accounts, distinguishing them from legacy GCP integration accounts of the same name.
 
 ```hcl
 data "newrelic_cloud_account" "gcp_dm_account" {
@@ -41,4 +41,4 @@ The following arguments are supported:
 * `account_id` - (Optional) The account ID in New Relic.
 * `cloud_provider` - (Required) The cloud provider of the account (aws, gcp, azure, etc)
 * `name` - (Required) The cloud account name in New Relic.
-* `is_dimensional_metrics` - (Optional) Set to `true` to look up a GCP **Dimensional Metrics** (keyless / Workload Identity Federation) linked account, which is stored internally under the `gcp_v2` provider slug. Can only be used when `cloud_provider` is `"gcp"`. Defaults to `false`.
+* `is_dimensional_metrics` - (Optional) Set to `true` to look up a GCP **Dimensional Metrics** (keyless / Workload Identity Federation) linked account, as opposed to a legacy GCP integration account of the same name. Can only be used when `cloud_provider` is `"gcp"`. Defaults to `false`.

--- a/website/docs/guides/cloud_integrations_guide.html.markdown
+++ b/website/docs/guides/cloud_integrations_guide.html.markdown
@@ -251,9 +251,9 @@ The following GCP services are supported by the `newrelic_cloud_gcp_dm_integrati
 | `Virtual Machines`     | `VPC Access`              |                          |
 | `Firebase Auth` *(DM only)* | `Firebase Vertex AI` *(DM only, metrics only)* | `Managed Kafka` *(DM only)* (supports 1m polling) |
 | `Memorystore` *(DM only)*   | `Firebase App Hosting` *(DM only, metrics only)* | `Istio` *(DM only, metrics only)* |
-| `API Gateway` *(DM only)* | `Kubernetes Engine` *(metrics only)* |                  |
+| `API Gateway` *(DM only)* | `Kubernetes Engine` *(metrics only)* (supports 1m polling) |                  |
 
--> **NOTE:** Services marked *(supports 1m polling)* support a `metrics_polling_interval` as low as **60 seconds**. 1-minute polling for these services is in **Limited Preview (LP)** and available only for: `alloy_db`, `big_query`, `data_flow`, `data_proc`, `load_balancing`, `managed_kafka`, `pub_sub`, and `spanner`. All other services have a **300-second** minimum. Services marked *(DM only)* are only available in the Dimensional Metrics integration. Services marked *(metrics only)* produce metrics but do not create entities in the New Relic entity explorer.
+-> **NOTE:** Services marked *(supports 1m polling)* support a `metrics_polling_interval` as low as **60 seconds**. 1-minute polling for these services is in **Limited Preview (LP)** and available only for: `alloy_db`, `big_query`, `data_flow`, `data_proc`, `kubernetes`, `load_balancing`, `managed_kafka`, `pub_sub`, and `spanner`. All other services have a **300-second** minimum. Services marked *(DM only)* are only available in the Dimensional Metrics integration. Services marked *(metrics only)* produce metrics but do not create entities in the New Relic entity explorer.
 
 #### Prerequisites
 

--- a/website/docs/r/cloud_gcp_dm_integrations.html.markdown
+++ b/website/docs/r/cloud_gcp_dm_integrations.html.markdown
@@ -45,7 +45,6 @@ resource "newrelic_cloud_gcp_dm_integrations" "example" {
   functions        { metrics_polling_interval = 300 }
   interconnect     { metrics_polling_interval = 300 }
   istio            { metrics_polling_interval = 300 }
-  kubernetes       { metrics_polling_interval = 300 }
   mem_cache        { metrics_polling_interval = 300 }
   memory_store     { metrics_polling_interval = 300 }
   redis            { metrics_polling_interval = 300 }
@@ -62,6 +61,7 @@ resource "newrelic_cloud_gcp_dm_integrations" "example" {
   big_query      { metrics_polling_interval = 60 }
   data_flow      { metrics_polling_interval = 60 }
   data_proc      { metrics_polling_interval = 60 }
+  kubernetes     { metrics_polling_interval = 60 }
   load_balancing { metrics_polling_interval = 60 }
   managed_kafka  { metrics_polling_interval = 60 }
   pub_sub        { metrics_polling_interval = 60 }
@@ -93,7 +93,6 @@ resource "newrelic_cloud_gcp_dm_integrations" "example" {
 * `functions` - (Optional) Cloud Functions integration. See [Integration blocks](#integration-blocks) below.
 * `interconnect` - (Optional) Cloud Interconnect integration. See [Integration blocks](#integration-blocks) below.
 * `istio` - (Optional) Istio integration (DM only, metrics only — no entity support). See [Integration blocks](#integration-blocks) below.
-* `kubernetes` - (Optional) Kubernetes Engine integration (metrics only — no entity support). See [Integration blocks](#integration-blocks) below.
 * `mem_cache` - (Optional) Memcache integration. See [Integration blocks](#integration-blocks) below.
 * `memory_store` - (Optional) Memorystore integration (DM only). See [Integration blocks](#integration-blocks) below.
 * `redis` - (Optional) Memorystore for Redis integration. See [Integration blocks](#integration-blocks) below.
@@ -114,6 +113,7 @@ The following services support a polling floor as low as **60 seconds**. 1-minut
 * `big_query` - (Optional) BigQuery integration. See [Integration blocks](#integration-blocks) below.
 * `data_flow` - (Optional) Dataflow integration. See [Integration blocks](#integration-blocks) below.
 * `data_proc` - (Optional) Dataproc integration. See [Integration blocks](#integration-blocks) below.
+* `kubernetes` - (Optional) Kubernetes Engine integration (metrics only — no entity support). See [Integration blocks](#integration-blocks) below.
 * `load_balancing` - (Optional) Cloud Load Balancing integration. See [Integration blocks](#integration-blocks) below.
 * `managed_kafka` - (Optional) Managed Apache Kafka integration (DM only). See [Integration blocks](#integration-blocks) below.
 * `pub_sub` - (Optional) Cloud Pub/Sub integration. See [Integration blocks](#integration-blocks) below.
@@ -123,7 +123,7 @@ The following services support a polling floor as low as **60 seconds**. 1-minut
 
 All integration blocks support the following argument:
 
-* `metrics_polling_interval` - (Optional) How often New Relic polls the service for metrics, **in seconds**. Minimum values: **60 s** for services where 1-minute polling is in Limited Preview (`alloy_db`, `big_query`, `data_flow`, `data_proc`, `load_balancing`, `managed_kafka`, `pub_sub`, `spanner`); **300 s** for all other services. All services accept the standard **300 s** interval.
+* `metrics_polling_interval` - (Optional) How often New Relic polls the service for metrics, **in seconds**. Minimum values: **60 s** for services where 1-minute polling is in Limited Preview (`alloy_db`, `big_query`, `data_flow`, `data_proc`, `kubernetes`, `load_balancing`, `managed_kafka`, `pub_sub`, `spanner`); **300 s** for all other services. All services accept the standard **300 s** interval.
 
 ## Attributes Reference
 

--- a/website/docs/r/cloud_gcp_link_account.html.markdown
+++ b/website/docs/r/cloud_gcp_link_account.html.markdown
@@ -36,7 +36,7 @@ resource "newrelic_cloud_gcp_link_account" "foo" {
 
 ### GCP Dimensional Metrics (keyless / WIF) linking
 
-To link a GCP project for **GCP Dimensional Metrics** using keyless authentication via Workload Identity Federation (WIF) instead of a service-account key, set `use_workload_identity_federation = true` and provide `audience` and `service_account_email`. When enabled, the resource authenticates via WIF and links the project under the Dimensional Metrics (`gcp_v2`) provider. Use this linked account with the [`newrelic_cloud_gcp_dm_integrations`](cloud_gcp_dm_integrations.html) resource.
+To link a GCP project for **GCP Dimensional Metrics** using keyless authentication via Workload Identity Federation (WIF) instead of a service-account key, set `use_workload_identity_federation = true` and provide `audience` and `service_account_email`. When enabled, the resource authenticates via WIF and links the project as a Dimensional Metrics account. Use this linked account with the [`newrelic_cloud_gcp_dm_integrations`](cloud_gcp_dm_integrations.html) resource.
 
 ```hcl
 resource "newrelic_cloud_gcp_link_account" "dm" {


### PR DESCRIPTION
## Summary
- Adds GKE/Kubernetes Engine to the 1-minute (Limited Preview) polling list for GCP Dimensional Metrics, alongside its existing metrics-only/no-entity-support status (resource doc, integrations guide, and all four `gcp-dimensional-metrics-*` example modules).
- Removes the `gcp_v2` internal provider-slug literal from `newrelic_cloud_account`'s data source logic and from all customer-facing docs/comments. The data source now queries with the given `cloud_provider` as-is and disambiguates Dimensional Metrics accounts from legacy ones using the linked account's own `HasDimensionalMetrics` flag instead of overriding the query filter to `"gcp_v2"`.

## :warning: Draft — blocked on an upstream client-go PR
`HasDimensionalMetrics` on `CloudLinkedAccount` does not exist in the currently released `newrelic-client-go` yet. `go.mod` has a **temporary** `replace` directive pointing at an unmerged fork commit for https://github.com/newrelic/newrelic-client-go/pull/1441, which adds this field.

**This must not be merged until:**
1. newrelic-client-go PR #1441 merges and a new version is tagged.
2. This PR's `go.mod`/`go.sum` are updated to depend on that official release instead of the fork commit (removing the `replace` directive).

Opening as draft now so the doc/code changes are visible and reviewable ahead of that.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet -tags CLOUD ./newrelic/...` passes (covers the `TestAcc*` files gated by the `integration || CLOUD` build tag)
- [ ] `TestAcc*` acceptance tests against live New Relic credentials (not run here — no `TF_ACC` credentials in this environment)
- [ ] Remove the temporary `go.mod` replace once newrelic-client-go #1441 ships, then re-verify build/tests