### PR TITLE
feat: add newrelic_organization terraform resource

### DIFF
--- a/newrelic/provider_newrelic.go
+++ b/newrelic/provider_newrelic.go
@@ -131,6 +131,7 @@ func Provider() *schema.Provider {
 			"newrelic_key_transaction":              dataSourceNewRelicKeyTransaction(),
 			"newrelic_notification_destination":     dataSourceNewRelicNotificationDestination(),
 			"newrelic_obfuscation_expression":       dataSourceNewRelicObfuscationExpression(),
+			"newrelic_organization": resourceNewRelicOrganization(),
 			"newrelic_synthetics_private_location":  dataSourceNewRelicSyntheticsPrivateLocation(),
 			"newrelic_synthetics_secure_credential": dataSourceNewRelicSyntheticsSecureCredential(),
 			"newrelic_test_grok_pattern":            dataSourceNewRelicTestGrokPattern(),

--- a/newrelic/resource_newrelic_organization.go
+++ b/newrelic/resource_newrelic_organization.go
@@ -1,0 +1,183 @@
+package newrelic
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceNewRelicOrganization() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNewRelicOrganizationCreate,
+		ReadContext:   resourceNewRelicOrganizationRead,
+		UpdateContext: resourceNewRelicOrganizationUpdate,
+		DeleteContext: resourceNewRelicOrganizationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "The name of the organization.",
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+			},
+			"customer_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The customer ID for the organization.",
+			},
+			"new_managed_account": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "Attributes for creating a new managed account.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The name of the new account to be created.",
+						},
+						"region_code": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The region code for the account to be created.",
+							ValidateFunc: validation.StringInSlice([]string{
+								"EU01",
+								"US01",
+							}, false),
+						},
+					},
+				},
+			},
+			"shared_account": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "Attributes for sharing an account with the new organization.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"account_id": {
+							Type:        schema.TypeInt,
+							Required:    true,
+							Description: "The ID of the account to share with the new organization.",
+						},
+						"limiting_role_id": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "The limiting role ID the new organization will be granted for the shared account.",
+						},
+					},
+				},
+			},
+			"job_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The job ID of the organization creation task.",
+			},
+		},
+	}
+}
+func resourceNewRelicOrganizationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+
+	organizationInput := organization.OrganizationCreateOrganizationInput{
+		Name: d.Get("name").(string),
+	}
+
+	customerID := d.Get("customer_id").(string)
+
+	var newManagedAccountInput *organization.OrganizationNewManagedAccountInput
+	if v, ok := d.GetOk("new_managed_account"); ok {
+		items := v.([]interface{})
+		if len(items) > 0 {
+			cfg := items[0].(map[string]interface{})
+			newManagedAccountInput = &organization.OrganizationNewManagedAccountInput{}
+			if n, ok := cfg["name"].(string); ok && n != "" {
+				newManagedAccountInput.Name = n
+			}
+			if rc, ok := cfg["region_code"].(string); ok && rc != "" {
+				newManagedAccountInput.RegionCode = organization.OrganizationRegionCodeEnum(rc)
+			}
+		}
+	}
+
+	var sharedAccountInput *organization.OrganizationSharedAccountInput
+	if v, ok := d.GetOk("shared_account"); ok {
+		items := v.([]interface{})
+		if len(items) > 0 {
+			cfg := items[0].(map[string]interface{})
+			sharedAccountInput = &organization.OrganizationSharedAccountInput{
+				AccountID: cfg["account_id"].(int),
+			}
+			if lri, ok := cfg["limiting_role_id"].(int); ok {
+				sharedAccountInput.LimitingRoleId = lri
+			}
+		}
+	}
+
+	result, err := client.OrganizationManagement.OrganizationCreateWithContext(ctx, customerID, newManagedAccountInput, organizationInput, sharedAccountInput)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(result.JobId)
+	_ = d.Set("job_id", result.JobId)
+
+	return resourceNewRelicOrganizationRead(ctx, d, meta)
+}
+
+func resourceNewRelicOrganizationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+
+	result, err := client.OrganizationManagement.GetOrganizationWithContext(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if result == nil || result.ID == "" {
+		d.SetId("")
+		return nil
+	}
+
+	_ = d.Set("name", result.Name)
+
+	return nil
+}
+
+func resourceNewRelicOrganizationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+
+	updateInput := organization.OrganizationUpdateInput{
+		Name: d.Get("name").(string),
+	}
+
+	result, err := client.OrganizationManagement.OrganizationUpdateWithContext(ctx, updateInput, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if len(result.Errors) > 0 {
+		var diags diag.Diagnostics
+		for _, e := range result.Errors {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  string(e.Type),
+				Detail:   e.Message,
+			})
+		}
+		return diags
+	}
+
+	_ = d.Set("name", result.OrganizationInformation.Name)
+
+	return resourceNewRelicOrganizationRead(ctx, d, meta)
+}
+
+func resourceNewRelicOrganizationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	d.SetId("")
+	return nil
+}

--- a/newrelic/structures_newrelic_organization.go
+++ b/newrelic/structures_newrelic_organization.go
@@ -1,0 +1,99 @@
+package newrelic
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/organization"
+)
+
+func expandOrganizationCreate(d *schema.ResourceData) (organization.OrganizationCreateOrganizationInput, *organization.OrganizationNewManagedAccountInput, *organization.OrganizationSharedAccountInput) {
+	input := organization.OrganizationCreateOrganizationInput{
+		Name: d.Get("name").(string),
+	}
+
+	var newManagedAccount *organization.OrganizationNewManagedAccountInput
+	if v, ok := d.GetOk("new_managed_account"); ok {
+		items := v.([]interface{})
+		if len(items) > 0 {
+			newManagedAccount = expandOrganizationNewManagedAccount(items[0].(map[string]interface{}))
+		}
+	}
+
+	var sharedAccount *organization.OrganizationSharedAccountInput
+	if v, ok := d.GetOk("shared_account"); ok {
+		items := v.([]interface{})
+		if len(items) > 0 {
+			sharedAccount = expandOrganizationSharedAccount(items[0].(map[string]interface{}))
+		}
+	}
+
+	return input, newManagedAccount, sharedAccount
+}
+
+func expandOrganizationNewManagedAccount(cfg map[string]interface{}) *organization.OrganizationNewManagedAccountInput {
+	input := &organization.OrganizationNewManagedAccountInput{}
+
+	if v, ok := cfg["name"].(string); ok && v != "" {
+		input.Name = v
+	}
+
+	if v, ok := cfg["region_code"].(string); ok && v != "" {
+		input.RegionCode = organization.OrganizationRegionCodeEnum(v)
+	}
+
+	return input
+}
+
+func expandOrganizationSharedAccount(cfg map[string]interface{}) *organization.OrganizationSharedAccountInput {
+	input := &organization.OrganizationSharedAccountInput{}
+
+	if v, ok := cfg["account_id"].(int); ok {
+		input.AccountID = v
+	}
+
+	if v, ok := cfg["limiting_role_id"].(int); ok {
+		input.LimitingRoleId = v
+	}
+
+	return input
+}
+
+func expandOrganizationUpdate(d *schema.ResourceData) organization.OrganizationUpdateInput {
+	return organization.OrganizationUpdateInput{
+		Name: d.Get("name").(string),
+	}
+}
+func flattenOrganization(result *organization.Organization, d *schema.ResourceData) error {
+	if result == nil {
+		return nil
+	}
+
+	_ = d.Set("name", result.Name)
+
+	return nil
+}
+
+func flattenOrganizationNewManagedAccount(input *organization.OrganizationNewManagedAccountInput) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"name":        input.Name,
+		"region_code": string(input.RegionCode),
+	}
+
+	return []interface{}{m}
+}
+
+func flattenOrganizationSharedAccount(input *organization.OrganizationSharedAccountInput) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"account_id":       input.AccountID,
+		"limiting_role_id": input.LimitingRoleId,
+	}
+
+	return []interface{}{m}
+}

--- a/website/docs/r/organization.html.markdown
+++ b/website/docs/r/organization.html.markdown
@@ -1,0 +1,78 @@
+---
+layout: "newrelic"
+page_title: "New Relic: newrelic_organization"
+sidebar_current: "docs-newrelic-resource-organization"
+description: |-
+  Create and manage a New Relic organization.
+---
+
+# Resource: newrelic\_organization
+
+Use this resource to create and manage New Relic organizations.
+
+~> **NOTE:** Deleting this resource via Terraform does not actually delete the organization from New Relic — it simply removes it from Terraform state. Organizations cannot be deleted via API.
+
+## Example Usage
+
+```hcl
+resource "newrelic_organization" "foo" {
+  name = "My New Organization"
+}
+```
+
+## Example Usage with Managed Account and Shared Account
+
+```hcl
+resource "newrelic_organization" "foo" {
+  name        = "My New Organization"
+  customer_id = "customer-123"
+
+  new_managed_account {
+    name        = "My Managed Account"
+    region_code = "US01"
+  }
+
+  shared_account {
+    account_id      = 12345678
+    limiting_role_id = 1234
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the organization.
+* `customer_id` - (Optional) The customer ID for the organization.
+* `new_managed_account` - (Optional) A nested block that describes a new managed account to create along with the organization. Only one `new_managed_account` block is permitted per resource definition. See [Nested new_managed_account blocks](#nested-new_managed_account-blocks) below for details.
+* `shared_account` - (Optional) A nested block that describes an account to share with the new organization. Only one `shared_account` block is permitted per resource definition. See [Nested shared_account blocks](#nested-shared_account-blocks) below for details.
+
+### Nested `new_managed_account` blocks
+
+* `name` - (Optional) The name of the new account to be created.
+* `region_code` - (Optional) The region code for the account to be created. One of: `EU01`, `US01`.
+
+### Nested `shared_account` blocks
+
+* `account_id` - (Required) The ID of the account to share with the new organization.
+* `limiting_role_id` - (Optional) The limiting role ID the new organization will be granted for the shared account.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The job ID of the organization creation task.
+* `job_id` - The job ID of the organization creation task.
+
+## Import
+
+An existing organization can be imported using its organization ID:
+
+```
+terraform import newrelic_organization.foo <organization_id>
+```
+
+~> **NOTE:** After importing, run `terraform state show newrelic_organization.foo` to review the imported state and copy the relevant attributes into your configuration.
+
+~> **NOTE:** Some fields used during creation (such as `customer_id`, `new_managed_account`, and `shared_account`) are only applicable at creation time and will not be reflected in the imported state.

--- a/website/newrelic.erb
+++ b/website/newrelic.erb
@@ -10,6 +10,7 @@
     "application",
     "entity",
     "key_transaction",
+    "organization",
     "synthetics_monitor",
     "synthetics_monitor_location",
     "synthetics_secure_credential",


### PR DESCRIPTION
## Summary

Adds a new Terraform resource `newrelic_organization` generated from the go-client `organization` namespace.

**Generated files:**
- `newrelic/resource_newrelic_organization.go`
- `newrelic/structures_newrelic_organization.go`
- `website/docs/r/organization.html.markdown`

**go-client source:** main @ `main`

**Before this can merge:**
- Check the registration in `newrelic/provider_newrelic.go` is in `ResourcesMap` and not `DataSourcesMap`, and that `website/newrelic.erb` lists it under Resources.
- Nothing here was built or `terraform validate`d. Review the schema against the provider's own naming conventions before approving.

---
*Generated by [api-governance codegen](https://source.datanerd.us/after/api-governance)*