### PR TITLE
feat: add newrelic_pathpoint terraform resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,3 +69,5 @@ require (
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 )
+
+replace github.com/newrelic/newrelic-client-go/v2 => github.com/newrelic/newrelic-client-go/v2 v2.0.0-0.00000000000000-7fb4115ca7f7

--- a/newrelic/provider_newrelic.go
+++ b/newrelic/provider_newrelic.go
@@ -131,6 +131,7 @@ func Provider() *schema.Provider {
 			"newrelic_key_transaction":              dataSourceNewRelicKeyTransaction(),
 			"newrelic_notification_destination":     dataSourceNewRelicNotificationDestination(),
 			"newrelic_obfuscation_expression":       dataSourceNewRelicObfuscationExpression(),
+			"newrelic_pathpoint": resourceNewRelicPathpoint(),
 			"newrelic_synthetics_private_location":  dataSourceNewRelicSyntheticsPrivateLocation(),
 			"newrelic_synthetics_secure_credential": dataSourceNewRelicSyntheticsSecureCredential(),
 			"newrelic_test_grok_pattern":            dataSourceNewRelicTestGrokPattern(),

--- a/newrelic/resource_newrelic_pathpoint.go
+++ b/newrelic/resource_newrelic_pathpoint.go
@@ -1,0 +1,520 @@
+package newrelic
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceNewRelicPathpoint() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNewRelicPathpointCreate,
+		ReadContext:   resourceNewRelicPathpointRead,
+		UpdateContext: resourceNewRelicPathpointUpdate,
+		DeleteContext: resourceNewRelicPathpointDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"account_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"category": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"health_rollup": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"ALERT_CONDITIONS",
+					"AUTOMATIC_ROLL_UP",
+				}, false),
+			},
+			"refresh_interval": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"FIFTEEN_MINUTES",
+					"FIVE_MINUTES",
+					"ONE_MINUTE",
+					"TEN_MINUTES",
+					"THIRTY_MINUTES",
+				}, false),
+			},
+			"kpis": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     resourceNewRelicPathpointKpiSchema(),
+			},
+			"stages": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     resourceNewRelicPathpointStageSchema(),
+			},
+			"guid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"flow_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"health_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"message": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"excluded_kpis": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func resourceNewRelicPathpointKpiSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"kpi_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"account_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"category": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"query": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     resourceNewRelicPathpointKpiNRQLSchema(),
+			},
+		},
+	}
+}
+
+func resourceNewRelicPathpointKpiNRQLSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"from": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"where": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"select": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     resourceNewRelicPathpointKpiNRQLSelectSchema(),
+			},
+			"time_window": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     resourceNewRelicPathpointKpiTimeWindowSchema(),
+			},
+		},
+	}
+}
+
+func resourceNewRelicPathpointKpiNRQLSelectSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"aggregation_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"AVERAGE",
+					"COUNT",
+					"HISTOGRAM",
+					"MAX",
+					"MIN",
+					"PERCENTILE",
+					"SUM",
+					"UNIQUE_COUNT",
+				}, false),
+			},
+			"alias": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"attribute": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"threshold": {
+				Type:     schema.TypeFloat,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceNewRelicPathpointKpiTimeWindowSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"custom_range": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"relative_range": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     resourceNewRelicPathpointKpiTimeWindowRelativeRangeSchema(),
+			},
+		},
+	}
+}
+
+func resourceNewRelicPathpointKpiTimeWindowRelativeRangeSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"since": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"SEVEN_DAYS",
+					"SIXTY_MINUTES",
+					"SIX_HOURS",
+					"THIRTY_DAYS",
+					"THIRTY_MINUTES",
+					"THREE_HOURS",
+					"TWENTY_FOUR_HOURS",
+				}, false),
+			},
+			"compare_against": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"SEVEN_DAYS",
+					"SIXTY_MINUTES",
+					"SIX_HOURS",
+					"THIRTY_DAYS",
+					"THIRTY_MINUTES",
+					"THREE_HOURS",
+					"TWENTY_FOUR_HOURS",
+				}, false),
+			},
+		},
+	}
+}
+
+func resourceNewRelicPathpointStageSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"stage_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"health_rollup": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"ALERT_CONDITIONS",
+					"AUTOMATIC_ROLL_UP",
+				}, false),
+			},
+			"is_excluded": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"link": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"related": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     resourceNewRelicPathpointRelatedSchema(),
+			},
+			"stage_kpis": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     resourceNewRelicPathpointKpiSchema(),
+			},
+			"levels": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     resourceNewRelicPathpointLevelSchema(),
+			},
+			"health_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceNewRelicPathpointRelatedSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"source": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"target": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func resourceNewRelicPathpointLevelSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"level_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"steps": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     resourceNewRelicPathpointStepSchema(),
+			},
+			"health_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceNewRelicPathpointStepSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"step_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"is_excluded": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"link": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"scoped_accounts": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
+			},
+			"config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     resourceNewRelicPathpointStepConfigSchema(),
+			},
+			"entity_search_query": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem:     resourceNewRelicPathpointSignalQuerySchema(),
+			},
+			"signals": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     resourceNewRelicPathpointSignalSchema(),
+			},
+			"health_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceNewRelicPathpointStepConfigSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"health_rollup": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"BEST_STATUS_WINS",
+					"WORST_STATUS_WINS",
+				}, false),
+			},
+			"threshold_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"FIXED",
+					"PERCENTAGE",
+				}, false),
+			},
+			"threshold_value": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceNewRelicPathpointSignalQuerySchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"query": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"is_excluded": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func resourceNewRelicPathpointSignalSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"guid": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"ALERT",
+					"ENTITY",
+				}, false),
+			},
+			"is_excluded": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+func resourceNewRelicPathpointCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+	accountID := selectAccountID(providerConfig, d)
+
+	input, err := expandPathpointFlowInput(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	scope := pathpoint.PathPointScopeInput{
+		ID:   accountID,
+		Type: pathpoint.PathPointScopeTypeTypes.ACCOUNT,
+	}
+
+	result, err := client.PathPoint.PathPointCreateWithContext(ctx, *input, scope)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(string(result.GUID))
+	return resourceNewRelicPathpointRead(ctx, d, meta)
+}
+
+func resourceNewRelicPathpointRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+	accountID := selectAccountID(providerConfig, d)
+
+	result, err := client.PathPoint.GetFlowWithContext(ctx, accountID, pathpoint.EntityGUID(d.Id()))
+	if err != nil {
+		if _, ok := err.(*nrErrors.NotFound); ok {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+
+	if result == nil {
+		d.SetId("")
+		return nil
+	}
+
+	return diag.FromErr(flattenPathpointFlowResult(result, d))
+}
+
+func resourceNewRelicPathpointUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+
+	input, err := expandPathpointFlowUpdateInput(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	result, err := client.PathPoint.PathPointUpdateWithContext(ctx, pathpoint.EntityGUID(d.Id()), *input)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	_ = result
+	return resourceNewRelicPathpointRead(ctx, d, meta)
+}
+
+func resourceNewRelicPathpointDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+
+	_, err := client.PathPoint.PathPointDeleteWithContext(ctx, pathpoint.EntityGUID(d.Id()))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/newrelic/structures_newrelic_pathpoint.go
+++ b/newrelic/structures_newrelic_pathpoint.go
@@ -1,0 +1,671 @@
+package newrelic
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/pathpoint"
+)
+
+func expandPathpointFlowInput(d *schema.ResourceData) (*pathpoint.PathPointFlowInput, error) {
+	input := &pathpoint.PathPointFlowInput{
+		Name: d.Get("name").(string),
+	}
+
+	if v, ok := d.GetOk("category"); ok {
+		input.Category = v.(string)
+	}
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = v.(string)
+	}
+	if v, ok := d.GetOk("health_rollup"); ok {
+		input.HealthRollup = pathpoint.PathPointFlowHealthRollup(v.(string))
+	}
+	if v, ok := d.GetOk("refresh_interval"); ok {
+		input.RefreshInterval = pathpoint.PathPointRefreshInterval(v.(string))
+	}
+	if v, ok := d.GetOk("kpis"); ok {
+		input.Kpis = expandPathpointKpiInputList(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("stages"); ok {
+		input.Stages = expandPathpointStageInputList(v.([]interface{}))
+	}
+
+	return input, nil
+}
+
+func expandPathpointFlowUpdateInput(d *schema.ResourceData) (*pathpoint.PathPointFlowUpdateInput, error) {
+	input := &pathpoint.PathPointFlowUpdateInput{
+		Name: d.Get("name").(string),
+	}
+
+	if v, ok := d.GetOk("category"); ok {
+		input.Category = v.(string)
+	}
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = v.(string)
+	}
+	if v, ok := d.GetOk("health_rollup"); ok {
+		input.HealthRollup = pathpoint.PathPointFlowHealthRollup(v.(string))
+	}
+	if v, ok := d.GetOk("refresh_interval"); ok {
+		input.RefreshInterval = pathpoint.PathPointRefreshInterval(v.(string))
+	}
+	if v, ok := d.GetOk("flow_id"); ok {
+		input.ID = v.(string)
+	}
+	if v, ok := d.GetOk("kpis"); ok {
+		input.Kpis = expandPathpointKpiUpdateInputList(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("stages"); ok {
+		input.Stages = expandPathpointStageUpdateInputList(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("version"); ok {
+		input.Version = pathpoint.EpochMilliseconds(v.(string))
+	}
+
+	return input, nil
+}
+
+func expandPathpointScopeInput(d *schema.ResourceData, accountID int) pathpoint.PathPointScopeInput {
+	return pathpoint.PathPointScopeInput{
+		ID:   accountID,
+		Type: pathpoint.PathPointScopeTypeTypes.ACCOUNT,
+	}
+}
+
+func expandPathpointKpiInputList(list []interface{}) []pathpoint.PathPointKpiInput {
+	out := make([]pathpoint.PathPointKpiInput, len(list))
+	for i, v := range list {
+		cfg := v.(map[string]interface{})
+		out[i] = expandPathpointKpiInput(cfg)
+	}
+	return out
+}
+
+func expandPathpointKpiInput(cfg map[string]interface{}) pathpoint.PathPointKpiInput {
+	input := pathpoint.PathPointKpiInput{
+		Name: cfg["name"].(string),
+	}
+	if v, ok := cfg["account_id"].(int); ok && v != 0 {
+		input.AccountID = v
+	}
+	if v, ok := cfg["category"].(string); ok && v != "" {
+		input.Category = v
+	}
+	if v, ok := cfg["description"].(string); ok && v != "" {
+		input.Description = v
+	}
+	if v, ok := cfg["query"].([]interface{}); ok && len(v) > 0 {
+		input.Query = expandPathpointKpiNRQLInput(v[0].(map[string]interface{}))
+	}
+	return input
+}
+
+func expandPathpointKpiUpdateInputList(list []interface{}) []pathpoint.PathPointKpiUpdateInput {
+	out := make([]pathpoint.PathPointKpiUpdateInput, len(list))
+	for i, v := range list {
+		cfg := v.(map[string]interface{})
+		out[i] = expandPathpointKpiUpdateInput(cfg)
+	}
+	return out
+}
+
+func expandPathpointKpiUpdateInput(cfg map[string]interface{}) pathpoint.PathPointKpiUpdateInput {
+	input := pathpoint.PathPointKpiUpdateInput{
+		Name: cfg["name"].(string),
+	}
+	if v, ok := cfg["kpi_id"].(string); ok && v != "" {
+		input.ID = v
+	}
+	if v, ok := cfg["account_id"].(int); ok && v != 0 {
+		input.AccountID = v
+	}
+	if v, ok := cfg["category"].(string); ok && v != "" {
+		input.Category = v
+	}
+	if v, ok := cfg["description"].(string); ok && v != "" {
+		input.Description = v
+	}
+	if v, ok := cfg["query"].([]interface{}); ok && len(v) > 0 {
+		input.Query = expandPathpointKpiNRQLInput(v[0].(map[string]interface{}))
+	}
+	return input
+}
+
+func expandPathpointKpiNRQLInput(cfg map[string]interface{}) pathpoint.PathPointKpiNRQLInput {
+	input := pathpoint.PathPointKpiNRQLInput{
+		From: pathpoint.NRQL(cfg["from"].(string)),
+	}
+	if v, ok := cfg["where"].(string); ok && v != "" {
+		input.Where = v
+	}
+	if v, ok := cfg["select"].([]interface{}); ok && len(v) > 0 {
+		sel := expandPathpointKpiNRQLSelectInput(v[0].(map[string]interface{}))
+		input.Select = sel
+	}
+	if v, ok := cfg["time_window"].([]interface{}); ok && len(v) > 0 {
+		tw := expandPathpointKpiTimeWindowInput(v[0].(map[string]interface{}))
+		input.TimeWindow = &tw
+	}
+	return input
+}
+
+func expandPathpointKpiNRQLSelectInput(cfg map[string]interface{}) pathpoint.PathPointKpiNRQLSelectInput {
+	input := pathpoint.PathPointKpiNRQLSelectInput{
+		AggregationType: pathpoint.PathPointKpiNRQLAggregations(cfg["aggregation_type"].(string)),
+	}
+	if v, ok := cfg["alias"].(string); ok && v != "" {
+		input.Alias = v
+	}
+	if v, ok := cfg["attribute"].(string); ok && v != "" {
+		input.Attribute = v
+	}
+	if v, ok := cfg["threshold"].(float64); ok && v != 0 {
+		input.Threshold = v
+	}
+	return input
+}
+
+func expandPathpointKpiTimeWindowInput(cfg map[string]interface{}) pathpoint.PathPointKpiTimeWindowInput {
+	input := pathpoint.PathPointKpiTimeWindowInput{}
+	if v, ok := cfg["custom_range"].(string); ok && v != "" {
+		input.CustomRange = pathpoint.NRQL(v)
+	}
+	if v, ok := cfg["relative_range"].([]interface{}); ok && len(v) > 0 {
+		rr := expandPathpointKpiTimeWindowRelativeRangeInput(v[0].(map[string]interface{}))
+		input.RelativeRange = &rr
+	}
+	return input
+}
+
+func expandPathpointKpiTimeWindowRelativeRangeInput(cfg map[string]interface{}) pathpoint.PathPointKpiTimeWindowRelativeRangeInput {
+	input := pathpoint.PathPointKpiTimeWindowRelativeRangeInput{
+		Since: pathpoint.PathPointKpiTimeDuration(cfg["since"].(string)),
+	}
+	if v, ok := cfg["compare_against"].(string); ok && v != "" {
+		input.CompareAgainst = pathpoint.PathPointKpiTimeDuration(v)
+	}
+	return input
+}
+
+func expandPathpointStageInputList(list []interface{}) []pathpoint.PathPointStageInput {
+	out := make([]pathpoint.PathPointStageInput, len(list))
+	for i, v := range list {
+		cfg := v.(map[string]interface{})
+		out[i] = expandPathpointStageInput(cfg)
+	}
+	return out
+}
+
+func expandPathpointStageInput(cfg map[string]interface{}) pathpoint.PathPointStageInput {
+	input := pathpoint.PathPointStageInput{
+		Name: cfg["name"].(string),
+	}
+	if v, ok := cfg["health_rollup"].(string); ok && v != "" {
+		input.HealthRollup = pathpoint.PathPointStageHealthRollup(v)
+	}
+	if v, ok := cfg["is_excluded"].(bool); ok {
+		input.IsExcluded = v
+	}
+	if v, ok := cfg["link"].(string); ok && v != "" {
+		input.Link = v
+	}
+	if v, ok := cfg["related"].([]interface{}); ok && len(v) > 0 {
+		input.Related = expandPathpointRelatedInput(v[0].(map[string]interface{}))
+	}
+	if v, ok := cfg["stage_kpis"].([]interface{}); ok && len(v) > 0 {
+		input.StageKpis = expandPathpointKpiInputList(v)
+	}
+	if v, ok := cfg["levels"].([]interface{}); ok && len(v) > 0 {
+		input.Levels = expandPathpointLevelInputList(v)
+	}
+	return input
+}
+
+func expandPathpointStageUpdateInputList(list []interface{}) []pathpoint.PathPointStageUpdateInput {
+	out := make([]pathpoint.PathPointStageUpdateInput, len(list))
+	for i, v := range list {
+		cfg := v.(map[string]interface{})
+		out[i] = expandPathpointStageUpdateInput(cfg)
+	}
+	return out
+}
+
+func expandPathpointStageUpdateInput(cfg map[string]interface{}) pathpoint.PathPointStageUpdateInput {
+	input := pathpoint.PathPointStageUpdateInput{
+		Name: cfg["name"].(string),
+	}
+	if v, ok := cfg["stage_id"].(string); ok && v != "" {
+		input.ID = v
+	}
+	if v, ok := cfg["health_rollup"].(string); ok && v != "" {
+		input.HealthRollup = pathpoint.PathPointStageHealthRollup(v)
+	}
+	if v, ok := cfg["is_excluded"].(bool); ok {
+		input.IsExcluded = v
+	}
+	if v, ok := cfg["link"].(string); ok && v != "" {
+		input.Link = v
+	}
+	if v, ok := cfg["related"].([]interface{}); ok && len(v) > 0 {
+		input.Related = expandPathpointRelatedInput(v[0].(map[string]interface{}))
+	}
+	if v, ok := cfg["stage_kpis"].([]interface{}); ok && len(v) > 0 {
+		input.StageKpis = expandPathpointKpiUpdateInputList(v)
+	}
+	if v, ok := cfg["levels"].([]interface{}); ok && len(v) > 0 {
+		input.Levels = expandPathpointLevelUpdateInputList(v)
+	}
+	return input
+}
+
+func expandPathpointRelatedInput(cfg map[string]interface{}) pathpoint.PathPointRelatedInput {
+	input := pathpoint.PathPointRelatedInput{}
+	if v, ok := cfg["source"].(bool); ok {
+		input.Source = v
+	}
+	if v, ok := cfg["target"].(bool); ok {
+		input.Target = v
+	}
+	return input
+}
+
+func expandPathpointLevelInputList(list []interface{}) []pathpoint.PathPointLevelInput {
+	out := make([]pathpoint.PathPointLevelInput, len(list))
+	for i, v := range list {
+		cfg := v.(map[string]interface{})
+		out[i] = expandPathpointLevelInput(cfg)
+	}
+	return out
+}
+
+func expandPathpointLevelInput(cfg map[string]interface{}) pathpoint.PathPointLevelInput {
+	input := pathpoint.PathPointLevelInput{}
+	if v, ok := cfg["steps"].([]interface{}); ok && len(v) > 0 {
+		input.Steps = expandPathpointStepInputList(v)
+	}
+	return input
+}
+
+func expandPathpointLevelUpdateInputList(list []interface{}) []pathpoint.PathPointLevelUpdateInput {
+	out := make([]pathpoint.PathPointLevelUpdateInput, len(list))
+	for i, v := range list {
+		cfg := v.(map[string]interface{})
+		out[i] = expandPathpointLevelUpdateInput(cfg)
+	}
+	return out
+}
+
+func expandPathpointLevelUpdateInput(cfg map[string]interface{}) pathpoint.PathPointLevelUpdateInput {
+	input := pathpoint.PathPointLevelUpdateInput{}
+	if v, ok := cfg["level_id"].(string); ok && v != "" {
+		input.ID = v
+	}
+	if v, ok := cfg["steps"].([]interface{}); ok && len(v) > 0 {
+		input.Steps = expandPathpointStepUpdateInputList(v)
+	}
+	return input
+}
+
+func expandPathpointStepInputList(list []interface{}) []pathpoint.PathPointStepInput {
+	out := make([]pathpoint.PathPointStepInput, len(list))
+	for i, v := range list {
+		cfg := v.(map[string]interface{})
+		out[i] = expandPathpointStepInput(cfg)
+	}
+	return out
+}
+
+func expandPathpointStepInput(cfg map[string]interface{}) pathpoint.PathPointStepInput {
+	input := pathpoint.PathPointStepInput{
+		Name: cfg["name"].(string),
+	}
+	if v, ok := cfg["is_excluded"].(bool); ok {
+		input.IsExcluded = v
+	}
+	if v, ok := cfg["link"].(string); ok && v != "" {
+		input.Link = v
+	}
+	if v, ok := cfg["scoped_accounts"].([]interface{}); ok && len(v) > 0 {
+		accounts := make([]int, len(v))
+		for i, a := range v {
+			accounts[i] = a.(int)
+		}
+		input.ScopedAccounts = accounts
+	}
+	if v, ok := cfg["config"].([]interface{}); ok && len(v) > 0 {
+		input.Config = expandPathpointStepStatusThresholdInput(v[0].(map[string]interface{}))
+	}
+	if v, ok := cfg["entity_search_query"].([]interface{}); ok && len(v) > 0 {
+		esq := expandPathpointSignalQueryInput(v[0].(map[string]interface{}))
+		input.EntitySearchQuery = &esq
+	}
+	if v, ok := cfg["signals"].([]interface{}); ok && len(v) > 0 {
+		input.Signals = expandPathpointSignalInputList(v)
+	}
+	return input
+}
+
+func expandPathpointStepUpdateInputList(list []interface{}) []pathpoint.PathPointStepUpdateInput {
+	out := make([]pathpoint.PathPointStepUpdateInput, len(list))
+	for i, v := range list {
+		cfg := v.(map[string]interface{})
+		out[i] = expandPathpointStepUpdateInput(cfg)
+	}
+	return out
+}
+
+func expandPathpointStepUpdateInput(cfg map[string]interface{}) pathpoint.PathPointStepUpdateInput {
+	input := pathpoint.PathPointStepUpdateInput{
+		Name: cfg["name"].(string),
+	}
+	if v, ok := cfg["step_id"].(string); ok && v != "" {
+		input.ID = v
+	}
+	if v, ok := cfg["is_excluded"].(bool); ok {
+		input.IsExcluded = v
+	}
+	if v, ok := cfg["link"].(string); ok && v != "" {
+		input.Link = v
+	}
+	if v, ok := cfg["scoped_accounts"].([]interface{}); ok && len(v) > 0 {
+		accounts := make([]int, len(v))
+		for i, a := range v {
+			accounts[i] = a.(int)
+		}
+		input.ScopedAccounts = accounts
+	}
+	if v, ok := cfg["config"].([]interface{}); ok && len(v) > 0 {
+		input.Config = expandPathpointStepStatusThresholdInput(v[0].(map[string]interface{}))
+	}
+	if v, ok := cfg["entity_search_query"].([]interface{}); ok && len(v) > 0 {
+		esq := expandPathpointSignalQueryInput(v[0].(map[string]interface{}))
+		input.EntitySearchQuery = &esq
+	}
+	if v, ok := cfg["signals"].([]interface{}); ok && len(v) > 0 {
+		input.Signals = expandPathpointSignalInputList(v)
+	}
+	return input
+}
+
+func expandPathpointStepStatusThresholdInput(cfg map[string]interface{}) pathpoint.PathPointStepStatusThresholdInput {
+	input := pathpoint.PathPointStepStatusThresholdInput{}
+	if v, ok := cfg["health_rollup"].(string); ok && v != "" {
+		input.HealthRollup = pathpoint.PathPointStepHealthRollup(v)
+	}
+	if v, ok := cfg["threshold_type"].(string); ok && v != "" {
+		input.ThresholdType = pathpoint.PathPointThresholdType(v)
+	}
+	if v, ok := cfg["threshold_value"].(int); ok && v != 0 {
+		input.ThresholdValue = v
+	}
+	return input
+}
+
+func expandPathpointSignalQueryInput(cfg map[string]interface{}) pathpoint.PathPointSignalQueryInput {
+	input := pathpoint.PathPointSignalQueryInput{
+		Query: cfg["query"].(string),
+	}
+	if v, ok := cfg["is_excluded"].(bool); ok {
+		input.IsExcluded = v
+	}
+	return input
+}
+
+func expandPathpointSignalInputList(list []interface{}) []pathpoint.PathPointSignalInput {
+	out := make([]pathpoint.PathPointSignalInput, len(list))
+	for i, v := range list {
+		cfg := v.(map[string]interface{})
+		out[i] = expandPathpointSignalInput(cfg)
+	}
+	return out
+}
+
+func expandPathpointSignalInput(cfg map[string]interface{}) pathpoint.PathPointSignalInput {
+	input := pathpoint.PathPointSignalInput{
+		GUID: pathpoint.EntityGUID(cfg["guid"].(string)),
+	}
+	if v, ok := cfg["name"].(string); ok && v != "" {
+		input.Name = v
+	}
+	if v, ok := cfg["type"].(string); ok && v != "" {
+		input.Type = pathpoint.PathPointSignalType(v)
+	}
+	if v, ok := cfg["is_excluded"].(bool); ok {
+		input.IsExcluded = v
+	}
+	return input
+}
+func flattenPathpointFlow(result *pathpoint.PathPointFlowResult, d *schema.ResourceData) error {
+	if result == nil {
+		return nil
+	}
+
+	_ = d.Set("name", result.Name)
+	_ = d.Set("category", result.Category)
+	_ = d.Set("description", result.Description)
+	_ = d.Set("health_rollup", string(result.HealthRollup))
+	_ = d.Set("refresh_interval", string(result.RefreshInterval))
+	_ = d.Set("guid", string(result.GUID))
+	_ = d.Set("flow_id", result.ID)
+	_ = d.Set("version", result.Version.String())
+	_ = d.Set("health_status", string(result.HealthStatus))
+	_ = d.Set("message", result.Message)
+
+	excludedKpis := make([]interface{}, len(result.ExcludedKpis))
+	for i, v := range result.ExcludedKpis {
+		excludedKpis[i] = v
+	}
+	_ = d.Set("excluded_kpis", excludedKpis)
+
+	if err := d.Set("kpis", flattenPathpointKpis(result.Kpis)); err != nil {
+		return fmt.Errorf("[DEBUG] Error setting `kpis`: %v", err)
+	}
+
+	if err := d.Set("stages", flattenPathpointStages(result.Stages.Items)); err != nil {
+		return fmt.Errorf("[DEBUG] Error setting `stages`: %v", err)
+	}
+
+	return nil
+}
+
+func flattenPathpointKpis(kpis []pathpoint.PathPointKpi) []interface{} {
+	out := make([]interface{}, len(kpis))
+	for i, k := range kpis {
+		out[i] = flattenPathpointKpi(k)
+	}
+	return out
+}
+
+func flattenPathpointKpi(k pathpoint.PathPointKpi) map[string]interface{} {
+	m := map[string]interface{}{
+		"kpi_id":      k.ID,
+		"account_id":  k.AccountID,
+		"name":        k.Name,
+		"category":    k.Category,
+		"description": k.Description,
+	}
+
+	queryList := flattenPathpointKpiNRQL(k.Query)
+	m["query"] = queryList
+
+	return m
+}
+
+func flattenPathpointKpiNRQL(q pathpoint.PathPointKpiNRQL) []interface{} {
+	m := map[string]interface{}{
+		"from":  string(q.From),
+		"where": q.Where,
+	}
+
+	selectList := flattenPathpointKpiNRQLSelect(q.Select)
+	m["select"] = selectList
+
+	timeWindowList := flattenPathpointKpiTimeWindow(q.TimeWindow)
+	m["time_window"] = timeWindowList
+
+	return []interface{}{m}
+}
+
+func flattenPathpointKpiNRQLSelect(s pathpoint.PathPointKpiNRQLSelect) []interface{} {
+	m := map[string]interface{}{
+		"aggregation_type": string(s.AggregationType),
+		"alias":            s.Alias,
+		"attribute":        s.Attribute,
+		"threshold":        s.Threshold,
+	}
+	return []interface{}{m}
+}
+
+func flattenPathpointKpiTimeWindow(tw pathpoint.PathPointKpiTimeWindow) []interface{} {
+	if tw == (pathpoint.PathPointKpiTimeWindow{}) {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"custom_range": string(tw.CustomRange),
+	}
+
+	relativeRangeList := flattenPathpointKpiTimeWindowRelativeRange(tw.RelativeRange)
+	m["relative_range"] = relativeRangeList
+
+	return []interface{}{m}
+}
+
+func flattenPathpointKpiTimeWindowRelativeRange(rr pathpoint.PathPointKpiTimeWindowRelativeRange) []interface{} {
+	if rr == (pathpoint.PathPointKpiTimeWindowRelativeRange{}) {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"since":           string(rr.Since),
+		"compare_against": string(rr.CompareAgainst),
+	}
+	return []interface{}{m}
+}
+
+func flattenPathpointStages(stages []pathpoint.PathPointStage) []interface{} {
+	out := make([]interface{}, len(stages))
+	for i, s := range stages {
+		out[i] = flattenPathpointStage(s)
+	}
+	return out
+}
+
+func flattenPathpointStage(s pathpoint.PathPointStage) map[string]interface{} {
+	m := map[string]interface{}{
+		"stage_id":      s.ID,
+		"name":          s.Name,
+		"health_rollup": string(s.HealthRollup),
+		"is_excluded":   s.IsExcluded,
+		"link":          s.Link,
+		"health_status": string(s.HealthStatus),
+	}
+
+	relatedList := flattenPathpointRelated(s.Related)
+	m["related"] = relatedList
+
+	m["stage_kpis"] = flattenPathpointKpis(s.StageKpis)
+
+	m["levels"] = flattenPathpointLevels(s.Levels.Items)
+
+	return m
+}
+
+func flattenPathpointRelated(r pathpoint.PathPointRelated) []interface{} {
+	m := map[string]interface{}{
+		"source": r.Source,
+		"target": r.Target,
+	}
+	return []interface{}{m}
+}
+
+func flattenPathpointLevels(levels []pathpoint.PathPointLevel) []interface{} {
+	out := make([]interface{}, len(levels))
+	for i, l := range levels {
+		out[i] = flattenPathpointLevel(l)
+	}
+	return out
+}
+
+func flattenPathpointLevel(l pathpoint.PathPointLevel) map[string]interface{} {
+	m := map[string]interface{}{
+		"level_id":      l.ID,
+		"health_status": string(l.HealthStatus),
+	}
+
+	m["steps"] = flattenPathpointSteps(l.Steps.Items)
+
+	return m
+}
+
+func flattenPathpointSteps(steps []pathpoint.PathPointStep) []interface{} {
+	out := make([]interface{}, len(steps))
+	for i, s := range steps {
+		out[i] = flattenPathpointStep(s)
+	}
+	return out
+}
+
+func flattenPathpointStep(s pathpoint.PathPointStep) map[string]interface{} {
+	m := map[string]interface{}{
+		"step_id":       s.ID,
+		"name":          s.Name,
+		"is_excluded":   s.IsExcluded,
+		"link":          s.Link,
+		"health_status": string(s.HealthStatus),
+	}
+
+	scopedAccounts := make([]interface{}, len(s.ScopedAccounts))
+	for i, v := range s.ScopedAccounts {
+		scopedAccounts[i] = v
+	}
+	m["scoped_accounts"] = scopedAccounts
+
+	m["config"] = flattenPathpointStepConfig(s.Config)
+	m["entity_search_query"] = flattenPathpointSignalQuery(s.EntitySearchQuery)
+	m["signals"] = flattenPathpointSignals(s.Signals)
+
+	return m
+}
+
+func flattenPathpointStepConfig(c pathpoint.PathPointStepStatusThreshold) []interface{} {
+	if c == (pathpoint.PathPointStepStatusThreshold{}) {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"health_rollup":   string(c.HealthRollup),
+		"threshold_type":  string(c.ThresholdType),
+		"threshold_value": c.ThresholdValue,
+	}
+	return []interface{}{m}
+}
+
+func flattenPathpointSignalQuery(q pathpoint.PathPointSignalQuery) []interface{} {
+	if q == (pathpoint.PathPointSignalQuery{}) {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"query":       q.Query,
+		"is_excluded": q.IsExcluded,
+	}
+	return []interface{}{m}
+}
+
+func flattenPathpointSignals(signals []pathpoint.PathPointSignal) []interface{} {
+	out := make([]interface{}, len(signals))
+	for i, s := range signals {
+		out[i] = flattenPathpointSignal(s)
+	}
+	return out
+}
+
+func flattenPathpointSignal(s pathpoint.PathPointSignal) map[string]interface{} {
+	return map[string]interface{}{
+		"guid":        string(s.GUID),
+		"name":        s.Name,
+		"type":        string(s.Type),
+		"is_excluded": s.IsExcluded,
+	}
+}

--- a/website/docs/r/pathpoint.html.markdown
+++ b/website/docs/r/pathpoint.html.markdown
@@ -1,0 +1,214 @@
+---
+layout: "newrelic"
+page_title: "New Relic: newrelic_pathpoint"
+sidebar_current: "docs-newrelic-resource-pathpoint"
+description: |-
+  Create and manage a Pathpoint flow in New Relic.
+---
+
+# Resource: newrelic\_pathpoint
+
+Use this resource to create and manage New Relic Pathpoint flows. Pathpoint is a New Relic app that lets you model your business flow and understand how each stage impacts the overall health of your system. Details regarding Pathpoint can be found [here](https://docs.newrelic.com/docs/new-relic-solutions/business-observability/introduction-pathpoint/).
+
+## Example Usage
+
+```hcl
+resource "newrelic_pathpoint" "example" {
+  account_id       = 12345678
+  name             = "My Pathpoint Flow"
+  category         = "Checkout"
+  description      = "Monitors the end-to-end checkout flow"
+  health_rollup    = "AUTOMATIC_ROLL_UP"
+  refresh_interval = "ONE_MINUTE"
+
+  kpis {
+    name        = "Flow KPI"
+    account_id  = 12345678
+
+    query {
+      from  = "Transaction"
+      where = "appName = 'MyApp'"
+
+      select {
+        aggregation_type = "COUNT"
+      }
+
+      time_window {
+        relative_range {
+          since           = "SIXTY_MINUTES"
+          compare_against = "TWENTY_FOUR_HOURS"
+        }
+      }
+    }
+  }
+
+  stages {
+    name         = "Browsing"
+    health_rollup = "AUTOMATIC_ROLL_UP"
+    is_excluded  = false
+    link         = "https://example.com/browsing"
+
+    related {
+      source = false
+      target = true
+    }
+
+    levels {
+      steps {
+        name        = "Product Page"
+        is_excluded = false
+        link        = "https://example.com/product"
+
+        scoped_accounts = [12345678]
+
+        config {
+          health_rollup   = "WORST_STATUS_WINS"
+          threshold_type  = "PERCENTAGE"
+          threshold_value = 90
+        }
+
+        entity_search_query {
+          query       = "domain = 'APM' AND type = 'APPLICATION'"
+          is_excluded = false
+        }
+
+        signals {
+          guid        = "MXxBUE18QVBQTElDQVRJT058MTIz"
+          name        = "My App"
+          type        = "ENTITY"
+          is_excluded = false
+        }
+      }
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `account_id` - (Optional) The New Relic account ID where the Pathpoint flow will be created. Defaults to the account associated with the API key used. Forces a new resource if changed.
+* `name` - (Required) The display name of the Pathpoint flow.
+* `category` - (Optional) A category used to group flows (e.g. Marketing, Checkout).
+* `description` - (Optional) A description of the Pathpoint flow.
+* `health_rollup` - (Optional) Health rollup strategy for the flow, derived from its stages. One of: `ALERT_CONDITIONS`, `AUTOMATIC_ROLL_UP`.
+* `refresh_interval` - (Optional) How often the flow, stage, level, and step health statuses are fetched. One of: `FIFTEEN_MINUTES`, `FIVE_MINUTES`, `ONE_MINUTE`, `TEN_MINUTES`, `THIRTY_MINUTES`.
+* `kpis` - (Optional) A list of KPIs to track at the flow level. See [Nested `kpis` blocks](#nested-kpis-blocks) below for details.
+* `stages` - (Optional) The ordered list of stages that make up this flow. See [Nested `stages` blocks](#nested-stages-blocks) below for details.
+
+### Nested `kpis` blocks
+
+* `name` - (Required) The display name of the KPI.
+* `account_id` - (Optional) The account ID this KPI belongs to.
+* `category` - (Optional) Optional category to group KPIs.
+* `description` - (Optional) Optional description of this KPI.
+* `query` - (Optional) The NRQL query definition for this KPI. See [Nested `query` blocks](#nested-query-blocks) below for details.
+
+### Nested `query` blocks
+
+* `from` - (Required) The data source to query from (e.g., `Transaction`, `Metric`, `Log`).
+* `where` - (Optional) Optional WHERE clause conditions to filter the data.
+* `select` - (Optional) The SELECT clause defining what to aggregate and return. See [Nested `select` blocks](#nested-select-blocks) below for details.
+* `time_window` - (Optional) The time window over which the KPI is evaluated. See [Nested `time_window` blocks](#nested-time_window-blocks) below for details.
+
+### Nested `select` blocks
+
+* `aggregation_type` - (Required) The aggregation function to apply to the attribute. One of: `AVERAGE`, `COUNT`, `HISTOGRAM`, `MAX`, `MIN`, `PERCENTILE`, `SUM`, `UNIQUE_COUNT`.
+* `alias` - (Optional) Optional alias for the aggregated value in the query result.
+* `attribute` - (Optional) The attribute name to aggregate. Required for all functions except `COUNT`.
+* `threshold` - (Optional) The threshold used in the selected function.
+
+### Nested `time_window` blocks
+
+* `custom_range` - (Optional) A raw NRQL time fragment, e.g. `SINCE 3 days ago COMPARE WITH 1 day ago`. Mutually exclusive with `relative_range`.
+* `relative_range` - (Optional) A relative window built from predefined duration values. Mutually exclusive with `custom_range`. See [Nested `relative_range` blocks](#nested-relative_range-blocks) below for details.
+
+### Nested `relative_range` blocks
+
+* `since` - (Required) How far back the KPI is evaluated (maps to NRQL `SINCE`). One of: `SEVEN_DAYS`, `SIXTY_MINUTES`, `SIX_HOURS`, `THIRTY_DAYS`, `THIRTY_MINUTES`, `THREE_HOURS`, `TWENTY_FOUR_HOURS`.
+* `compare_against` - (Optional) The earlier window the current window is compared against (maps to NRQL `COMPARE WITH`). One of: `SEVEN_DAYS`, `SIXTY_MINUTES`, `SIX_HOURS`, `THIRTY_DAYS`, `THIRTY_MINUTES`, `THREE_HOURS`, `TWENTY_FOUR_HOURS`.
+
+### Nested `stages` blocks
+
+* `name` - (Required) The display name of the stage.
+* `health_rollup` - (Optional) Health rollup strategy for the stage, derived from its levels. One of: `ALERT_CONDITIONS`, `AUTOMATIC_ROLL_UP`.
+* `is_excluded` - (Optional) When true, this stage is excluded from the flow health calculation. Defaults to `false`.
+* `link` - (Optional) Optional URL to an external resource related to this stage.
+* `related` - (Optional) Defines the relationship role of a stage within a flow. See [Nested `related` blocks](#nested-related-blocks) below for details.
+* `stage_kpis` - (Optional) KPIs tracked at the stage level. See [Nested `kpis` blocks](#nested-kpis-blocks) above for details.
+* `levels` - (Optional) The ordered list of levels within this stage. See [Nested `levels` blocks](#nested-levels-blocks) below for details.
+
+### Nested `related` blocks
+
+* `source` - (Optional) When true, this stage acts as a source to other stages. Defaults to `false`.
+* `target` - (Optional) When true, this stage acts as a target to other stages. Defaults to `false`.
+
+### Nested `levels` blocks
+
+* `steps` - (Optional) The ordered list of steps within this level. See [Nested `steps` blocks](#nested-steps-blocks) below for details.
+
+### Nested `steps` blocks
+
+* `name` - (Required) The display name of the step.
+* `is_excluded` - (Optional) When true, this step is excluded from the level health calculation. Defaults to `false`.
+* `link` - (Optional) Optional URL to an external resource related to this step.
+* `scoped_accounts` - (Optional) Account IDs whose entities are included in scope for this step.
+* `config` - (Optional) Health evaluation configuration for this step. See [Nested `config` blocks](#nested-config-blocks) below for details.
+* `entity_search_query` - (Optional) The filter query used to fetch signals for this step. See [Nested `entity_search_query` blocks](#nested-entity_search_query-blocks) below for details.
+* `signals` - (Optional) Entity signals associated with this step. See [Nested `signals` blocks](#nested-signals-blocks) below for details.
+
+### Nested `config` blocks
+
+* `health_rollup` - (Optional) How the step health is rolled up from its signals. One of: `BEST_STATUS_WINS`, `WORST_STATUS_WINS`.
+* `threshold_type` - (Optional) Whether the threshold value is a fixed number or a percentage. One of: `FIXED`, `PERCENTAGE`.
+* `threshold_value` - (Optional) The numeric threshold value used to evaluate step health.
+
+### Nested `entity_search_query` blocks
+
+* `query` - (Required) Filter query for signals in this step, e.g. `domain='NR1' AND type='APPLICATION'`.
+* `is_excluded` - (Optional) When true, this query is excluded from the step health evaluation. Defaults to `false`.
+
+### Nested `signals` blocks
+
+* `guid` - (Required) The entity GUID of the signal.
+* `name` - (Optional) The display name of the signal.
+* `type` - (Optional) Whether this GUID belongs to an entity or an alert condition. One of: `ALERT`, `ENTITY`.
+* `is_excluded` - (Optional) When true, this signal is excluded from the step health evaluation. Defaults to `false`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The entity GUID of the Pathpoint flow (same as `guid`).
+* `guid` - The unique entity GUID assigned to this Pathpoint flow.
+* `flow_id` - The workload ID of the flow entity.
+* `version` - The last updated timestamp of the Pathpoint, used for version control.
+* `health_status` - The computed health status of the flow. One of: `DEGRADED`, `DISRUPTED`, `OPERATIONAL`, `UNKNOWN`.
+* `message` - Error details when one or more stages, levels, or steps fail during a create or update operation.
+* `excluded_kpis` - Names of KPIs that were excluded during create or update.
+
+The following computed attributes are also exported on nested blocks:
+
+* `stages[*].stage_id` - The workload ID of the stage entity.
+* `stages[*].health_status` - The computed health status of the stage.
+* `stages[*].levels[*].level_id` - The workload ID of the level entity.
+* `stages[*].levels[*].health_status` - The computed health status of the level.
+* `stages[*].levels[*].steps[*].step_id` - The workload ID of the step entity.
+* `stages[*].levels[*].steps[*].health_status` - The computed health status of the step.
+* `kpis[*].kpi_id` - The unique identifier of the KPI.
+* `stages[*].stage_kpis[*].kpi_id` - The unique identifier of the stage KPI.
+
+## Import
+
+Pathpoint flows can be imported using the entity GUID:
+
+```
+terraform import newrelic_pathpoint.example <guid>
+```
+
+~> **NOTE:** The `account_id` is encoded in the entity GUID. After import, run `terraform state show newrelic_pathpoint.example` to view all attributes.
+
+## Additional Information
+
+More information about Pathpoint can be found in the New Relic [documentation](https://docs.newrelic.com/docs/new-relic-solutions/business-observability/introduction-pathpoint/).

--- a/website/newrelic.erb
+++ b/website/newrelic.erb
@@ -10,6 +10,7 @@
     "application",
     "entity",
     "key_transaction",
+    "pathpoint",
     "synthetics_monitor",
     "synthetics_monitor_location",
     "synthetics_secure_credential",


### PR DESCRIPTION
## Summary

Adds a new Terraform resource `newrelic_pathpoint` generated from the go-client `pathpoint` namespace.

**Generated files:**
- `newrelic/resource_newrelic_pathpoint.go`
- `newrelic/structures_newrelic_pathpoint.go`
- `website/docs/r/pathpoint.html.markdown`

**go-client source:** https://github.com/newrelic/newrelic-client-go/pull/1443 (sha: `7fb4115ca7f7e20ef4772430dc7f390d8eef6efe`)

---
*Generated by [api-governance codegen](https://source.datanerd.us/after/api-governance)*