### PR TITLE
fix(alerts): accept composite IDs in compound condition component_conditions

### DIFF
--- a/newrelic/resource_newrelic_alert_compound_condition.go
+++ b/newrelic/resource_newrelic_alert_compound_condition.go
@@ -59,7 +59,7 @@ func resourceNewRelicAlertCompoundCondition() *schema.Resource {
 						"id": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "The ID of the existing alert condition to use as a component. Composite IDs in the format `< policyID>:<conditionID>` (as exposed by `newrelic_nrql_alert_condition.<name>.id`) are accepted and reduced to the condition ID.",
+							Description: "The ID of the existing alert condition to use as a component. Composite IDs in the format `<policyID>:<conditionID>` (as exposed by `newrelic_nrql_alert_condition.<name>.id`) are accepted and reduced to the condition ID.",
 							StateFunc: func(v interface{}) string {
 								return normalizeComponentConditionID(v.(string))
 							},

--- a/newrelic/resource_newrelic_alert_compound_condition.go
+++ b/newrelic/resource_newrelic_alert_compound_condition.go
@@ -59,7 +59,10 @@ func resourceNewRelicAlertCompoundCondition() *schema.Resource {
 						"id": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "The ID of the existing alert condition to use as a component.",
+							Description: "The ID of the existing alert condition to use as a component. Composite IDs in the format `<accountID>:<conditionID>` (as exposed by `newrelic_nrql_alert_condition.<name>.id`) are accepted and reduced to the condition ID.",
+							StateFunc: func(v interface{}) string {
+								return normalizeComponentConditionID(v.(string))
+							},
 						},
 						"alias": {
 							Type:        schema.TypeString,

--- a/newrelic/resource_newrelic_alert_compound_condition.go
+++ b/newrelic/resource_newrelic_alert_compound_condition.go
@@ -59,7 +59,7 @@ func resourceNewRelicAlertCompoundCondition() *schema.Resource {
 						"id": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "The ID of the existing alert condition to use as a component. Composite IDs in the format `<accountID>:<conditionID>` (as exposed by `newrelic_nrql_alert_condition.<name>.id`) are accepted and reduced to the condition ID.",
+							Description: "The ID of the existing alert condition to use as a component. Composite IDs in the format `< policyID>:<conditionID>` (as exposed by `newrelic_nrql_alert_condition.<name>.id`) are accepted and reduced to the condition ID.",
 							StateFunc: func(v interface{}) string {
 								return normalizeComponentConditionID(v.(string))
 							},

--- a/newrelic/structures_newrelic_alert_compound_condition.go
+++ b/newrelic/structures_newrelic_alert_compound_condition.go
@@ -10,12 +10,12 @@ import (
 	"github.com/newrelic/newrelic-client-go/v2/pkg/alerts"
 )
 
-// componentConditionCompositeIDRegex matches the composite "< policyID>:<conditionID>"
+// componentConditionCompositeIDRegex matches the composite "<policyID>:<conditionID>"
 // format that resources such as newrelic_nrql_alert_condition expose via their `id`.
 var componentConditionCompositeIDRegex = regexp.MustCompile(`^\d+:(\d+)$`)
 
 // normalizeComponentConditionID returns the plain numeric condition ID, since the
-// API rejects the composite "< policyID>:<conditionID>" form.
+// API rejects the composite "<policyID>:<conditionID>" form.
 func normalizeComponentConditionID(id string) string {
 	trimmed := strings.TrimSpace(id)
 	if matches := componentConditionCompositeIDRegex.FindStringSubmatch(trimmed); matches != nil {

--- a/newrelic/structures_newrelic_alert_compound_condition.go
+++ b/newrelic/structures_newrelic_alert_compound_condition.go
@@ -10,12 +10,12 @@ import (
 	"github.com/newrelic/newrelic-client-go/v2/pkg/alerts"
 )
 
-// componentConditionCompositeIDRegex matches the composite "<accountID>:<conditionID>"
+// componentConditionCompositeIDRegex matches the composite "< policyID>:<conditionID>"
 // format that resources such as newrelic_nrql_alert_condition expose via their `id`.
 var componentConditionCompositeIDRegex = regexp.MustCompile(`^\d+:(\d+)$`)
 
 // normalizeComponentConditionID returns the plain numeric condition ID, since the
-// API rejects the composite "<accountID>:<conditionID>" form.
+// API rejects the composite "< policyID>:<conditionID>" form.
 func normalizeComponentConditionID(id string) string {
 	trimmed := strings.TrimSpace(id)
 	if matches := componentConditionCompositeIDRegex.FindStringSubmatch(trimmed); matches != nil {

--- a/newrelic/structures_newrelic_alert_compound_condition.go
+++ b/newrelic/structures_newrelic_alert_compound_condition.go
@@ -2,11 +2,28 @@ package newrelic
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/alerts"
 )
+
+// componentConditionCompositeIDRegex matches the composite "<accountID>:<conditionID>"
+// format that resources such as newrelic_nrql_alert_condition expose via their `id`.
+var componentConditionCompositeIDRegex = regexp.MustCompile(`^\d+:(\d+)$`)
+
+// normalizeComponentConditionID returns the plain numeric condition ID, since the
+// API rejects the composite "<accountID>:<conditionID>" form.
+func normalizeComponentConditionID(id string) string {
+	trimmed := strings.TrimSpace(id)
+	if matches := componentConditionCompositeIDRegex.FindStringSubmatch(trimmed); matches != nil {
+		return matches[1]
+	}
+
+	return trimmed
+}
 
 // expandAlertCompoundConditionCreateInput builds the create input from Terraform schema
 func expandAlertCompoundConditionCreateInput(d *schema.ResourceData) (*alerts.CompoundConditionCreateInput, error) {
@@ -110,7 +127,7 @@ func expandComponentConditions(componentSet *schema.Set) ([]alerts.ComponentCond
 	for _, c := range componentSet.List() {
 		component := c.(map[string]interface{})
 
-		id := component["id"].(string)
+		id := normalizeComponentConditionID(component["id"].(string))
 		alias := component["alias"].(string)
 
 		// Validate unique aliases

--- a/newrelic/structures_newrelic_alert_compound_condition_test.go
+++ b/newrelic/structures_newrelic_alert_compound_condition_test.go
@@ -267,3 +267,72 @@ func TestExpandComponentConditionsNormalizesCompositeIDs(t *testing.T) {
 	assert.Equal(t, "10395010", ids["A"])
 	assert.Equal(t, "10395011", ids["B"])
 }
+
+// TestComponentConditionIDRoundTripNoDrift verifies that the StateFunc on
+// component_conditions.id prevents perpetual diff after a create+read cycle.
+//
+// Important: StateFunc is NOT applied by d.Set or d.Get. It is called by
+// Terraform's plan engine on the raw config value before comparing it against
+// state. We simulate that here by calling normalizeComponentConditionID
+// directly (which is exactly what the StateFunc wraps).
+//
+// The lifecycle under test:
+//  1. User writes composite or plain id in config.
+//  2. Plan engine calls StateFunc(config_id) → plain id; compares with state.
+//  3. Apply calls Create/Update: expandComponentConditions normalizes the raw
+//     ResourceData id (still composite at this point) before sending to API.
+//  4. Read calls flattenComponentConditions: API returns plain id → stored in state.
+//  5. Next plan: StateFunc(config_id) == state id → no diff.
+func TestComponentConditionIDRoundTripNoDrift(t *testing.T) {
+	// setHash mirrors the hash function defined on the component_conditions schema.
+	setHash := func(v interface{}) int {
+		return schema.HashString(v.(map[string]interface{})["alias"].(string))
+	}
+
+	// readSet represents what flattenComponentConditions produces after a Read:
+	// the API always returns plain numeric condition IDs.
+	readSet := flattenComponentConditions([]alerts.ComponentCondition{
+		{ID: "10395010", Alias: "A"},
+		{ID: "10395011", Alias: "B"},
+	})
+
+	cases := map[string][]map[string]string{
+		"composite ids (newrelic_nrql_alert_condition.x.id format)": {
+			{"id": "1254186:10395010", "alias": "A"},
+			{"id": "1254186:10395011", "alias": "B"},
+		},
+		"plain numeric ids (split workaround or direct numeric)": {
+			{"id": "10395010", "alias": "A"},
+			{"id": "10395011", "alias": "B"},
+		},
+		"mixed (one composite, one plain)": {
+			{"id": "1254186:10395010", "alias": "A"},
+			{"id": "10395011", "alias": "B"},
+		},
+	}
+
+	for name, rawPairs := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Simulate Terraform's plan engine applying StateFunc to every config id.
+			// This is what prevents drift: the plan engine normalizes the user's
+			// composite id to a plain id before comparing it against state.
+			elems := make([]interface{}, 0, len(rawPairs))
+			for _, pair := range rawPairs {
+				elems = append(elems, map[string]interface{}{
+					"id":    normalizeComponentConditionID(pair["id"]),
+					"alias": pair["alias"],
+				})
+			}
+			configSet := schema.NewSet(setHash, elems)
+
+			// The plan engine compares configSet against readSet element-by-element
+			// using Difference. A non-empty result means a perpetual diff.
+			onlyInConfig := configSet.Difference(readSet)
+			onlyInRead := readSet.Difference(configSet)
+			assert.Zero(t, onlyInConfig.Len(),
+				"case %q: StateFunc-normalized config has elements not in read state: %v", name, onlyInConfig.List())
+			assert.Zero(t, onlyInRead.Len(),
+				"case %q: read state has elements not in StateFunc-normalized config: %v", name, onlyInRead.List())
+		})
+	}
+}

--- a/newrelic/structures_newrelic_alert_compound_condition_test.go
+++ b/newrelic/structures_newrelic_alert_compound_condition_test.go
@@ -5,6 +5,7 @@ package newrelic
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/alerts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -223,4 +224,46 @@ func TestFlattenAlertCompoundCondition(t *testing.T) {
 	assert.Equal(t, "MTAxMzMyMDB8QUxFUlR8Q09ORGU5OfDEwMzQ1NTc", d.Get("entity_guid"))
 	assert.Equal(t, "Test description", d.Get("description"))
 	assert.Equal(t, "{{compoundCondition.name}} triggered", d.Get("title_template"))
+}
+
+func TestNormalizeComponentConditionID(t *testing.T) {
+	cases := map[string]struct {
+		Input    string
+		Expected string
+	}{
+		"composite id":           {Input: "1254186:10395010", Expected: "10395010"},
+		"plain id":               {Input: "10395010", Expected: "10395010"},
+		"whitespace padded":      {Input: " 1254186:10395010 ", Expected: "10395010"},
+		"non numeric parts":      {Input: "abc:def", Expected: "abc:def"},
+		"more than two segments": {Input: "1:2:3", Expected: "1:2:3"},
+		"empty":                  {Input: "", Expected: ""},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.Expected, normalizeComponentConditionID(tc.Input))
+		})
+	}
+}
+
+func TestExpandComponentConditionsNormalizesCompositeIDs(t *testing.T) {
+	r := resourceNewRelicAlertCompoundCondition()
+	d := r.TestResourceData()
+
+	err := d.Set("component_conditions", []interface{}{
+		map[string]interface{}{"id": "1254186:10395010", "alias": "A"},
+		map[string]interface{}{"id": "10395011", "alias": "B"},
+	})
+	require.NoError(t, err)
+
+	components, err := expandComponentConditions(d.Get("component_conditions").(*schema.Set))
+	require.NoError(t, err)
+
+	ids := map[string]string{}
+	for _, c := range components {
+		ids[c.Alias] = c.ID
+	}
+
+	assert.Equal(t, "10395010", ids["A"])
+	assert.Equal(t, "10395011", ids["B"])
 }

--- a/website/docs/r/alert_compound_condition.html.markdown
+++ b/website/docs/r/alert_compound_condition.html.markdown
@@ -249,7 +249,7 @@ The `component_conditions` block supports the following arguments:
 - `id` - (Required) The ID of the existing alert condition to use as a component.
 - `alias` - (Required) The identifier that will be used in the compound alert condition's `trigger_expression` (e.g., 'a', 'b', 'c', 'd', 'e').
 
--> **NOTE:** `newrelic_nrql_alert_condition.<name>.id` is a composite identifier in the format `< policyID>:<conditionID>`. You can assign it to `id` directly — the provider extracts the condition ID before calling the API and stores the normalized value in state.
+-> **NOTE:** `newrelic_nrql_alert_condition.<name>.id` is a composite identifier in the format `<policyID>:<conditionID>`. You can assign it to `id` directly — the provider extracts the condition ID before calling the API and stores the normalized value in state.
 
 ## Attributes Reference
 

--- a/website/docs/r/alert_compound_condition.html.markdown
+++ b/website/docs/r/alert_compound_condition.html.markdown
@@ -249,6 +249,8 @@ The `component_conditions` block supports the following arguments:
 - `id` - (Required) The ID of the existing alert condition to use as a component.
 - `alias` - (Required) The identifier that will be used in the compound alert condition's `trigger_expression` (e.g., 'a', 'b', 'c', 'd', 'e').
 
+-> **NOTE:** `newrelic_nrql_alert_condition.<name>.id` is a composite identifier in the format `<accountID>:<conditionID>`. You can assign it to `id` directly — the provider extracts the condition ID before calling the API and stores the normalized value in state.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/website/docs/r/alert_compound_condition.html.markdown
+++ b/website/docs/r/alert_compound_condition.html.markdown
@@ -249,7 +249,7 @@ The `component_conditions` block supports the following arguments:
 - `id` - (Required) The ID of the existing alert condition to use as a component.
 - `alias` - (Required) The identifier that will be used in the compound alert condition's `trigger_expression` (e.g., 'a', 'b', 'c', 'd', 'e').
 
--> **NOTE:** `newrelic_nrql_alert_condition.<name>.id` is a composite identifier in the format `<accountID>:<conditionID>`. You can assign it to `id` directly — the provider extracts the condition ID before calling the API and stores the normalized value in state.
+-> **NOTE:** `newrelic_nrql_alert_condition.<name>.id` is a composite identifier in the format `< policyID>:<conditionID>`. You can assign it to `id` directly — the provider extracts the condition ID before calling the API and stores the normalized value in state.
 
 ## Attributes Reference
 


### PR DESCRIPTION
# Description

`newrelic_alert_compound_condition` fails on `terraform apply` whenever `component_conditions.id` is populated from a `newrelic_nrql_alert_condition` resource attribute — which is exactly what the resource's own documented examples show:

```hcl
component_conditions {
  id    = newrelic_nrql_alert_condition.high_response_time.id
  alias = "A"
}
```

`newrelic_nrql_alert_condition.<name>.id` is a composite `<accountID>:<conditionID>` string, but the compound condition API expects a plain numeric condition ID and rejects the composite form:

```
Error: JSON parse error: Cannot deserialize value of type `long` from String "1254186:10395010": not a valid `long` value
```

The only workaround today is `split(":", newrelic_nrql_alert_condition.cond_a.id)[1]`, which is undocumented and contradicts the resource documentation.

This PR takes option 1 from the two options below (keeps the documented usage pattern working as-is):

1. Normalize `component_conditions.id` in the provider before sending it to the API.
2. Change the docs to require `split(":", ...)[1]`.

### Changes

- `newrelic/structures_newrelic_alert_compound_condition.go`
  - New helper `normalizeComponentConditionID`, which reduces `<accountID>:<conditionID>` (matched via `^\d+:(\d+)$`) to the plain condition ID. Anything not matching that shape is passed through unchanged (only trimmed), so plain numeric IDs and any future ID formats keep working.
  - `expandComponentConditions` normalizes every `component_conditions.id` before it reaches the API — this covers both create and update.
- `newrelic/resource_newrelic_alert_compound_condition.go`
  - Added a `StateFunc` on `component_conditions.id` so the normalized value is what gets persisted to state. Without this, the API (which only ever returns the numeric ID) would produce a permanent diff on every subsequent plan for users who pass the composite ID.
- `website/docs/r/alert_compound_condition.html.markdown`
  - Note clarifying that `newrelic_nrql_alert_condition.<name>.id` can be assigned directly.

### Backwards compatibility

No breaking change. Configs already using the `split(":", ...)[1]` workaround pass a plain numeric ID, which `normalizeComponentConditionID` leaves untouched. Existing state entries already hold the plain numeric ID, so no state migration is needed and no diff is produced for existing resources.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist:

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes.

## How to test this change?

Unit tests:

```bash
go test -tags unit ./newrelic/ -run 'CompoundCondition|ComponentCondition' -v
```

Two tests were added in `newrelic/structures_newrelic_alert_compound_condition_test.go`:

- `TestNormalizeComponentConditionID` — covers composite IDs, plain IDs, whitespace padding, and non-matching inputs (`abc:def`, `1:2:3`, empty string) that must pass through unchanged.
- `TestExpandComponentConditionsNormalizesCompositeIDs` — verifies that a composite and a plain ID in the same `component_conditions` set both expand to the plain condition ID.

Acceptance/manual check — the following config reproduces the failure on `main` (it is the shape reported by affected users) and should now apply cleanly:

```hcl
resource "newrelic_alert_policy" "example" {
  name = "compound-condition-repro"
}

resource "newrelic_nrql_alert_condition" "cond_a" {
  policy_id = newrelic_alert_policy.example.id
  name      = "Condition A"
  enabled   = true

  nrql {
    query = "SELECT count(*) FROM Transaction"
  }

  critical {
    operator              = "above"
    threshold             = 1
    threshold_duration    = 300
    threshold_occurrences = "all"
  }

  violation_time_limit_seconds = 3600
}

resource "newrelic_nrql_alert_condition" "cond_b" {
  policy_id = newrelic_alert_policy.example.id
  name      = "Condition B"
  enabled   = true

  nrql {
    query = "SELECT count(*) FROM TransactionError"
  }

  critical {
    operator              = "above"
    threshold             = 1
    threshold_duration    = 300
    threshold_occurrences = "all"
  }

  violation_time_limit_seconds = 3600
}

resource "newrelic_alert_compound_condition" "repro" {
  policy_id          = newrelic_alert_policy.example.id
  name               = "Repro Compound Condition"
  enabled            = true
  trigger_expression = "A AND B"
  threshold_duration = 120

  component_conditions {
    id    = newrelic_nrql_alert_condition.cond_a.id
    alias = "A"
  }

  component_conditions {
    id    = newrelic_nrql_alert_condition.cond_b.id
    alias = "B"
  }
}
```

- Step 1: `terraform apply` — the compound condition is created successfully.
- Step 2: `terraform plan` — reports no changes (confirms the `StateFunc` prevents drift).

Fixes #3173 
