### PR TITLE
chore(deps): bump newrelic-client-go to v2.93.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.30.0
-	github.com/newrelic/newrelic-client-go/v2 v2.92.0
+	github.com/newrelic/newrelic-client-go/v2 v2.93.0
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 	gopkg.in/yaml.v3 v3.0.1
@@ -69,8 +69,3 @@ require (
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 )
-
-// TEMPORARY: points at unmerged https://github.com/newrelic/newrelic-client-go/pull/1441
-// (adds CloudLinkedAccount.HasDimensionalMetrics). Remove this replace and bump the
-// require above to the official release once #1441 merges and is tagged.
-replace github.com/newrelic/newrelic-client-go/v2 => github.com/sarvetiNr/newrelic-client-go/v2 v2.0.0-20260804112544-60d23544cccd

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S3bfBjY=
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
+github.com/newrelic/newrelic-client-go/v2 v2.93.0 h1:KLlR8m44D6fWDLU9HoBwZtEaltbZ4RJNxqjBzmxKIsg=
+github.com/newrelic/newrelic-client-go/v2 v2.93.0/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
@@ -177,8 +179,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/robertkrimen/otto v0.5.1 h1:avDI4ToRk8k1hppLdYFTuuzND41n37vPGJU7547dGf0=
 github.com/robertkrimen/otto v0.5.1/go.mod h1:bS433I4Q9p+E5pZLu7r17vP6FkE6/wLxBdmKjoqJXF8=
-github.com/sarvetiNr/newrelic-client-go/v2 v2.0.0-20260804112544-60d23544cccd h1:Rpls8PfrFlXtIHMd7HVaPMpTJnhP6A3xYcrOZQ7hNDM=
-github.com/sarvetiNr/newrelic-client-go/v2 v2.0.0-20260804112544-60d23544cccd/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=


### PR DESCRIPTION
## Summary

Replaces the temporary \`replace\` directive from #3141 that pointed at an unmerged personal fork (\`sarvetiNr/newrelic-client-go\`) with the official [v2.93.0](https://github.com/newrelic/newrelic-client-go/releases/tag/v2.93.0) release.

[newrelic/newrelic-client-go#1441](https://github.com/newrelic/newrelic-client-go/pull/1441) has been merged and released. It adds \`CloudLinkedAccount.HasDimensionalMetrics\` and \`CloudService.IsEntitySupported\` — the fields used by the \`findCloudLinkedAccount\` logic introduced in #3141 to disambiguate GCP Dimensional Metrics linked accounts from legacy ones without relying on the internal \`gcp_v2\` provider slug.

No functional change — this is purely a dependency cleanup.