### PR TITLE
docs(notifications): improve WORKFLOW_AUTOMATION destination example

### DIFF
--- a/website/docs/r/notification_destination.html.markdown
+++ b/website/docs/r/notification_destination.html.markdown
@@ -46,10 +46,9 @@ The following arguments are supported:
 * `type` - (Required) The type of destination.  One of: `EMAIL`, `SERVICE_NOW`, `SERVICE_NOW_APP`, `WEBHOOK`, `JIRA`, `MOBILE_PUSH`, `EVENT_BRIDGE`, `PAGERDUTY_ACCOUNT_INTEGRATION` or `PAGERDUTY_SERVICE_INTEGRATION`, `MICROSOFT_TEAMS`, `WORKFLOW_AUTOMATION`. The types `SLACK` and `SLACK_COLLABORATION` can only be imported, updated and destroyed (cannot be created via terraform).
 * `auth_basic` - (Optional) A nested block that describes a basic username and password authentication credentials. Only one auth_basic block is permitted per notification destination definition.  See [Nested auth_basic blocks](#nested-auth_basic-blocks) below for details.
 * `auth_token` - (Optional) A nested block that describes a token authentication credentials. Only one auth_token block is permitted per notification destination definition.  See [Nested auth_token blocks](#nested-auth_token-blocks) below for details.
-* `auth_custom_header` - (Optional) A nested block that describes a custom header authentication credentials. This field is required when the destination type is WORKFLOW_AUTOMATION and optional for other destination types. Multiple blocks are permitted per notification destination definition. [Nested auth_custom_header blocks](#nested-authcustomheader-blocks) below for details.
+* `auth_custom_header` - (Optional) A nested block that describes a custom header authentication credentials. This field is required when the destination type is WORKFLOW_AUTOMATION and optional for other destination types. Multiple blocks are permitted per notification destination definition. See [Nested auth_custom_header blocks](#nested-authcustomheader-blocks) below for details.
 * `secure_url` - (Optional) A nested block that describes a URL that contains sensitive data at the path or parameters. Only one secure_url block is permitted per notification destination definition. See [Nested secure_url blocks](#nested-secureurl-blocks) below for details.
 * `property` - (Required) A nested block that describes a notification destination property. See [Nested property blocks](#nested-property-blocks) below for details.
-* 
 
 ### Nested `auth_basic` blocks
 
@@ -114,7 +113,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ~> **NOTE:** We support all properties. The mentioned properties are just an example.
 
-#### [WORKFLOW_AUTOMATION]
+#### WORKFLOW_AUTOMATION
+
+~> **NOTE:** For `WORKFLOW_AUTOMATION` destinations, all authentication is handled through `auth_custom_header` — no property values are needed. The `property` block <u>must</u> still be included because the provider requires it for all destination types; use empty strings for both `key` and `value` as shown.
 
 ```hcl
 resource "newrelic_notification_destination" "foo" {
@@ -122,6 +123,10 @@ resource "newrelic_notification_destination" "foo" {
   name = "workflow-automation-destination-name"
   type = "WORKFLOW_AUTOMATION"
 
+  # This destination type authenticates via auth_custom_header below and
+  # does not use property values. The block still needs to be here because
+  # the provider schema requires it for every destination type;
+  # **leave both key and value as empty strings**.
   property {
     key   = ""
     value = ""


### PR DESCRIPTION
## Summary

`WORKFLOW_AUTOMATION` destinations authenticate purely via a custom header and carry no destination-specific properties. The existing example showed an empty `property {}` block with no context, which read as an oversight and prompted questions about what values to supply.

Changes:
- Added a comment inside the HCL example explaining why the block is there, with `**leave both key and value as empty strings**` called out explicitly
- Added a `~> NOTE` above the example reinforcing the same point in prose, with `must` underlined for emphasis
- Removed brackets from the `[WORKFLOW_AUTOMATION]` section heading, which were rendering as a broken link with no URL
- Added missing `See` prefix on the `auth_custom_header` argument description to match the style of all other arguments
- Removed a stray blank bullet in the argument reference section

## Test plan

- [ ] Docs-only change; no resource code modified
- [ ] Verified the empty `property {}` is intentional: the provider schema defines `property` as `Required` across all destination types with no per-type override

🤖 Generated with [Claude Code](https://claude.com/claude-code)