### PR TITLE
feat: add newrelic_change_tracking_deployment terraform resource

### DIFF
--- a/newrelic/provider_newrelic.go
+++ b/newrelic/provider_newrelic.go
@@ -125,6 +125,7 @@ func Provider() *schema.Provider {
 			"newrelic_api_access_key":               dataSourceNewRelicAPIAccessKey(),
 			"newrelic_application":                  dataSourceNewRelicApplication(),
 			"newrelic_authentication_domain":        dataSourceNewRelicAuthenticationDomain(),
+			"newrelic_change_tracking_deployment": resourceNewRelicChangeTrackingDeployment(),
 			"newrelic_cloud_account":                dataSourceNewRelicCloudAccount(),
 			"newrelic_entity":                       dataSourceNewRelicEntity(),
 			"newrelic_group":                        dataSourceNewRelicGroup(),

--- a/newrelic/resource_newrelic_change_tracking_deployment.go
+++ b/newrelic/resource_newrelic_change_tracking_deployment.go
@@ -1,0 +1,147 @@
+package newrelic
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceNewRelicChangeTrackingDeployment() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNewRelicChangeTrackingDeploymentCreate,
+		ReadContext:   resourceNewRelicChangeTrackingDeploymentRead,
+		DeleteContext: resourceNewRelicChangeTrackingDeploymentDelete,
+		Schema: map[string]*schema.Schema{
+			"version": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"entity_guid": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"changelog": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"commit": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"deep_link": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"deployment_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"BASIC",
+					"BLUE_GREEN",
+					"CANARY",
+					"OTHER",
+					"ROLLING",
+					"SHADOW",
+				}, false),
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"timestamp": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"user": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"deployment_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+	}
+}
+func resourceNewRelicChangeTrackingDeploymentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+
+	input := changetracking.ChangeTrackingDeploymentInput{
+		EntityGUID: common.EntityGUID(d.Get("entity_guid").(string)),
+		Version:    d.Get("version").(string),
+	}
+
+	if v, ok := d.GetOk("changelog"); ok {
+		input.Changelog = v.(string)
+	}
+	if v, ok := d.GetOk("commit"); ok {
+		input.Commit = v.(string)
+	}
+	if v, ok := d.GetOk("deep_link"); ok {
+		input.DeepLink = v.(string)
+	}
+	if v, ok := d.GetOk("deployment_type"); ok {
+		input.DeploymentType = changetracking.ChangeTrackingDeploymentType(v.(string))
+	}
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = v.(string)
+	}
+	if v, ok := d.GetOk("group_id"); ok {
+		input.GroupId = v.(string)
+	}
+	if v, ok := d.GetOk("timestamp"); ok {
+		input.Timestamp = nrtime.EpochMilliseconds(v.(int))
+	}
+	if v, ok := d.GetOk("user"); ok {
+		input.User = v.(string)
+	}
+
+	dataHandlingRules := changetracking.ChangeTrackingDataHandlingRules{}
+
+	result, err := client.ChangeTracking.ChangeTrackingCreateDeploymentWithContext(ctx, dataHandlingRules, input)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(result.DeploymentId)
+	_ = d.Set("deployment_id", result.DeploymentId)
+	_ = d.Set("entity_guid", string(result.EntityGUID))
+	_ = d.Set("version", result.Version)
+	_ = d.Set("changelog", result.Changelog)
+	_ = d.Set("commit", result.Commit)
+	_ = d.Set("deep_link", result.DeepLink)
+	_ = d.Set("deployment_type", string(result.DeploymentType))
+	_ = d.Set("description", result.Description)
+	_ = d.Set("group_id", result.GroupId)
+	_ = d.Set("timestamp", int(result.Timestamp))
+	_ = d.Set("user", result.User)
+
+	return nil
+}
+
+func resourceNewRelicChangeTrackingDeploymentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceNewRelicChangeTrackingDeploymentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	d.SetId("")
+	return nil
+}

--- a/newrelic/structures_newrelic_change_tracking_deployment.go
+++ b/newrelic/structures_newrelic_change_tracking_deployment.go
@@ -1,0 +1,69 @@
+package newrelic
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/changetracking"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/nrtime"
+)
+
+func expandChangeTrackingDeployment(d *schema.ResourceData) (*changetracking.ChangeTrackingDeploymentInput, error) {
+	input := changetracking.ChangeTrackingDeploymentInput{}
+
+	input.Version = d.Get("version").(string)
+	input.EntityGUID = common.EntityGUID(d.Get("entity_guid").(string))
+
+	if v, ok := d.GetOk("changelog"); ok {
+		input.Changelog = v.(string)
+	}
+
+	if v, ok := d.GetOk("commit"); ok {
+		input.Commit = v.(string)
+	}
+
+	if v, ok := d.GetOk("deep_link"); ok {
+		input.DeepLink = v.(string)
+	}
+
+	if v, ok := d.GetOk("deployment_type"); ok {
+		input.DeploymentType = changetracking.ChangeTrackingDeploymentType(v.(string))
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = v.(string)
+	}
+
+	if v, ok := d.GetOk("group_id"); ok {
+		input.GroupId = v.(string)
+	}
+
+	if v, ok := d.GetOk("timestamp"); ok {
+		input.Timestamp = nrtime.EpochMilliseconds(v.(int))
+	}
+
+	if v, ok := d.GetOk("user"); ok {
+		input.User = v.(string)
+	}
+
+	return &input, nil
+}
+
+func expandChangeTrackingDataHandlingRules(d *schema.ResourceData) changetracking.ChangeTrackingDataHandlingRules {
+	return changetracking.ChangeTrackingDataHandlingRules{
+		ValidationFlags: []changetracking.ChangeTrackingValidationFlag{},
+	}
+}
+func flattenChangeTrackingDeployment(result *changetracking.ChangeTrackingDeployment, d *schema.ResourceData) error {
+	_ = d.Set("version", result.Version)
+	_ = d.Set("entity_guid", string(result.EntityGUID))
+	_ = d.Set("changelog", result.Changelog)
+	_ = d.Set("commit", result.Commit)
+	_ = d.Set("deep_link", result.DeepLink)
+	_ = d.Set("deployment_type", string(result.DeploymentType))
+	_ = d.Set("description", result.Description)
+	_ = d.Set("group_id", result.GroupId)
+	_ = d.Set("timestamp", int(result.Timestamp))
+	_ = d.Set("user", result.User)
+	_ = d.Set("deployment_id", result.DeploymentId)
+	return nil
+}

--- a/website/docs/r/change_tracking_deployment.html.markdown
+++ b/website/docs/r/change_tracking_deployment.html.markdown
@@ -1,0 +1,73 @@
+---
+layout: "newrelic"
+page_title: "New Relic: newrelic_change_tracking_deployment"
+sidebar_current: "docs-newrelic-resource-change-tracking-deployment"
+description: |-
+  Create and manage a deployment marker for change tracking in New Relic.
+---
+
+# Resource: newrelic\_change\_tracking\_deployment
+
+Use this resource to create deployment markers for change tracking in New Relic. Details regarding change tracking and deployment markers can be found [here](https://docs.newrelic.com/docs/change-tracking/change-tracking-introduction/).
+
+## Example Usage
+
+```hcl
+resource "newrelic_change_tracking_deployment" "foo" {
+  entity_guid     = "MXxBUE18QVBQTElDQVRJT058MTIzNDU2Nzg"
+  version         = "1.0.0"
+  deployment_type = "BASIC"
+  changelog       = "Added new feature X"
+  commit          = "abc123def456"
+  deep_link       = "https://github.com/example/repo/commit/abc123def456"
+  description     = "Production deployment of version 1.0.0"
+  group_id        = "deployment-group-1"
+  user            = "deployment-bot"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `entity_guid` - (Required) The GUID of the entity the deployment is associated with.
+* `version` - (Required) The version of the deployed software, for example, something like v1.1.
+* `changelog` - (Optional) A URL to the changelog or, if not linkable, a list of changes.
+* `commit` - (Optional) The commit identifier, for example, a Git commit SHA.
+* `deep_link` - (Optional) A URL to the system that generated the deployment.
+* `deployment_type` - (Optional) The type of deployment. One of: `BASIC`, `BLUE_GREEN`, `CANARY`, `OTHER`, `ROLLING`, `SHADOW`.
+* `description` - (Optional) A description of the deployment.
+* `group_id` - (Optional) An identifier used to correlate account-wide changes across entities. These changes are shown together in the `Changes in group` section of the change event details UI.
+* `timestamp` - (Optional) The start time of the deployment as the number of milliseconds since the Unix epoch. Defaults to now.
+* `user` - (Optional) The username of the deployer or bot.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `deployment_id` - The unique identifier of the deployment.
+
+## Import
+
+Change tracking deployments can be imported using the `deployment_id`:
+
+```
+$ terraform import newrelic_change_tracking_deployment.foo <deployment_id>
+```
+
+~> **NOTE:** Change tracking deployments are immutable — all fields require recreation (ForceNew). Importing a deployment will allow you to manage its lifecycle in Terraform, but no updates are supported. Use `ignore_changes` if needed:
+
+```hcl
+resource "newrelic_change_tracking_deployment" "foo" {
+  lifecycle {
+    ignore_changes = all
+  }
+  entity_guid = "MXxBUE18QVBQTElDQVRJT058MTIzNDU2Nzg"
+  version     = "1.0.0"
+}
+```
+
+## Additional Information
+
+More information about change tracking can be found in the New Relic [documentation](https://docs.newrelic.com/docs/change-tracking/change-tracking-introduction/).
+More details about the change tracking API can be found [here](https://docs.newrelic.com/docs/change-tracking/change-tracking-graphql/).

--- a/website/newrelic.erb
+++ b/website/newrelic.erb
@@ -8,6 +8,7 @@
     "alert_channel",
     "alert_policy",
     "application",
+    "change_tracking_deployment",
     "entity",
     "key_transaction",
     "synthetics_monitor",


### PR DESCRIPTION
## Summary

Adds a new Terraform resource `newrelic_change_tracking_deployment` generated from the go-client `changetracking` namespace.

**Generated files:**
- `newrelic/resource_newrelic_change_tracking_deployment.go`
- `newrelic/structures_newrelic_change_tracking_deployment.go`
- `website/docs/r/change_tracking_deployment.html.markdown`

**go-client source:** main @ `main`

**Before this can merge:**
- Check the registration in `newrelic/provider_newrelic.go` is in `ResourcesMap` and not `DataSourcesMap`, and that `website/newrelic.erb` lists it under Resources.
- Nothing here was built or `terraform validate`d. Review the schema against the provider's own naming conventions before approving.

---
*Generated by [api-governance codegen](https://source.datanerd.us/after/api-governance)*