### PR TITLE
docs(oci): document audit log ingestion via _Audit and _Audit_Include_Subcompartment (NR-605224)

### DIFF
--- a/website/docs/guides/cloud_integrations_guide.html.markdown
+++ b/website/docs/guides/cloud_integrations_guide.html.markdown
@@ -628,7 +628,7 @@ The example above shows a single‑element JSON array wrapped in quotes to satis
 
 #### OCI Audit Logs (Optional)
 
-OCI audit logs are emitted from a reserved log group named `_Audit` that OCI's `ListLogGroups` API intentionally never returns, so it does not appear in any log group listing. To ingest audit logs into New Relic, add a dedicated audit connector object to `connector_hub_details` and set `log_group_id` to one of the two OCI-reserved literals below. No log group OCID is needed — OCI resolves the literal to the correct log group internally.
+OCI provides two reserved literals that can be used as `log_group_id` values to ingest audit logs without requiring a log group OCID. See the [OCI Service Connector Hub documentation](https://docs.oracle.com/en-us/iaas/Content/connector-hub/overview.htm) for details. Add a dedicated audit connector object to `connector_hub_details` and set `log_group_id` to one of the values below.
 
 Two audit scoping modes are supported:
 

--- a/website/docs/guides/cloud_integrations_guide.html.markdown
+++ b/website/docs/guides/cloud_integrations_guide.html.markdown
@@ -626,6 +626,63 @@ The example above shows a single‑element JSON array wrapped in quotes to satis
 ]
 ```
 
+#### OCI Audit Logs (Optional)
+
+OCI audit logs are emitted from a reserved log group named `_Audit` that OCI's `ListLogGroups` API intentionally never returns, so it does not appear in any log group listing. To ingest audit logs into New Relic, add a dedicated audit connector object to `connector_hub_details` and set `log_group_id` to one of the two OCI-reserved literals below. No log group OCID is needed — OCI resolves the literal to the correct log group internally.
+
+Two audit scoping modes are supported:
+
+| Mode | `log_group_id` value | Coverage |
+|---|---|---|
+| Selected compartment only | `_Audit` | Audit logs from the chosen compartment only. Subcompartments are NOT included. |
+| Selected compartment + all subcompartments (recursive) | `_Audit_Include_Subcompartment` | Audit logs from the chosen compartment and every subcompartment beneath it. Tenancy-wide when the chosen compartment is the tenancy root. |
+
+`compartment_id` selects the root of the audit scope; the `log_group_id` literal decides whether recursion is enabled.
+
+Guidelines:
+* Keep the audit connector as a separate object in the `connector_hub_details` array — do not mix `_Audit` / `_Audit_Include_Subcompartment` log sources with business log sources in the same connector.
+* `display_name` must follow the convention `newrelic-logs-<region>-audit` (e.g. `newrelic-logs-us-ashburn-1-audit`).
+* On first creation, OCI may deliver up to 24 hours of historical audit events before switching to steady-state streaming — this is standard OCI Connector Hub behaviour.
+
+##### Example: tenancy-wide audit logs (root compartment, recursive)
+
+```json
+[
+  {
+    "display_name": "newrelic-logs-us-ashburn-1-audit",
+    "log_sources": [
+      { "compartment_id": "ocid1.tenancy.oc1..***", "log_group_id": "_Audit_Include_Subcompartment" }
+    ]
+  }
+]
+```
+
+##### Example: compartment subtree (non-root compartment, recursive)
+
+```json
+[
+  {
+    "display_name": "newrelic-logs-us-ashburn-1-audit",
+    "log_sources": [
+      { "compartment_id": "ocid1.compartment.oc1..***", "log_group_id": "_Audit_Include_Subcompartment" }
+    ]
+  }
+]
+```
+
+##### Example: selected compartment only (no recursion)
+
+```json
+[
+  {
+    "display_name": "newrelic-logs-us-ashburn-1-audit",
+    "log_sources": [
+      { "compartment_id": "ocid1.compartment.oc1..***", "log_group_id": "_Audit" }
+    ]
+  }
+]
+```
+
 > When implementing the New Relic OCI integration with Workload Identity Federation, the modules must be applied in this order: `wif-setup` (to create OAuth credentials) → `policy-setup` (to configure IAM policies and vault secrets) → `metrics-integration` or `logging-integration` (to set up data collection). The `wif-setup` module outputs (`client_id`, `client_secret`, `oci_domain_url`) must be provided as inputs to the `policy-setup` module. These modules can be run together in a single Terraform configuration if the dependency graph can be successfully resolved by referencing outputs from earlier modules. Failure to apply modules in the correct order will result in authorization errors when creating Service Connector Hub resources or invoking functions.
 
 [*Browse the OCI module source code on GitHub*](https://github.com/newrelic/terraform-provider-newrelic/tree/main/examples/modules/cloud-integrations/oci)

--- a/website/docs/guides/cloud_integrations_guide.html.markdown
+++ b/website/docs/guides/cloud_integrations_guide.html.markdown
@@ -639,45 +639,53 @@ Two audit scoping modes are supported:
 
 `compartment_id` selects the root of the audit scope; the `log_group_id` literal decides whether recursion is enabled.
 
-Guidelines:
-* Keep the audit connector as a separate object in the `connector_hub_details` array — do not mix `_Audit` / `_Audit_Include_Subcompartment` log sources with business log sources in the same connector.
-* `display_name` must follow the convention `newrelic-logs-<region>-audit` (e.g. `newrelic-logs-us-ashburn-1-audit`).
-* On first creation, OCI may deliver up to 24 hours of historical audit events before switching to steady-state streaming — this is standard OCI Connector Hub behaviour.
+- Keep the audit connector as a separate object in the `connector_hub_details` array — do not mix `_Audit` / `_Audit_Include_Subcompartment` log sources with business log sources in the same connector.
+- `display_name` must follow the convention `newrelic-logs-<region>-audit` (e.g. `newrelic-logs-us-ashburn-1-audit`).
+- On first creation, OCI may deliver up to 24 hours of historical audit events before switching to steady-state streaming — this is standard OCI Connector Hub behaviour.
 
-##### Example: tenancy-wide audit logs (root compartment, recursive)
+#### Example: tenancy-wide audit logs (root compartment, recursive)
 
 ```json
 [
   {
     "display_name": "newrelic-logs-us-ashburn-1-audit",
     "log_sources": [
-      { "compartment_id": "ocid1.tenancy.oc1..***", "log_group_id": "_Audit_Include_Subcompartment" }
+      {
+        "compartment_id": "ocid1.tenancy.oc1..***",
+        "log_group_id": "_Audit_Include_Subcompartment"
+      }
     ]
   }
 ]
 ```
 
-##### Example: compartment subtree (non-root compartment, recursive)
+#### Example: compartment subtree (non-root compartment, recursive)
 
 ```json
 [
   {
     "display_name": "newrelic-logs-us-ashburn-1-audit",
     "log_sources": [
-      { "compartment_id": "ocid1.compartment.oc1..***", "log_group_id": "_Audit_Include_Subcompartment" }
+      {
+        "compartment_id": "ocid1.compartment.oc1..***",
+        "log_group_id": "_Audit_Include_Subcompartment"
+      }
     ]
   }
 ]
 ```
 
-##### Example: selected compartment only (no recursion)
+#### Example: selected compartment only (no recursion)
 
 ```json
 [
   {
     "display_name": "newrelic-logs-us-ashburn-1-audit",
     "log_sources": [
-      { "compartment_id": "ocid1.compartment.oc1..***", "log_group_id": "_Audit" }
+      {
+        "compartment_id": "ocid1.compartment.oc1..***",
+        "log_group_id": "_Audit"
+      }
     ]
   }
 ]

--- a/website/docs/guides/cloud_integrations_guide.html.markdown
+++ b/website/docs/guides/cloud_integrations_guide.html.markdown
@@ -628,22 +628,22 @@ The example above shows a single‑element JSON array wrapped in quotes to satis
 
 #### OCI Audit Logs (Optional)
 
-OCI provides two reserved literals that can be used as `log_group_id` values to ingest audit logs without requiring a log group OCID. See the [OCI Service Connector Hub documentation](https://docs.oracle.com/en-us/iaas/Content/connector-hub/overview.htm) for details. Add a dedicated audit connector object to `connector_hub_details` and set `log_group_id` to one of the values below.
+To ingest OCI audit logs, add a dedicated audit connector object to `connector_hub_details` and set `log_group_id` to one of the two OCI-reserved literals below. For reference, see the [Oracle tutorial on centralizing OCI logs](https://docs.oracle.com/en/learn/centralize-oci-tenancies-logs/index.html).
 
 Two audit scoping modes are supported:
 
 | Mode | `log_group_id` value | Coverage |
 |---|---|---|
-| Selected compartment only | `_Audit` | Audit logs from the chosen compartment only. Subcompartments are NOT included. |
-| Selected compartment + all subcompartments (recursive) | `_Audit_Include_Subcompartment` | Audit logs from the chosen compartment and every subcompartment beneath it. Tenancy-wide when the chosen compartment is the tenancy root. |
+| Selected compartment only | `_Audit` | Audit logs from the chosen compartment only. Child compartments are NOT included. |
+| Selected compartment + all child compartments | `_Audit_Include_Subcompartment` | Audit logs from the chosen compartment and every child compartment beneath it. Tenancy-wide when the chosen compartment is the tenancy root. |
 
-`compartment_id` selects the root of the audit scope; the `log_group_id` literal decides whether recursion is enabled.
+`compartment_id` selects the root of the audit scope; the `log_group_id` literal decides whether child compartments are included.
 
 - Keep the audit connector as a separate object in the `connector_hub_details` array — do not mix `_Audit` / `_Audit_Include_Subcompartment` log sources with business log sources in the same connector.
 - `display_name` must follow the convention `newrelic-logs-<region>-audit` (e.g. `newrelic-logs-us-ashburn-1-audit`).
 - On first creation, OCI may deliver up to 24 hours of historical audit events before switching to steady-state streaming — this is standard OCI Connector Hub behaviour.
 
-#### Example: tenancy-wide audit logs (root compartment, recursive)
+#### Example: tenancy-wide audit logs (root compartment, include all child compartments)
 
 ```json
 [
@@ -659,7 +659,7 @@ Two audit scoping modes are supported:
 ]
 ```
 
-#### Example: compartment subtree (non-root compartment, recursive)
+#### Example: compartment + all child compartments (non-root compartment)
 
 ```json
 [
@@ -675,7 +675,7 @@ Two audit scoping modes are supported:
 ]
 ```
 
-#### Example: selected compartment only (no recursion)
+#### Example: selected compartment only (child compartments not included)
 
 ```json
 [


### PR DESCRIPTION
## Description

OCI audit logs live under a reserved log group `_Audit` that OCI's `ListLogGroups` API intentionally never returns — it never appears in any listing. Customers who want to ingest audit logs into New Relic via Terraform have no way to discover the required `log_group_id` values from the docs today.

This PR adds a new subsection **OCI Audit Logs (Optional)** to the OCI cloud integrations guide documenting both OCI-native scoping modes:

| Mode | `log_group_id` value | Coverage |
|---|---|---|
| Selected compartment only | `_Audit` | Chosen compartment only; subcompartments not included |
| Selected compartment + all subcompartments | `_Audit_Include_Subcompartment` | Chosen compartment and every subcompartment beneath it; tenancy-wide when compartment is the tenancy root |

Includes three worked JSON examples for `connector_hub_details` — tenancy-wide, compartment subtree, and single-compartment — that can be copy-pasted directly.

## Type of change

- [x] This change requires a documentation update

## Checklist

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have performed a self-review of my own changes
- [x] No code changes — the Terraform module already passes `log_group_id` straight through to `oci_sch_service_connector`

## How to test this change?

1. Browse to the updated section in the rendered docs preview
2. Copy any of the three JSON examples into a `connector_hub_details` value in the logs integration module
3. Apply via Terraform — OCI creates the audit connector and audit events start flowing to New Relic Logs

## References

- Jira: NR-605224
- Related: NR-601160 (ORM backend), NR-602241 (Manual journey wizard step)