### PR TITLE
feat(dashboards): add support for widget `description` and `link`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,3 +69,5 @@ require (
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 )
+
+replace github.com/newrelic/newrelic-client-go/v2 => github.com/driimus/newrelic-client-go/v2 v2.93.2-0.20260816223630-d3d5b946d8ae

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/driimus/newrelic-client-go/v2 v2.93.2-0.20260816223630-d3d5b946d8ae h1:otmLd+BW8lB/VuqBh9eYO3k7rWSEgYgbZSft2PJNSWs=
+github.com/driimus/newrelic-client-go/v2 v2.93.2-0.20260816223630-d3d5b946d8ae/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/elazarl/goproxy v0.0.0-20231117061959-7cc037d33fb5 h1:m62nsMU279qRD9PQSWD1l66kmkXzuYcnVJqL4XLeV2M=
 github.com/elazarl/goproxy v0.0.0-20231117061959-7cc037d33fb5/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
@@ -167,8 +169,6 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S3bfBjY=
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
-github.com/newrelic/newrelic-client-go/v2 v2.93.1 h1:CaIc3K9wFg57dwKCpAo1PaydnXePB069wGTbS5z7Hec=
-github.com/newrelic/newrelic-client-go/v2 v2.93.1/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/newrelic/resource_newrelic_one_dashboard.go
+++ b/newrelic/resource_newrelic_one_dashboard.go
@@ -305,6 +305,26 @@ func dashboardWidgetSchemaBase() map[string]*schema.Schema {
 			Required:    true,
 			Description: "A title for the widget.",
 		},
+		"description": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Additional text that provides context about the widget, displayed as a tooltip when users point to the widget.",
+		},
+		"link": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "Makes the widget title clickable, allowing navigation to related dashboards, documentation, or external resources.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"url": {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "The URL to open when the widget title is clicked. Must use http:// or https:// protocol.",
+					},
+				},
+			},
+		},
 		"column": {
 			Type:     schema.TypeInt,
 			Required: true,

--- a/newrelic/resource_newrelic_one_dashboard_test.go
+++ b/newrelic/resource_newrelic_one_dashboard_test.go
@@ -306,6 +306,12 @@ func TestAccNewRelicOneDashboard_ChangeCheck(t *testing.T) {
 				Config: testAccCheckNewRelicOneDashboardConfig_OnePageFull(rName, strconv.Itoa(testAccountID)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicOneDashboardExists("newrelic_one_dashboard.bar", 0),
+					testAccCheckNewRelicOneDashboard_WidgetDescriptionAndLink(
+						"newrelic_one_dashboard.bar",
+						"table widget",
+						"Raw transaction events for the selected time window.",
+						"https://example.com/runbooks/transactions",
+					),
 				),
 			},
 			// Make lots of changes
@@ -313,6 +319,12 @@ func TestAccNewRelicOneDashboard_ChangeCheck(t *testing.T) {
 				Config: testAccCheckNewRelicOneDashboardConfig_OnePageFullChanged(rName, strconv.Itoa(testAccountID)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicOneDashboardExists("newrelic_one_dashboard.bar", 0),
+					testAccCheckNewRelicOneDashboard_WidgetDescriptionAndLink(
+						"newrelic_one_dashboard.bar",
+						"table widget with new name",
+						"Raw transaction events for the selected time window, updated.",
+						"https://example.com/runbooks/transactions-updated",
+					),
 				),
 			},
 		},
@@ -516,6 +528,62 @@ func testAccCheckNewRelicOneDashboard_BillboardCriticalWarning(resourceName stri
 
 			if !foundWidget {
 				return resource.NonRetryableError(fmt.Errorf("Unable to find widget: %s", widgetTitle))
+			}
+
+			return nil
+		})
+
+		if retryErr != nil {
+			return retryErr
+		}
+
+		return nil
+	}
+}
+
+// testAccCheckNewRelicOneDashboard_WidgetDescriptionAndLink fetches the dashboard resource and checks that
+// the widget matching widgetTitle has the expected description and link URL.
+func testAccCheckNewRelicOneDashboard_WidgetDescriptionAndLink(resourceName string, widgetTitle string, expectedDescription string, expectedLinkURL string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no dashboard ID is set")
+		}
+
+		client := testAccProvider.Meta().(*ProviderConfig).NewClient
+
+		retryErr := resource.RetryContext(context.Background(), 5*time.Second, func() *resource.RetryError {
+			found, err := client.Dashboards.GetDashboardEntity(common.EntityGUID(rs.Primary.ID))
+			if err != nil {
+				return resource.RetryableError(err)
+			}
+
+			if string(found.GUID) != rs.Primary.ID {
+				return resource.RetryableError(fmt.Errorf("dashboard not found: %v - %v", rs.Primary.ID, found))
+			}
+
+			foundWidget := false
+			for _, page := range found.Pages {
+				for _, widget := range page.Widgets {
+					if widget.Title != widgetTitle {
+						continue
+					}
+					foundWidget = true
+
+					if widget.Description != expectedDescription {
+						return resource.NonRetryableError(fmt.Errorf("expected description %q, got %q for widget: %s", expectedDescription, widget.Description, widgetTitle))
+					}
+					if widget.Link.URL != expectedLinkURL {
+						return resource.NonRetryableError(fmt.Errorf("expected link URL %q, got %q for widget: %s", expectedLinkURL, widget.Link.URL, widgetTitle))
+					}
+				}
+			}
+
+			if !foundWidget {
+				return resource.NonRetryableError(fmt.Errorf("unable to find widget: %s", widgetTitle))
 			}
 
 			return nil
@@ -1051,7 +1119,8 @@ func testAccCheckNewRelicOneDashboardConfig_PageFull(pageName string, accountID 
     }
 
 	widget_table {
-      title = "table widget"
+      title       = "table widget"
+      description = "Raw transaction events for the selected time window."
       row = 13
       column = 1
       nrql_query {
@@ -1063,6 +1132,9 @@ func testAccCheckNewRelicOneDashboardConfig_PageFull(pageName string, accountID 
 		column_name = "C1"
 		severity 	= "unavailable"
 	  }
+      link {
+        url = "https://example.com/runbooks/transactions"
+      }
       linked_entity_guids = ["MjUyMDUyOHxWSVp8REFTSEJPQVJEfDE2NDYzMDQ"]
       refresh_rate = 30000
       initial_sorting {
@@ -1356,7 +1428,8 @@ func testAccCheckNewRelicOneDashboardConfig_PageFullChanged(pageName string, acc
     }
 
     widget_table {
-      title = "table widget with new name"
+      title       = "table widget with new name"
+      description = "Raw transaction events for the selected time window, updated."
       row = 13
       column = 1
       nrql_query {
@@ -1367,7 +1440,10 @@ func testAccCheckNewRelicOneDashboardConfig_PageFullChanged(pageName string, acc
 		to 			= 200.4
 		column_name = "C1"
 		severity 	= "unavailable"
-	  }		
+	  }
+      link {
+        url = "https://example.com/runbooks/transactions-updated"
+      }
       linked_entity_guids = ["MjUyMDUyOHxWSVp8REFTSEJPQVJEfDE2NDYzMDQ"]
     }
 

--- a/newrelic/structures_newrelic_one_dashboard.go
+++ b/newrelic/structures_newrelic_one_dashboard.go
@@ -771,6 +771,12 @@ func expandDashboardWidgetInput(w map[string]interface{}, meta interface{}, visu
 	if i, ok := w["title"]; ok {
 		widget.Title = i.(string)
 	}
+	if i, ok := w["description"]; ok {
+		widget.Description = i.(string)
+	}
+	if i, ok := w["link"]; ok {
+		widget.Link = expandDashboardWidgetLink(i.([]interface{}))
+	}
 
 	if i, ok := w["linked_entity_guids"]; ok {
 		widget.LinkedEntityGUIDs = expandLinkedEntityGUIDs(i.([]interface{}))
@@ -1420,6 +1426,12 @@ func flattenDashboardWidget(in *entities.DashboardWidget, pageGUID string) (stri
 	out["width"] = in.Layout.Width
 	if in.Title != "" {
 		out["title"] = in.Title
+	}
+	if in.Description != "" {
+		out["description"] = in.Description
+	}
+	if in.Link.URL != "" {
+		out["link"] = flattenDashboardWidgetLink(in.Link)
 	}
 
 	// NOTE: The widget types that currently support linked entities
@@ -2254,4 +2266,30 @@ func flattenDashboardWidgetBillboardSettings(billboardSettings *dashboards.Dashb
 
 	billboardSettingsFetchedInterface = append(billboardSettingsFetchedInterface, billboardSettingsFetched)
 	return billboardSettingsFetchedInterface
+}
+
+func expandDashboardWidgetLink(linkData []interface{}) dashboards.DashboardWidgetLinkInput {
+	var link dashboards.DashboardWidgetLinkInput
+
+	if len(linkData) == 0 || linkData[0] == nil {
+		return link
+	}
+
+	linkMap := linkData[0].(map[string]interface{})
+
+	if url, ok := linkMap["url"]; ok {
+		link.URL = url.(string)
+	}
+
+	return link
+}
+
+func flattenDashboardWidgetLink(in entities.DashboardWidgetLink) []interface{} {
+	var linkFetched = make(map[string]interface{})
+
+	if in.URL != "" {
+		linkFetched["url"] = in.URL
+	}
+
+	return []interface{}{linkFetched}
 }

--- a/website/docs/r/one_dashboard.html.markdown
+++ b/website/docs/r/one_dashboard.html.markdown
@@ -22,13 +22,18 @@ resource "newrelic_one_dashboard" "exampledash" {
     name = "New Relic Terraform Example"
 
     widget_table {
-      title  = "List of Transactions"
-      row    = 1
-      column = 4
-      width  = 6
-      height = 3
+      title       = "List of Transactions"
+      description = "Raw transaction events for the selected time window."
+      row         = 1
+      column      = 4
+      width       = 6
+      height      = 3
 
       refresh_rate = 60000 // data refreshes every 60 seconds
+
+      link {
+        url = "https://example.com/runbooks/transactions"
+      }
 
       nrql_query {
         query = "FROM Transaction SELECT *"
@@ -321,6 +326,9 @@ In addition to all arguments above, the following attributes are exported:
 All nested `widget` blocks support the following common arguments:
 
   * `title` - (Required) A title for the widget.
+  * `description` - (Optional) Additional text that provides context about the widget, displayed as a tooltip when users point to the widget.
+  * `link` - (Optional) URL that makes the widget title clickable, allowing navigation to related dashboards, documentation, or external resources. Supports the following nested attribute(s) -
+    * `url` - (Required) The URL to open when the widget title is clicked. Must use `http://` or `https://` protocol and can't exceed 2,048 characters.
   * `row` - (Required) Row position of widget from top left, starting at `1`.
   * `column` - (Required) Column position of widget from top left, starting at `1`.
   * `width` - (Optional) Width of the widget.  Valid values are `1` to `12` inclusive.  Defaults to `4`.


### PR DESCRIPTION
# Description

> [!NOTE]
> Not ready for review. Depends on newrelic/newrelic-client-go#1445.
 
Closes #3155.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

1. Replace the local `newrelic-client-go` module with a version built from newrelic/newrelic-client-go#1445
2. Run the tests in this codebase
3. Build the updated provider locally (as suggested in [CONTRIBUTING.md](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#changes-to-the-provider)) and provision a dashboard containing widgets with `description` and `link` properties
