### PR TITLE
fix(fleet): paginate configuration lookup by name and flag duplicate matches

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/newrelic/terraform-provider-newrelic/v3
 
 go 1.26.0
 
+replace github.com/newrelic/newrelic-client-go/v2 => github.com/newrelic/newrelic-client-go/v2 v2.93.1-0.20260810175905-93cb87f7dc94
+
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,11 @@ module github.com/newrelic/terraform-provider-newrelic/v3
 
 go 1.26.0
 
-replace github.com/newrelic/newrelic-client-go/v2 => github.com/newrelic/newrelic-client-go/v2 v2.93.1-0.20260810175905-93cb87f7dc94
-
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/newrelic/go-agent/v3 v3.30.0
-	github.com/newrelic/newrelic-client-go/v2 v2.93.1
+	github.com/newrelic/newrelic-client-go/v2 v2.93.2
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S3bfBjY=
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
-github.com/newrelic/newrelic-client-go/v2 v2.93.1 h1:CaIc3K9wFg57dwKCpAo1PaydnXePB069wGTbS5z7Hec=
-github.com/newrelic/newrelic-client-go/v2 v2.93.1/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
+github.com/newrelic/newrelic-client-go/v2 v2.93.1-0.20260810175905-93cb87f7dc94 h1:LQlQrXBREfuwIN/dfFsBeLmfJhQg2wYL5+mrBLUEGUo=
+github.com/newrelic/newrelic-client-go/v2 v2.93.1-0.20260810175905-93cb87f7dc94/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S3bfBjY=
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
-github.com/newrelic/newrelic-client-go/v2 v2.93.1-0.20260810175905-93cb87f7dc94 h1:LQlQrXBREfuwIN/dfFsBeLmfJhQg2wYL5+mrBLUEGUo=
-github.com/newrelic/newrelic-client-go/v2 v2.93.1-0.20260810175905-93cb87f7dc94/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
+github.com/newrelic/newrelic-client-go/v2 v2.93.2 h1:OPrJPULKBH38VZVIrTsrMBx5iJURgT5obpzMKNNcBw4=
+github.com/newrelic/newrelic-client-go/v2 v2.93.2/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/integration_test_utilities/integration_test_mappings.yaml
+++ b/integration_test_utilities/integration_test_mappings.yaml
@@ -58,6 +58,9 @@ data_source_newrelic_fleet_configuration.go:
 data_source_newrelic_fleet_configuration_test.go:
   test: true
   product_mapping: FLEET
+data_source_newrelic_fleet_configuration_unit_test.go:
+  test: true
+  product_mapping: FLEET
 data_source_newrelic_fleet_members.go:
   test: false
   product_mapping: FLEET

--- a/newrelic/data_source_newrelic_fleet_configuration.go
+++ b/newrelic/data_source_newrelic_fleet_configuration.go
@@ -105,7 +105,7 @@ func dataSourceNewRelicFleetConfigurationRead(ctx context.Context, d *schema.Res
 		return diag.FromErr(setErr)
 	}
 
-	return nil
+	return diags
 }
 
 func dsFleetReadByConfigID(d *schema.ResourceData, client *nr.NewRelic, orgID string) (string, *fleetcontrol.GetConfigurationResponse, diag.Diagnostics) {

--- a/newrelic/data_source_newrelic_fleet_configuration.go
+++ b/newrelic/data_source_newrelic_fleet_configuration.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -143,36 +144,64 @@ func dsFleetReadByVersionGUID(d *schema.ResourceData, client *nr.NewRelic, orgID
 	return versionGUID, content, nil
 }
 
+// findFleetConfigurationsByName pages through every AGENT_CONFIGURATION entity via
+// GetEntitySearch, following NextCursor until exhausted, and returns every entity
+// whose name matches. The entity management entitySearch API only supports
+// type-based filtering, so name filtering has to happen client-side.
+func findFleetConfigurationsByName(client *nr.NewRelic, name string) ([]*fleetcontrol.EntityManagementAgentConfigurationEntity, error) {
+	var matches []*fleetcontrol.EntityManagementAgentConfigurationEntity
+	var cursor *string
+	for {
+		result, err := client.FleetControl.GetEntitySearch(
+			cursor, "type = 'AGENT_CONFIGURATION'",
+		)
+		if err != nil {
+			return nil, err
+		}
+		if result == nil {
+			break
+		}
+		for _, entity := range result.Entities {
+			if cfgEntity, ok := entity.(*fleetcontrol.EntityManagementAgentConfigurationEntity); ok && cfgEntity.Name == name {
+				matches = append(matches, cfgEntity)
+			}
+		}
+		if result.NextCursor == "" {
+			break
+		}
+		cursor = &result.NextCursor
+	}
+	return matches, nil
+}
+
 func dsFleetReadByName(d *schema.ResourceData, client *nr.NewRelic, orgID string) (string, string, *fleetcontrol.GetConfigurationResponse, diag.Diagnostics) {
 	name := d.Get("name").(string)
-	// The entity management entitySearch API only supports type-based filtering;
-	// name filtering is not a valid predicate. Fetch all AGENT_CONFIGURATION
-	// entities and filter by name client-side.
-	result, searchErr := client.FleetControl.GetEntitySearch(
-		"", "type = 'AGENT_CONFIGURATION'",
-	)
+
+	matches, searchErr := findFleetConfigurationsByName(client, name)
 	if searchErr != nil {
 		return "", orgID, nil, diag.FromErr(fmt.Errorf("failed to search fleet configurations by name %q: %w", name, searchErr))
 	}
-	if result == nil || len(result.Entities) == 0 {
+
+	if len(matches) == 0 {
 		return "", orgID, nil, diag.Errorf("no fleet configuration found with name %q", name)
 	}
 
-	var configID string
-	for _, entity := range result.Entities {
-		if cfgEntity, ok := entity.(*fleetcontrol.EntityManagementAgentConfigurationEntity); ok {
-			if cfgEntity.Name != name {
-				continue
-			}
-			configID = cfgEntity.ID
-			if cfgEntity.Scope.Type == "ORGANIZATION" {
-				orgID = cfgEntity.Scope.ID
-			}
-			break
-		}
+	configID := matches[0].ID
+	if matches[0].Scope.Type == "ORGANIZATION" {
+		orgID = matches[0].Scope.ID
 	}
-	if configID == "" {
-		return "", orgID, nil, diag.Errorf("no fleet configuration found with name %q", name)
+
+	var diags diag.Diagnostics
+	if len(matches) > 1 {
+		ids := make([]string, len(matches))
+		for i, m := range matches {
+			ids[i] = m.ID
+		}
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  fmt.Sprintf("found %d fleet configurations named %q; using the first match (%s)", len(matches), name, configID),
+			Detail:   fmt.Sprintf("configuration names are not guaranteed to be unique. All matching configuration IDs: %s. Use configuration_id instead of name to select a specific configuration deterministically.", strings.Join(ids, ", ")),
+		})
 	}
 
 	if setErr := d.Set("configuration_id", configID); setErr != nil {
@@ -185,11 +214,11 @@ func dsFleetReadByName(d *schema.ResourceData, client *nr.NewRelic, orgID string
 	if err != nil {
 		return "", orgID, nil, diag.FromErr(fmt.Errorf("failed to fetch fleet configuration %q (found via name %q): %w", configID, name, err))
 	}
-	if diags := setVersionFields(d, client, configID, orgID); diags != nil {
-		return "", orgID, nil, diags
+	if versionDiags := setVersionFields(d, client, configID, orgID); versionDiags != nil {
+		return "", orgID, nil, append(diags, versionDiags...)
 	}
 
-	return configID, orgID, content, nil
+	return configID, orgID, content, diags
 }
 
 // setVersionFields fetches all versions for configID and populates

--- a/newrelic/data_source_newrelic_fleet_configuration_unit_test.go
+++ b/newrelic/data_source_newrelic_fleet_configuration_unit_test.go
@@ -1,0 +1,138 @@
+//go:build unit
+
+package newrelic
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	nr "github.com/newrelic/newrelic-client-go/v2/newrelic"
+)
+
+// newMockEntitySearchServer serves a sequence of canned NerdGraph responses, one per
+// request, and records the raw request body of each request so tests can assert on
+// the GraphQL variables actually sent over the wire (in particular, the cursor).
+func newMockEntitySearchServer(t *testing.T, responses []string) (*nr.NewRelic, *[][]byte) {
+	var requestBodies [][]byte
+	callCount := 0
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		requestBodies = append(requestBodies, body)
+
+		require.Less(t, callCount, len(responses), "unexpected extra request to mock NerdGraph server")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err = w.Write([]byte(responses[callCount]))
+		require.NoError(t, err)
+
+		callCount++
+	}))
+	t.Cleanup(ts.Close)
+
+	client, err := nr.New(
+		nr.ConfigPersonalAPIKey("test-api-key"),
+		nr.ConfigNerdGraphBaseURL(ts.URL),
+	)
+	require.NoError(t, err)
+
+	return client, &requestBodies
+}
+
+func entitySearchPage(entitiesJSON, nextCursor string) string {
+	return `{"data":{"actor":{"entityManagement":{"entitySearch":{"entities":[` +
+		entitiesJSON + `],"nextCursor":"` + nextCursor + `"}}}}}`
+}
+
+func agentConfigEntityJSON(id, name, scopeType, scopeID string) string {
+	b, _ := json.Marshal(map[string]interface{}{
+		"__typename": "EntityManagementAgentConfigurationEntity",
+		"id":         id,
+		"name":       name,
+		"type":       "AGENT_CONFIGURATION",
+		"scope": map[string]string{
+			"id":   scopeID,
+			"type": scopeType,
+		},
+	})
+	return string(b)
+}
+
+type entitySearchRequestBody struct {
+	Variables map[string]interface{} `json:"variables"`
+}
+
+func TestUnitFindFleetConfigurationsByName_FollowsCursorAcrossPages(t *testing.T) {
+	t.Parallel()
+
+	page1 := entitySearchPage(agentConfigEntityJSON("cfg-other", "other-config", "ORGANIZATION", "org-1"), "page-2-cursor")
+	page2 := entitySearchPage(agentConfigEntityJSON("cfg-match", "target-config", "ORGANIZATION", "org-1"), "")
+
+	client, requestBodies := newMockEntitySearchServer(t, []string{page1, page2})
+
+	matches, err := findFleetConfigurationsByName(client, "target-config")
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+	assert.Equal(t, "cfg-match", matches[0].ID)
+
+	require.Len(t, *requestBodies, 2, "expected one request per page")
+
+	var firstReq, secondReq entitySearchRequestBody
+	require.NoError(t, json.Unmarshal((*requestBodies)[0], &firstReq))
+	require.NoError(t, json.Unmarshal((*requestBodies)[1], &secondReq))
+
+	assert.Nil(t, firstReq.Variables["cursor"], "first request should search from the beginning")
+	assert.Equal(t, "page-2-cursor", secondReq.Variables["cursor"], "second request should use the cursor returned by page 1")
+}
+
+func TestUnitFindFleetConfigurationsByName_MultipleMatchesAcrossPages(t *testing.T) {
+	t.Parallel()
+
+	page1 := entitySearchPage(agentConfigEntityJSON("cfg-1", "shared-name", "ORGANIZATION", "org-1"), "page-2-cursor")
+	page2 := entitySearchPage(agentConfigEntityJSON("cfg-2", "shared-name", "ORGANIZATION", "org-1"), "")
+
+	client, _ := newMockEntitySearchServer(t, []string{page1, page2})
+
+	matches, err := findFleetConfigurationsByName(client, "shared-name")
+	require.NoError(t, err)
+	require.Len(t, matches, 2, "matches with the same name on different pages should all be returned")
+
+	ids := []string{matches[0].ID, matches[1].ID}
+	assert.ElementsMatch(t, []string{"cfg-1", "cfg-2"}, ids)
+}
+
+func TestUnitFindFleetConfigurationsByName_NoMatch(t *testing.T) {
+	t.Parallel()
+
+	page1 := entitySearchPage(agentConfigEntityJSON("cfg-1", "unrelated-config", "ORGANIZATION", "org-1"), "")
+
+	client, _ := newMockEntitySearchServer(t, []string{page1})
+
+	matches, err := findFleetConfigurationsByName(client, "does-not-exist")
+	require.NoError(t, err)
+	assert.Empty(t, matches)
+}
+
+func TestUnitFindFleetConfigurationsByName_StopsWhenCursorEmpty(t *testing.T) {
+	t.Parallel()
+
+	// Only one page is registered; if the function kept paging past an empty
+	// nextCursor it would request a second page and the mock server would fail
+	// the test via the callCount bounds check in newMockEntitySearchServer.
+	page1 := entitySearchPage(agentConfigEntityJSON("cfg-1", "target-config", "ORGANIZATION", "org-1"), "")
+
+	client, requestBodies := newMockEntitySearchServer(t, []string{page1})
+
+	matches, err := findFleetConfigurationsByName(client, "target-config")
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+	assert.Len(t, *requestBodies, 1)
+}


### PR DESCRIPTION
# Description

Depends on [newrelic/newrelic-client-go#1442](https://github.com/newrelic/newrelic-client-go/pull/1442), which fixes `FleetControl.GetEntitySearch`'s cursor parameter — it was declared but never actually wired into the GraphQL query, so pagination silently never advanced. That PR changed `cursor` from `string` to `*string`, and has since merged and shipped in [v2.93.2](https://github.com/newrelic/newrelic-client-go/releases/tag/v2.93.2). `go.mod` now points at that real release.

Pulling that fix in surfaced three things here:

1. **Compile break**: `dsFleetReadByName` in `data_source_newrelic_fleet_configuration.go` called `GetEntitySearch("", ...)`; updated to `GetEntitySearch(nil, ...)`.
2. **Latent correctness gap**: with the client-go bug fixed, it became possible (and necessary) to actually page through results. `dsFleetReadByName` previously only ever inspected page one of `AGENT_CONFIGURATION` entities when resolving a fleet configuration by name — a config sitting on page two+ could never be found. It now follows `NextCursor` across every page via a new `findFleetConfigurationsByName` helper, and if more than one configuration shares the requested name, returns a warning diagnostic listing every matching config ID instead of silently picking one.
3. **Dropped diagnostic, found via live testing**: `dataSourceNewRelicFleetConfigurationRead` discarded the `diags` returned by `dsFleetReadByName` on its success path (`return nil` instead of `return diags`), so the "multiple matches" warning from point 2 never actually reached Terraform. This wasn't caught by the mocked unit tests, which only exercise `findFleetConfigurationsByName` in isolation — it surfaced when running a live `terraform apply` against a real account with two same-named fleet configurations (see [test results comment](https://github.com/newrelic/terraform-provider-newrelic/pull/3171#issuecomment-5359848769) below). Fixed by returning `diags` instead of `nil`.

Fixes # (n/a — discovered while validating newrelic/newrelic-client-go#1442 against this provider)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My commit message follows conventional commits
- [x] My code is formatted to Go standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## How to test this change?

- `go test -tags unit ./newrelic/... -run TestUnitFindFleetConfigurationsByName -v`
- Acceptance: `TestAccNewRelicFleetConfigurationDataSource_ByName` (requires `NEW_RELIC_FLEET_TEST_API_KEY`, `NEW_RELIC_FLEET_TEST_ACCOUNT_ID`, `NEW_RELIC_LICENSE_KEY`)
- **Live-tested** against a real account per [Development & Debugging in the New Relic Terraform Provider](https://newrelic.atlassian.net/wiki/spaces/VIRTUOSO/pages/4316004786): created two `newrelic_fleet_configuration` resources sharing a name, looked them up via the `by_name` data source using the dev-override local binary, confirmed real multi-page pagination (16s read against the account's existing `AGENT_CONFIGURATION` entities) and the duplicate-match warning surfacing correctly after fix #3 above. Full before/after output in [this comment](https://github.com/newrelic/terraform-provider-newrelic/pull/3171#issuecomment-5359848769). Test resources were destroyed afterward — nothing left in the account. (That live test predates the v2.93.2 bump and used the temporary replace-directive commit; the fix itself is unchanged by the version bump.)