### PR TITLE
feat: add newrelic_pathpoint terraform resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,3 +69,5 @@ require (
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 )
+
+replace github.com/newrelic/newrelic-client-go/v2 => github.com/newrelic/newrelic-client-go/v2 v2.0.0-0.00000000000000-d45ed41675f3

--- a/newrelic/provider_newrelic.go
+++ b/newrelic/provider_newrelic.go
@@ -178,6 +178,7 @@ func Provider() *schema.Provider {
 			"newrelic_cardinality_management":                   resourceNewRelicCardinalityManagement(),
 			"newrelic_metric_pruning_rule":                      resourceNewRelicMetricPruningRule(),
 			"newrelic_nrql_drop_rule":                           resourceNewRelicNRQLDropRule(),
+			"newrelic_pathpoint": resourceNewRelicPathpoint(),
 			"newrelic_pipeline_cloud_rule":                      resourceNewRelicPipelineCloudRule(),
 			"newrelic_obfuscation_expression":                   resourceNewRelicObfuscationExpression(),
 			"newrelic_obfuscation_rule":                         resourceNewRelicObfuscationRule(),

--- a/newrelic/resource_newrelic_pathpoint.go
+++ b/newrelic/resource_newrelic_pathpoint.go
@@ -1,0 +1,660 @@
+package newrelic
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	nrErrors "github.com/newrelic/newrelic-client-go/v2/pkg/errors"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/pathpoint"
+)
+
+func resourceNewRelicPathpoint() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNewRelicPathpointCreate,
+		ReadContext:   resourceNewRelicPathpointRead,
+		UpdateContext: resourceNewRelicPathpointUpdate,
+		DeleteContext: resourceNewRelicPathpointDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"account_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"category": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"health_rollup": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"ALERT_CONDITIONS",
+					"AUTOMATIC_ROLL_UP",
+				}, false),
+			},
+			"refresh_interval": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"FIFTEEN_MINUTES",
+					"FIVE_MINUTES",
+					"ONE_MINUTE",
+					"TEN_MINUTES",
+					"THIRTY_MINUTES",
+				}, false),
+			},
+			"kpis": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kpi_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"account_id": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"category": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"query": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"from": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"where": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"select": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"aggregation_type": {
+													Type:     schema.TypeString,
+													Required: true,
+													ValidateFunc: validation.StringInSlice([]string{
+														"AVERAGE",
+														"COUNT",
+														"HISTOGRAM",
+														"MAX",
+														"MIN",
+														"PERCENTILE",
+														"SUM",
+														"UNIQUE_COUNT",
+													}, false),
+												},
+												"alias": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"attribute": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"threshold": {
+													Type:     schema.TypeFloat,
+													Optional: true,
+												},
+											},
+										},
+									},
+									"time_window": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"custom_range": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"relative_range": {
+													Type:     schema.TypeList,
+													Optional: true,
+													MaxItems: 1,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"since": {
+																Type:     schema.TypeString,
+																Required: true,
+																ValidateFunc: validation.StringInSlice([]string{
+																	"SEVEN_DAYS",
+																	"SIXTY_MINUTES",
+																	"SIX_HOURS",
+																	"THIRTY_DAYS",
+																	"THIRTY_MINUTES",
+																	"THREE_HOURS",
+																	"TWENTY_FOUR_HOURS",
+																}, false),
+															},
+															"compare_against": {
+																Type:     schema.TypeString,
+																Optional: true,
+																ValidateFunc: validation.StringInSlice([]string{
+																	"SEVEN_DAYS",
+																	"SIXTY_MINUTES",
+																	"SIX_HOURS",
+																	"THIRTY_DAYS",
+																	"THIRTY_MINUTES",
+																	"THREE_HOURS",
+																	"TWENTY_FOUR_HOURS",
+																}, false),
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"stages": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"stage_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"health_rollup": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"ALERT_CONDITIONS",
+								"AUTOMATIC_ROLL_UP",
+							}, false),
+						},
+						"is_excluded": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+						"link": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"related": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"source": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
+									"target": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
+								},
+							},
+						},
+						"stage_kpis": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kpi_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"account_id": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+									"category": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"description": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"query": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem:     resourceNewRelicPathpointKpiNRQLSchema(),
+									},
+								},
+							},
+						},
+						"levels": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"level_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"steps": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"step_id": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"name": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"is_excluded": {
+													Type:     schema.TypeBool,
+													Optional: true,
+													Default:  false,
+												},
+												"link": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"scoped_accounts": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem:     &schema.Schema{Type: schema.TypeInt},
+												},
+												"entity_search_query": {
+													Type:     schema.TypeList,
+													Optional: true,
+													MaxItems: 1,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"query": {
+																Type:     schema.TypeString,
+																Required: true,
+															},
+															"is_excluded": {
+																Type:     schema.TypeBool,
+																Optional: true,
+																Default:  false,
+															},
+														},
+													},
+												},
+												"config": {
+													Type:     schema.TypeList,
+													Optional: true,
+													MaxItems: 1,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"health_rollup": {
+																Type:     schema.TypeString,
+																Optional: true,
+																ValidateFunc: validation.StringInSlice([]string{
+																	"BEST_STATUS_WINS",
+																	"WORST_STATUS_WINS",
+																}, false),
+															},
+															"threshold_type": {
+																Type:     schema.TypeString,
+																Optional: true,
+																ValidateFunc: validation.StringInSlice([]string{
+																	"FIXED",
+																	"PERCENTAGE",
+																}, false),
+															},
+															"threshold_value": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+														},
+													},
+												},
+												"signals": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"guid": {
+																Type:     schema.TypeString,
+																Required: true,
+															},
+															"name": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"type": {
+																Type:     schema.TypeString,
+																Optional: true,
+																ValidateFunc: validation.StringInSlice([]string{
+																	"ALERT",
+																	"ENTITY",
+																}, false),
+															},
+															"is_excluded": {
+																Type:     schema.TypeBool,
+																Optional: true,
+																Default:  false,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"guid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceNewRelicPathpointKpiNRQLSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"from": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"where": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"select": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"aggregation_type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"AVERAGE",
+								"COUNT",
+								"HISTOGRAM",
+								"MAX",
+								"MIN",
+								"PERCENTILE",
+								"SUM",
+								"UNIQUE_COUNT",
+							}, false),
+						},
+						"alias": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"attribute": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"threshold": {
+							Type:     schema.TypeFloat,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"time_window": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"custom_range": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"relative_range": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"since": {
+										Type:     schema.TypeString,
+										Required: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											"SEVEN_DAYS",
+											"SIXTY_MINUTES",
+											"SIX_HOURS",
+											"THIRTY_DAYS",
+											"THIRTY_MINUTES",
+											"THREE_HOURS",
+											"TWENTY_FOUR_HOURS",
+										}, false),
+									},
+									"compare_against": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											"SEVEN_DAYS",
+											"SIXTY_MINUTES",
+											"SIX_HOURS",
+											"THIRTY_DAYS",
+											"THIRTY_MINUTES",
+											"THREE_HOURS",
+											"TWENTY_FOUR_HOURS",
+										}, false),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceNewRelicPathpointCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+	accountID := selectAccountID(providerConfig, d)
+
+	input, err := expandPathpointFlowInput(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	scope := pathpoint.PathPointScopeInput{
+		ID:   accountID,
+		Type: pathpoint.PathPointScopeTypeTypes.ACCOUNT,
+	}
+
+	result, err := client.PathPoint.PathPointCreateWithContext(ctx, *input, scope)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(string(result.GUID))
+	_ = d.Set("account_id", accountID)
+
+	return resourceNewRelicPathpointRead(ctx, d, meta)
+}
+
+func resourceNewRelicPathpointRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+	accountID := selectAccountID(providerConfig, d)
+
+	result, err := client.PathPoint.GetFlowWithContext(ctx, accountID, pathpoint.EntityGUID(d.Id()))
+	if err != nil {
+		if _, ok := err.(*nrErrors.NotFound); ok {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+
+	if result == nil || result.GUID == "" {
+		d.SetId("")
+		return nil
+	}
+
+	return diag.FromErr(flattenPathpointFlowResult(result, d))
+}
+
+func resourceNewRelicPathpointUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+
+	input, err := expandPathpointFlowUpdateInput(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	result, err := client.PathPoint.PathPointUpdateWithContext(ctx, pathpoint.EntityGUID(d.Id()), *input)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	_ = result
+
+	return resourceNewRelicPathpointRead(ctx, d, meta)
+}
+
+func resourceNewRelicPathpointDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+
+	_, err := client.PathPoint.PathPointDeleteWithContext(ctx, pathpoint.EntityGUID(d.Id()))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+var _ = fmt.Sprintf
+func resourceNewRelicPathpointCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+	accountID := selectAccountID(providerConfig, d)
+
+	input, err := expandPathpointFlowInput(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	scope := pathpoint.PathPointScopeInput{
+		ID:   accountID,
+		Type: pathpoint.PathPointScopeTypeTypes.ACCOUNT,
+	}
+
+	result, err := client.PathPoint.PathPointCreateWithContext(ctx, *input, scope)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(string(result.GUID))
+	_ = d.Set("account_id", accountID)
+
+	return resourceNewRelicPathpointRead(ctx, d, meta)
+}
+
+func resourceNewRelicPathpointRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+	accountID := selectAccountID(providerConfig, d)
+
+	result, err := client.PathPoint.GetFlowWithContext(ctx, accountID, pathpoint.EntityGUID(d.Id()))
+	if err != nil {
+		if _, ok := err.(*nrErrors.NotFound); ok {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+
+	if result == nil || result.GUID == "" {
+		d.SetId("")
+		return nil
+	}
+
+	return diag.FromErr(flattenPathpointFlowResult(result, d))
+}
+
+func resourceNewRelicPathpointUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+
+	input, err := expandPathpointFlowUpdateInput(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	result, err := client.PathPoint.PathPointUpdateWithContext(ctx, pathpoint.EntityGUID(d.Id()), *input)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	_ = result
+
+	return resourceNewRelicPathpointRead(ctx, d, meta)
+}
+
+func resourceNewRelicPathpointDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+
+	_, err := client.PathPoint.PathPointDeleteWithContext(ctx, pathpoint.EntityGUID(d.Id()))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/newrelic/structures_newrelic_pathpoint.go
+++ b/newrelic/structures_newrelic_pathpoint.go
@@ -1,0 +1,819 @@
+package newrelic
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/pathpoint"
+)
+
+func expandPathpointFlowInput(d *schema.ResourceData) (*pathpoint.PathPointFlowInput, error) {
+	input := &pathpoint.PathPointFlowInput{
+		Name: d.Get("name").(string),
+	}
+
+	if v, ok := d.GetOk("category"); ok {
+		input.Category = v.(string)
+	}
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = v.(string)
+	}
+	if v, ok := d.GetOk("health_rollup"); ok {
+		input.HealthRollup = pathpoint.PathPointFlowHealthRollup(v.(string))
+	}
+	if v, ok := d.GetOk("refresh_interval"); ok {
+		input.RefreshInterval = pathpoint.PathPointRefreshInterval(v.(string))
+	}
+	if v, ok := d.GetOk("kpis"); ok {
+		kpis, err := expandPathpointKpiInputList(v.([]interface{}))
+		if err != nil {
+			return nil, err
+		}
+		input.Kpis = kpis
+	}
+	if v, ok := d.GetOk("stages"); ok {
+		stages, err := expandPathpointStageInputList(v.([]interface{}))
+		if err != nil {
+			return nil, err
+		}
+		input.Stages = stages
+	}
+
+	return input, nil
+}
+
+func expandPathpointFlowUpdateInput(d *schema.ResourceData) (*pathpoint.PathPointFlowUpdateInput, error) {
+	input := &pathpoint.PathPointFlowUpdateInput{
+		Name: d.Get("name").(string),
+	}
+
+	if v, ok := d.GetOk("category"); ok {
+		input.Category = v.(string)
+	}
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = v.(string)
+	}
+	if v, ok := d.GetOk("health_rollup"); ok {
+		input.HealthRollup = pathpoint.PathPointFlowHealthRollup(v.(string))
+	}
+	if v, ok := d.GetOk("refresh_interval"); ok {
+		input.RefreshInterval = pathpoint.PathPointRefreshInterval(v.(string))
+	}
+	if v, ok := d.GetOk("kpis"); ok {
+		kpis, err := expandPathpointKpiUpdateInputList(v.([]interface{}))
+		if err != nil {
+			return nil, err
+		}
+		input.Kpis = kpis
+	}
+	if v, ok := d.GetOk("stages"); ok {
+		stages, err := expandPathpointStageUpdateInputList(v.([]interface{}))
+		if err != nil {
+			return nil, err
+		}
+		input.Stages = stages
+	}
+
+	// version is required for update
+	if v, ok := d.GetOk("version"); ok {
+		input.Version = pathpoint.EpochMilliseconds(v.(string))
+	}
+
+	return input, nil
+}
+
+func expandPathpointKpiInputList(list []interface{}) ([]pathpoint.PathPointKpiInput, error) {
+	if len(list) == 0 {
+		return []pathpoint.PathPointKpiInput{}, nil
+	}
+	out := make([]pathpoint.PathPointKpiInput, len(list))
+	for i, v := range list {
+		cfg, ok := v.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid kpi element at index %d", i)
+		}
+		kpi, err := expandPathpointKpiInput(cfg)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = kpi
+	}
+	return out, nil
+}
+
+func expandPathpointKpiInput(cfg map[string]interface{}) (pathpoint.PathPointKpiInput, error) {
+	kpi := pathpoint.PathPointKpiInput{
+		Name: cfg["name"].(string),
+	}
+	if v, ok := cfg["account_id"]; ok {
+		kpi.AccountID = v.(int)
+	}
+	if v, ok := cfg["category"]; ok {
+		kpi.Category = v.(string)
+	}
+	if v, ok := cfg["description"]; ok {
+		kpi.Description = v.(string)
+	}
+	if v, ok := cfg["query"]; ok {
+		queryList := v.([]interface{})
+		if len(queryList) > 0 {
+			q, err := expandPathpointKpiNRQLInput(queryList[0].(map[string]interface{}))
+			if err != nil {
+				return kpi, err
+			}
+			kpi.Query = q
+		}
+	}
+	return kpi, nil
+}
+
+func expandPathpointKpiUpdateInputList(list []interface{}) ([]pathpoint.PathPointKpiUpdateInput, error) {
+	if len(list) == 0 {
+		return []pathpoint.PathPointKpiUpdateInput{}, nil
+	}
+	out := make([]pathpoint.PathPointKpiUpdateInput, len(list))
+	for i, v := range list {
+		cfg, ok := v.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid kpi element at index %d", i)
+		}
+		kpi, err := expandPathpointKpiUpdateInput(cfg)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = kpi
+	}
+	return out, nil
+}
+
+func expandPathpointKpiUpdateInput(cfg map[string]interface{}) (pathpoint.PathPointKpiUpdateInput, error) {
+	kpi := pathpoint.PathPointKpiUpdateInput{
+		Name: cfg["name"].(string),
+	}
+	if v, ok := cfg["kpi_id"]; ok {
+		kpi.ID = v.(string)
+	}
+	if v, ok := cfg["account_id"]; ok {
+		kpi.AccountID = v.(int)
+	}
+	if v, ok := cfg["category"]; ok {
+		kpi.Category = v.(string)
+	}
+	if v, ok := cfg["description"]; ok {
+		kpi.Description = v.(string)
+	}
+	if v, ok := cfg["query"]; ok {
+		queryList := v.([]interface{})
+		if len(queryList) > 0 {
+			q, err := expandPathpointKpiNRQLInput(queryList[0].(map[string]interface{}))
+			if err != nil {
+				return kpi, err
+			}
+			kpi.Query = q
+		}
+	}
+	return kpi, nil
+}
+
+func expandPathpointKpiNRQLInput(cfg map[string]interface{}) (pathpoint.PathPointKpiNRQLInput, error) {
+	q := pathpoint.PathPointKpiNRQLInput{
+		From: pathpoint.NRQL(cfg["from"].(string)),
+	}
+	if v, ok := cfg["where"]; ok {
+		q.Where = v.(string)
+	}
+	if v, ok := cfg["select"]; ok {
+		selectList := v.([]interface{})
+		if len(selectList) > 0 {
+			s := expandPathpointKpiNRQLSelectInput(selectList[0].(map[string]interface{}))
+			q.Select = s
+		}
+	}
+	if v, ok := cfg["time_window"]; ok {
+		twList := v.([]interface{})
+		if len(twList) > 0 {
+			tw, err := expandPathpointKpiTimeWindowInput(twList[0].(map[string]interface{}))
+			if err != nil {
+				return q, err
+			}
+			q.TimeWindow = tw
+		}
+	}
+	return q, nil
+}
+
+func expandPathpointKpiNRQLSelectInput(cfg map[string]interface{}) pathpoint.PathPointKpiNRQLSelectInput {
+	s := pathpoint.PathPointKpiNRQLSelectInput{
+		AggregationType: pathpoint.PathPointKpiNRQLAggregations(cfg["aggregation_type"].(string)),
+	}
+	if v, ok := cfg["alias"]; ok {
+		s.Alias = v.(string)
+	}
+	if v, ok := cfg["attribute"]; ok {
+		s.Attribute = v.(string)
+	}
+	if v, ok := cfg["threshold"]; ok {
+		s.Threshold = v.(float64)
+	}
+	return s
+}
+
+func expandPathpointKpiTimeWindowInput(cfg map[string]interface{}) (*pathpoint.PathPointKpiTimeWindowInput, error) {
+	tw := &pathpoint.PathPointKpiTimeWindowInput{}
+	if v, ok := cfg["custom_range"]; ok {
+		tw.CustomRange = pathpoint.NRQL(v.(string))
+	}
+	if v, ok := cfg["relative_range"]; ok {
+		rrList := v.([]interface{})
+		if len(rrList) > 0 {
+			rr := expandPathpointKpiTimeWindowRelativeRangeInput(rrList[0].(map[string]interface{}))
+			tw.RelativeRange = rr
+		}
+	}
+	return tw, nil
+}
+
+func expandPathpointKpiTimeWindowRelativeRangeInput(cfg map[string]interface{}) *pathpoint.PathPointKpiTimeWindowRelativeRangeInput {
+	rr := &pathpoint.PathPointKpiTimeWindowRelativeRangeInput{
+		Since: pathpoint.PathPointKpiTimeDuration(cfg["since"].(string)),
+	}
+	if v, ok := cfg["compare_against"]; ok {
+		rr.CompareAgainst = pathpoint.PathPointKpiTimeDuration(v.(string))
+	}
+	return rr
+}
+
+func expandPathpointStageInputList(list []interface{}) ([]pathpoint.PathPointStageInput, error) {
+	if len(list) == 0 {
+		return []pathpoint.PathPointStageInput{}, nil
+	}
+	out := make([]pathpoint.PathPointStageInput, len(list))
+	for i, v := range list {
+		cfg, ok := v.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid stage element at index %d", i)
+		}
+		stage, err := expandPathpointStageInput(cfg)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = stage
+	}
+	return out, nil
+}
+
+func expandPathpointStageInput(cfg map[string]interface{}) (pathpoint.PathPointStageInput, error) {
+	stage := pathpoint.PathPointStageInput{
+		Name: cfg["name"].(string),
+	}
+	if v, ok := cfg["health_rollup"]; ok {
+		stage.HealthRollup = pathpoint.PathPointStageHealthRollup(v.(string))
+	}
+	if v, ok := cfg["is_excluded"]; ok {
+		stage.IsExcluded = v.(bool)
+	}
+	if v, ok := cfg["link"]; ok {
+		stage.Link = v.(string)
+	}
+	if v, ok := cfg["related"]; ok {
+		relList := v.([]interface{})
+		if len(relList) > 0 {
+			stage.Related = expandPathpointRelatedInput(relList[0].(map[string]interface{}))
+		}
+	}
+	if v, ok := cfg["stage_kpis"]; ok {
+		kpis, err := expandPathpointKpiInputList(v.([]interface{}))
+		if err != nil {
+			return stage, err
+		}
+		stage.StageKpis = kpis
+	}
+	if v, ok := cfg["levels"]; ok {
+		levels, err := expandPathpointLevelInputList(v.([]interface{}))
+		if err != nil {
+			return stage, err
+		}
+		stage.Levels = levels
+	}
+	return stage, nil
+}
+
+func expandPathpointStageUpdateInputList(list []interface{}) ([]pathpoint.PathPointStageUpdateInput, error) {
+	if len(list) == 0 {
+		return []pathpoint.PathPointStageUpdateInput{}, nil
+	}
+	out := make([]pathpoint.PathPointStageUpdateInput, len(list))
+	for i, v := range list {
+		cfg, ok := v.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid stage element at index %d", i)
+		}
+		stage, err := expandPathpointStageUpdateInput(cfg)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = stage
+	}
+	return out, nil
+}
+
+func expandPathpointStageUpdateInput(cfg map[string]interface{}) (pathpoint.PathPointStageUpdateInput, error) {
+	stage := pathpoint.PathPointStageUpdateInput{
+		Name: cfg["name"].(string),
+	}
+	if v, ok := cfg["stage_id"]; ok {
+		stage.ID = v.(string)
+	}
+	if v, ok := cfg["health_rollup"]; ok {
+		stage.HealthRollup = pathpoint.PathPointStageHealthRollup(v.(string))
+	}
+	if v, ok := cfg["is_excluded"]; ok {
+		stage.IsExcluded = v.(bool)
+	}
+	if v, ok := cfg["link"]; ok {
+		stage.Link = v.(string)
+	}
+	if v, ok := cfg["related"]; ok {
+		relList := v.([]interface{})
+		if len(relList) > 0 {
+			stage.Related = expandPathpointRelatedInput(relList[0].(map[string]interface{}))
+		}
+	}
+	if v, ok := cfg["stage_kpis"]; ok {
+		kpis, err := expandPathpointKpiUpdateInputList(v.([]interface{}))
+		if err != nil {
+			return stage, err
+		}
+		stage.StageKpis = kpis
+	}
+	if v, ok := cfg["levels"]; ok {
+		levels, err := expandPathpointLevelUpdateInputList(v.([]interface{}))
+		if err != nil {
+			return stage, err
+		}
+		stage.Levels = levels
+	}
+	return stage, nil
+}
+
+func expandPathpointRelatedInput(cfg map[string]interface{}) pathpoint.PathPointRelatedInput {
+	related := pathpoint.PathPointRelatedInput{}
+	if v, ok := cfg["source"]; ok {
+		related.Source = v.(bool)
+	}
+	if v, ok := cfg["target"]; ok {
+		related.Target = v.(bool)
+	}
+	return related
+}
+
+func expandPathpointLevelInputList(list []interface{}) ([]pathpoint.PathPointLevelInput, error) {
+	if len(list) == 0 {
+		return []pathpoint.PathPointLevelInput{}, nil
+	}
+	out := make([]pathpoint.PathPointLevelInput, len(list))
+	for i, v := range list {
+		cfg, ok := v.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid level element at index %d", i)
+		}
+		level, err := expandPathpointLevelInput(cfg)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = level
+	}
+	return out, nil
+}
+
+func expandPathpointLevelInput(cfg map[string]interface{}) (pathpoint.PathPointLevelInput, error) {
+	level := pathpoint.PathPointLevelInput{}
+	if v, ok := cfg["steps"]; ok {
+		steps, err := expandPathpointStepInputList(v.([]interface{}))
+		if err != nil {
+			return level, err
+		}
+		level.Steps = steps
+	}
+	return level, nil
+}
+
+func expandPathpointLevelUpdateInputList(list []interface{}) ([]pathpoint.PathPointLevelUpdateInput, error) {
+	if len(list) == 0 {
+		return []pathpoint.PathPointLevelUpdateInput{}, nil
+	}
+	out := make([]pathpoint.PathPointLevelUpdateInput, len(list))
+	for i, v := range list {
+		cfg, ok := v.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid level element at index %d", i)
+		}
+		level, err := expandPathpointLevelUpdateInput(cfg)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = level
+	}
+	return out, nil
+}
+
+func expandPathpointLevelUpdateInput(cfg map[string]interface{}) (pathpoint.PathPointLevelUpdateInput, error) {
+	level := pathpoint.PathPointLevelUpdateInput{}
+	if v, ok := cfg["level_id"]; ok {
+		level.ID = v.(string)
+	}
+	if v, ok := cfg["steps"]; ok {
+		steps, err := expandPathpointStepUpdateInputList(v.([]interface{}))
+		if err != nil {
+			return level, err
+		}
+		level.Steps = steps
+	}
+	return level, nil
+}
+
+func expandPathpointStepInputList(list []interface{}) ([]pathpoint.PathPointStepInput, error) {
+	if len(list) == 0 {
+		return []pathpoint.PathPointStepInput{}, nil
+	}
+	out := make([]pathpoint.PathPointStepInput, len(list))
+	for i, v := range list {
+		cfg, ok := v.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid step element at index %d", i)
+		}
+		step, err := expandPathpointStepInput(cfg)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = step
+	}
+	return out, nil
+}
+
+func expandPathpointStepInput(cfg map[string]interface{}) (pathpoint.PathPointStepInput, error) {
+	step := pathpoint.PathPointStepInput{
+		Name: cfg["name"].(string),
+	}
+	if v, ok := cfg["is_excluded"]; ok {
+		step.IsExcluded = v.(bool)
+	}
+	if v, ok := cfg["link"]; ok {
+		step.Link = v.(string)
+	}
+	if v, ok := cfg["scoped_accounts"]; ok {
+		rawList := v.([]interface{})
+		accounts := make([]int, len(rawList))
+		for i, a := range rawList {
+			accounts[i] = a.(int)
+		}
+		step.ScopedAccounts = accounts
+	}
+	if v, ok := cfg["entity_search_query"]; ok {
+		eqList := v.([]interface{})
+		if len(eqList) > 0 {
+			eq := expandPathpointSignalQueryInput(eqList[0].(map[string]interface{}))
+			step.EntitySearchQuery = eq
+		}
+	}
+	if v, ok := cfg["config"]; ok {
+		cfgList := v.([]interface{})
+		if len(cfgList) > 0 {
+			step.Config = expandPathpointStepStatusThresholdInput(cfgList[0].(map[string]interface{}))
+		}
+	}
+	if v, ok := cfg["signals"]; ok {
+		signals, err := expandPathpointSignalInputList(v.([]interface{}))
+		if err != nil {
+			return step, err
+		}
+		step.Signals = signals
+	}
+	return step, nil
+}
+
+func expandPathpointStepUpdateInputList(list []interface{}) ([]pathpoint.PathPointStepUpdateInput, error) {
+	if len(list) == 0 {
+		return []pathpoint.PathPointStepUpdateInput{}, nil
+	}
+	out := make([]pathpoint.PathPointStepUpdateInput, len(list))
+	for i, v := range list {
+		cfg, ok := v.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid step element at index %d", i)
+		}
+		step, err := expandPathpointStepUpdateInput(cfg)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = step
+	}
+	return out, nil
+}
+
+func expandPathpointStepUpdateInput(cfg map[string]interface{}) (pathpoint.PathPointStepUpdateInput, error) {
+	step := pathpoint.PathPointStepUpdateInput{
+		Name: cfg["name"].(string),
+	}
+	if v, ok := cfg["step_id"]; ok {
+		step.ID = v.(string)
+	}
+	if v, ok := cfg["is_excluded"]; ok {
+		step.IsExcluded = v.(bool)
+	}
+	if v, ok := cfg["link"]; ok {
+		step.Link = v.(string)
+	}
+	if v, ok := cfg["scoped_accounts"]; ok {
+		rawList := v.([]interface{})
+		accounts := make([]int, len(rawList))
+		for i, a := range rawList {
+			accounts[i] = a.(int)
+		}
+		step.ScopedAccounts = accounts
+	}
+	if v, ok := cfg["entity_search_query"]; ok {
+		eqList := v.([]interface{})
+		if len(eqList) > 0 {
+			eq := expandPathpointSignalQueryInput(eqList[0].(map[string]interface{}))
+			step.EntitySearchQuery = eq
+		}
+	}
+	if v, ok := cfg["config"]; ok {
+		cfgList := v.([]interface{})
+		if len(cfgList) > 0 {
+			step.Config = expandPathpointStepStatusThresholdInput(cfgList[0].(map[string]interface{}))
+		}
+	}
+	if v, ok := cfg["signals"]; ok {
+		signals, err := expandPathpointSignalInputList(v.([]interface{}))
+		if err != nil {
+			return step, err
+		}
+		step.Signals = signals
+	}
+	return step, nil
+}
+
+func expandPathpointSignalQueryInput(cfg map[string]interface{}) *pathpoint.PathPointSignalQueryInput {
+	eq := &pathpoint.PathPointSignalQueryInput{
+		Query: cfg["query"].(string),
+	}
+	if v, ok := cfg["is_excluded"]; ok {
+		eq.IsExcluded = v.(bool)
+	}
+	return eq
+}
+
+func expandPathpointStepStatusThresholdInput(cfg map[string]interface{}) pathpoint.PathPointStepStatusThresholdInput {
+	threshold := pathpoint.PathPointStepStatusThresholdInput{}
+	if v, ok := cfg["health_rollup"]; ok {
+		threshold.HealthRollup = pathpoint.PathPointStepHealthRollup(v.(string))
+	}
+	if v, ok := cfg["threshold_type"]; ok {
+		threshold.ThresholdType = pathpoint.PathPointThresholdType(v.(string))
+	}
+	if v, ok := cfg["threshold_value"]; ok {
+		threshold.ThresholdValue = v.(int)
+	}
+	return threshold
+}
+
+func expandPathpointSignalInputList(list []interface{}) ([]pathpoint.PathPointSignalInput, error) {
+	if len(list) == 0 {
+		return []pathpoint.PathPointSignalInput{}, nil
+	}
+	out := make([]pathpoint.PathPointSignalInput, len(list))
+	for i, v := range list {
+		cfg, ok := v.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid signal element at index %d", i)
+		}
+		out[i] = expandPathpointSignalInput(cfg)
+	}
+	return out, nil
+}
+
+func expandPathpointSignalInput(cfg map[string]interface{}) pathpoint.PathPointSignalInput {
+	signal := pathpoint.PathPointSignalInput{
+		GUID: pathpoint.EntityGUID(cfg["guid"].(string)),
+	}
+	if v, ok := cfg["name"]; ok {
+		signal.Name = v.(string)
+	}
+	if v, ok := cfg["type"]; ok {
+		signal.Type = pathpoint.PathPointSignalType(v.(string))
+	}
+	if v, ok := cfg["is_excluded"]; ok {
+		signal.IsExcluded = v.(bool)
+	}
+	return signal
+}
+
+// EpochMilliseconds is a type alias helper used for version field conversion.
+// pathpoint.EpochMilliseconds is actually nrtime.EpochMilliseconds — use it directly.
+func init() {
+	// ensure schema package is used
+	_ = schema.TypeString
+}
+func flattenPathpointFlowResult(result *pathpoint.PathPointFlowResult, d *schema.ResourceData) error {
+	if result == nil {
+		return nil
+	}
+
+	_ = d.Set("name", result.Name)
+	_ = d.Set("category", result.Category)
+	_ = d.Set("description", result.Description)
+	_ = d.Set("health_rollup", string(result.HealthRollup))
+	_ = d.Set("refresh_interval", string(result.RefreshInterval))
+	_ = d.Set("guid", string(result.GUID))
+	_ = d.Set("version", result.Version.String())
+
+	if err := d.Set("kpis", flattenPathpointKpis(result.Kpis)); err != nil {
+		return fmt.Errorf("[DEBUG] Error setting `kpis`: %v", err)
+	}
+
+	if err := d.Set("stages", flattenPathpointStages(result.Stages.Items)); err != nil {
+		return fmt.Errorf("[DEBUG] Error setting `stages`: %v", err)
+	}
+
+	return nil
+}
+
+func flattenPathpointKpis(kpis []pathpoint.PathPointKpi) []interface{} {
+	out := make([]interface{}, len(kpis))
+	for i, kpi := range kpis {
+		m := map[string]interface{}{
+			"kpi_id":      kpi.ID,
+			"name":        kpi.Name,
+			"account_id":  kpi.AccountID,
+			"category":    kpi.Category,
+			"description": kpi.Description,
+		}
+		m["query"] = flattenPathpointKpiNRQL(kpi.Query)
+		out[i] = m
+	}
+	return out
+}
+
+func flattenPathpointKpiNRQL(query pathpoint.PathPointKpiNRQL) []interface{} {
+	m := map[string]interface{}{
+		"from":  string(query.From),
+		"where": query.Where,
+	}
+
+	m["select"] = flattenPathpointKpiNRQLSelect(query.Select)
+	m["time_window"] = flattenPathpointKpiTimeWindow(query.TimeWindow)
+
+	return []interface{}{m}
+}
+
+func flattenPathpointKpiNRQLSelect(sel pathpoint.PathPointKpiNRQLSelect) []interface{} {
+	m := map[string]interface{}{
+		"aggregation_type": string(sel.AggregationType),
+		"alias":            sel.Alias,
+		"attribute":        sel.Attribute,
+		"threshold":        sel.Threshold,
+	}
+	return []interface{}{m}
+}
+
+func flattenPathpointKpiTimeWindow(tw pathpoint.PathPointKpiTimeWindow) []interface{} {
+	if tw.CustomRange == "" && tw.RelativeRange == (pathpoint.PathPointKpiTimeWindowRelativeRange{}) {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"custom_range": string(tw.CustomRange),
+	}
+
+	if tw.RelativeRange != (pathpoint.PathPointKpiTimeWindowRelativeRange{}) {
+		rr := map[string]interface{}{
+			"since":           string(tw.RelativeRange.Since),
+			"compare_against": string(tw.RelativeRange.CompareAgainst),
+		}
+		m["relative_range"] = []interface{}{rr}
+	} else {
+		m["relative_range"] = []interface{}{}
+	}
+
+	return []interface{}{m}
+}
+
+func flattenPathpointStages(stages []pathpoint.PathPointStage) []interface{} {
+	out := make([]interface{}, len(stages))
+	for i, stage := range stages {
+		m := map[string]interface{}{
+			"stage_id":     stage.ID,
+			"name":         stage.Name,
+			"health_rollup": string(stage.HealthRollup),
+			"is_excluded":  stage.IsExcluded,
+			"link":         stage.Link,
+		}
+
+		m["related"] = flattenPathpointRelated(stage.Related)
+		m["stage_kpis"] = flattenPathpointStageKpis(stage.StageKpis)
+		m["levels"] = flattenPathpointLevels(stage.Levels.Items)
+
+		out[i] = m
+	}
+	return out
+}
+
+func flattenPathpointRelated(related pathpoint.PathPointRelated) []interface{} {
+	m := map[string]interface{}{
+		"source": related.Source,
+		"target": related.Target,
+	}
+	return []interface{}{m}
+}
+
+func flattenPathpointStageKpis(kpis []pathpoint.PathPointKpi) []interface{} {
+	out := make([]interface{}, len(kpis))
+	for i, kpi := range kpis {
+		m := map[string]interface{}{
+			"kpi_id":      kpi.ID,
+			"name":        kpi.Name,
+			"account_id":  kpi.AccountID,
+			"category":    kpi.Category,
+			"description": kpi.Description,
+		}
+		m["query"] = flattenPathpointKpiNRQL(kpi.Query)
+		out[i] = m
+	}
+	return out
+}
+
+func flattenPathpointLevels(levels []pathpoint.PathPointLevel) []interface{} {
+	out := make([]interface{}, len(levels))
+	for i, level := range levels {
+		m := map[string]interface{}{
+			"level_id": level.ID,
+		}
+		m["steps"] = flattenPathpointSteps(level.Steps.Items)
+		out[i] = m
+	}
+	return out
+}
+
+func flattenPathpointSteps(steps []pathpoint.PathPointStep) []interface{} {
+	out := make([]interface{}, len(steps))
+	for i, step := range steps {
+		m := map[string]interface{}{
+			"step_id":     step.ID,
+			"name":        step.Name,
+			"is_excluded": step.IsExcluded,
+			"link":        step.Link,
+		}
+
+		scopedAccounts := make([]interface{}, len(step.ScopedAccounts))
+		for j, v := range step.ScopedAccounts {
+			scopedAccounts[j] = v
+		}
+		m["scoped_accounts"] = scopedAccounts
+
+		m["entity_search_query"] = flattenPathpointEntitySearchQuery(step.EntitySearchQuery)
+		m["config"] = flattenPathpointStepConfig(step.Config)
+		m["signals"] = flattenPathpointSignals(step.Signals)
+
+		out[i] = m
+	}
+	return out
+}
+
+func flattenPathpointEntitySearchQuery(q pathpoint.PathPointSignalQuery) []interface{} {
+	if q.Query == "" && !q.IsExcluded {
+		return []interface{}{}
+	}
+	m := map[string]interface{}{
+		"query":       q.Query,
+		"is_excluded": q.IsExcluded,
+	}
+	return []interface{}{m}
+}
+
+func flattenPathpointStepConfig(config pathpoint.PathPointStepStatusThreshold) []interface{} {
+	if config.HealthRollup == "" && config.ThresholdType == "" && config.ThresholdValue == 0 {
+		return []interface{}{}
+	}
+	m := map[string]interface{}{
+		"health_rollup":   string(config.HealthRollup),
+		"threshold_type":  string(config.ThresholdType),
+		"threshold_value": config.ThresholdValue,
+	}
+	return []interface{}{m}
+}
+
+func flattenPathpointSignals(signals []pathpoint.PathPointSignal) []interface{} {
+	out := make([]interface{}, len(signals))
+	for i, sig := range signals {
+		m := map[string]interface{}{
+			"guid":        string(sig.GUID),
+			"name":        sig.Name,
+			"type":        string(sig.Type),
+			"is_excluded": sig.IsExcluded,
+		}
+		out[i] = m
+	}
+	return out
+}

--- a/website/docs/r/pathpoint.html.markdown
+++ b/website/docs/r/pathpoint.html.markdown
@@ -1,0 +1,222 @@
+---
+layout: "newrelic"
+page_title: "New Relic: newrelic_pathpoint"
+sidebar_current: "docs-newrelic-resource-pathpoint"
+description: |-
+  Create and manage a Pathpoint flow in New Relic.
+---
+
+# Resource: newrelic\_pathpoint
+
+Use this resource to create and manage New Relic Pathpoint flows. Pathpoint is an enterprise platform tracker that monitors the health of each stage of a business flow, from first contact through to conversion. Details regarding Pathpoint can be found [here](https://docs.newrelic.com/docs/new-relic-solutions/business-observability/introduction-pathpoint/).
+
+## Example Usage
+
+```hcl
+resource "newrelic_pathpoint" "example" {
+  account_id       = 12345678
+  name             = "My Business Flow"
+  category         = "Checkout"
+  description      = "End-to-end checkout flow"
+  health_rollup    = "AUTOMATIC_ROLL_UP"
+  refresh_interval = "ONE_MINUTE"
+
+  kpis {
+    name        = "Conversion Rate"
+    account_id  = 12345678
+    description = "Overall conversion KPI"
+
+    query {
+      from  = "Transaction"
+      where = "appName = 'MyApp'"
+
+      select {
+        aggregation_type = "COUNT"
+        alias            = "conversions"
+      }
+
+      time_window {
+        relative_range {
+          since           = "TWENTY_FOUR_HOURS"
+          compare_against = "SEVEN_DAYS"
+        }
+      }
+    }
+  }
+
+  stages {
+    name          = "Checkout"
+    health_rollup = "AUTOMATIC_ROLL_UP"
+    is_excluded   = false
+    link          = "https://example.com/checkout"
+
+    related {
+      source = false
+      target = false
+    }
+
+    stage_kpis {
+      name       = "Stage KPI"
+      account_id = 12345678
+
+      query {
+        from = "Transaction"
+
+        select {
+          aggregation_type = "COUNT"
+        }
+      }
+    }
+
+    levels {
+      steps {
+        name        = "Payment Step"
+        is_excluded = false
+        link        = "https://example.com/payment"
+
+        scoped_accounts = [12345678]
+
+        entity_search_query {
+          query       = "domain='NR1' AND type='APPLICATION'"
+          is_excluded = false
+        }
+
+        config {
+          health_rollup   = "WORST_STATUS_WINS"
+          threshold_type  = "PERCENTAGE"
+          threshold_value = 90
+        }
+
+        signals {
+          guid        = "MXxBUE18QVBQTElDQVRJT058MTIz"
+          name        = "My Application"
+          type        = "ENTITY"
+          is_excluded = false
+        }
+      }
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `account_id` - (Optional) Determines the New Relic account where the Pathpoint flow will be created. Defaults to the account associated with the API key used.
+* `name` - (Required) The display name of the Pathpoint flow.
+* `category` - (Optional) A category used to group flows (e.g. Marketing, Checkout).
+* `description` - (Optional) A description of the Pathpoint flow.
+* `health_rollup` - (Optional) Health rollup strategy for the flow, derived from its stages. One of: `ALERT_CONDITIONS`, `AUTOMATIC_ROLL_UP`.
+* `refresh_interval` - (Optional) How frequently the flow, stage, level, and step health statuses are fetched. One of: `FIFTEEN_MINUTES`, `FIVE_MINUTES`, `ONE_MINUTE`, `TEN_MINUTES`, `THIRTY_MINUTES`.
+* `kpis` - (Optional) A list of KPIs tracked at the flow level. See [Nested `kpis` blocks](#nested-kpis-blocks) below for details.
+* `stages` - (Optional) The ordered list of stages that make up this flow. Maximum 50 stages allowed. See [Nested `stages` blocks](#nested-stages-blocks) below for details.
+
+### Nested `kpis` blocks
+
+* `name` - (Required) The display name of the KPI.
+* `account_id` - (Optional) The account ID this KPI belongs to.
+* `category` - (Optional) Optional category to group KPIs.
+* `description` - (Optional) Optional description of this KPI.
+* `query` - (Optional) The NRQL query definition for this KPI. Only one `query` block is permitted per KPI. See [Nested `query` blocks](#nested-query-blocks) below for details.
+* `kpi_id` - (Computed) The unique identifier of the KPI assigned by the API.
+
+### Nested `query` blocks
+
+* `from` - (Required) The data source to query from (e.g., `Transaction`, `Metric`, `Log`).
+* `where` - (Optional) Optional WHERE clause conditions to filter the data.
+* `select` - (Optional) The SELECT clause defining what to aggregate and return. Only one `select` block is permitted per query. See [Nested `select` blocks](#nested-select-blocks) below for details.
+* `time_window` - (Optional) The time window over which the KPI is evaluated. Only one `time_window` block is permitted per query. See [Nested `time_window` blocks](#nested-time_window-blocks) below for details.
+
+### Nested `select` blocks
+
+* `aggregation_type` - (Required) The aggregation function to apply to the attribute. One of: `AVERAGE`, `COUNT`, `HISTOGRAM`, `MAX`, `MIN`, `PERCENTILE`, `SUM`, `UNIQUE_COUNT`.
+* `alias` - (Optional) Optional alias for the aggregated value in the query result.
+* `attribute` - (Optional) The attribute name to aggregate. Required for all functions except `COUNT`.
+* `threshold` - (Optional) The threshold used in the selected function.
+
+### Nested `time_window` blocks
+
+* `custom_range` - (Optional) A raw NRQL time fragment, e.g. `SINCE 3 days ago COMPARE WITH 1 day ago`. Mutually exclusive with `relative_range`.
+* `relative_range` - (Optional) A relative window built from predefined duration values. Mutually exclusive with `custom_range`. Only one `relative_range` block is permitted per `time_window`. See [Nested `relative_range` blocks](#nested-relative_range-blocks) below for details.
+
+### Nested `relative_range` blocks
+
+* `since` - (Required) How far back the KPI is evaluated (maps to NRQL `SINCE`). One of: `SEVEN_DAYS`, `SIXTY_MINUTES`, `SIX_HOURS`, `THIRTY_DAYS`, `THIRTY_MINUTES`, `THREE_HOURS`, `TWENTY_FOUR_HOURS`.
+* `compare_against` - (Optional) The earlier window the current window is compared against (maps to NRQL `COMPARE WITH`). One of: `SEVEN_DAYS`, `SIXTY_MINUTES`, `SIX_HOURS`, `THIRTY_DAYS`, `THIRTY_MINUTES`, `THREE_HOURS`, `TWENTY_FOUR_HOURS`.
+
+### Nested `stages` blocks
+
+* `name` - (Required) The display name of the stage.
+* `health_rollup` - (Optional) Health rollup strategy for the stage, derived from its levels. One of: `ALERT_CONDITIONS`, `AUTOMATIC_ROLL_UP`.
+* `is_excluded` - (Optional) When true, this stage is excluded from the flow health calculation. Defaults to `false`.
+* `link` - (Optional) Optional URL to an external resource related to this stage.
+* `related` - (Optional) Defines whether this stage is a source, target, or both in a flow relationship. Only one `related` block is permitted per stage. See [Nested `related` blocks](#nested-related-blocks) below for details.
+* `stage_kpis` - (Optional) KPIs tracked at the stage level. See [Nested `stage_kpis` blocks](#nested-stage_kpis-blocks) below for details.
+* `levels` - (Optional) The ordered list of levels within this stage. Maximum 50 levels allowed. See [Nested `levels` blocks](#nested-levels-blocks) below for details.
+* `stage_id` - (Computed) The workload ID of the stage entity assigned by the API.
+
+### Nested `related` blocks
+
+* `source` - (Optional) When true, this stage acts as a source to other stages. Defaults to `false`.
+* `target` - (Optional) When true, this stage acts as a target to other stages. Defaults to `false`.
+
+### Nested `stage_kpis` blocks
+
+* `name` - (Required) The display name of the KPI.
+* `account_id` - (Optional) The account ID this KPI belongs to.
+* `category` - (Optional) Optional category to group KPIs.
+* `description` - (Optional) Optional description of this KPI.
+* `query` - (Optional) The NRQL query definition for this KPI. Only one `query` block is permitted per KPI. See [Nested `query` blocks](#nested-query-blocks) above for details.
+* `kpi_id` - (Computed) The unique identifier of the KPI assigned by the API.
+
+### Nested `levels` blocks
+
+* `steps` - (Optional) The ordered list of steps within this level. Maximum 50 steps allowed. See [Nested `steps` blocks](#nested-steps-blocks) below for details.
+* `level_id` - (Computed) The workload ID of the level entity assigned by the API.
+
+### Nested `steps` blocks
+
+* `name` - (Required) The display name of the step.
+* `is_excluded` - (Optional) When true, this step is excluded from the level health calculation. Defaults to `false`.
+* `link` - (Optional) Optional URL to an external resource related to this step.
+* `scoped_accounts` - (Optional) A list of account IDs whose entities are included in scope for this step.
+* `entity_search_query` - (Optional) A filter query used to fetch the signals for this step. Only one `entity_search_query` block is permitted per step. See [Nested `entity_search_query` blocks](#nested-entity_search_query-blocks) below for details.
+* `config` - (Optional) Health evaluation configuration for this step. Only one `config` block is permitted per step. See [Nested `config` blocks](#nested-config-blocks) below for details.
+* `signals` - (Optional) Entity signals associated with this step. See [Nested `signals` blocks](#nested-signals-blocks) below for details.
+* `step_id` - (Computed) The workload ID of the step entity assigned by the API.
+
+### Nested `entity_search_query` blocks
+
+* `query` - (Required) Filter query for signals in this step, e.g. `domain='NR1' AND type='APPLICATION'`.
+* `is_excluded` - (Optional) When true, this query is excluded from the step health evaluation. Defaults to `false`.
+
+### Nested `config` blocks
+
+* `health_rollup` - (Optional) How the step health is rolled up from its signals. One of: `BEST_STATUS_WINS`, `WORST_STATUS_WINS`.
+* `threshold_type` - (Optional) Whether the threshold value is a fixed number or a percentage. One of: `FIXED`, `PERCENTAGE`.
+* `threshold_value` - (Optional) The numeric threshold value used to evaluate step health.
+
+### Nested `signals` blocks
+
+* `guid` - (Required) The entity GUID of the signal.
+* `name` - (Optional) The display name of the signal.
+* `type` - (Optional) Whether this GUID belongs to an entity or an alert condition. One of: `ALERT`, `ENTITY`.
+* `is_excluded` - (Optional) When true, this signal is excluded from the step health calculation. Defaults to `false`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `guid` - The entity GUID assigned to this Pathpoint flow.
+* `version` - The last updated timestamp of the Pathpoint, used for version control.
+
+## Import
+
+Pathpoint flows can be imported using the entity GUID:
+
+```
+terraform import newrelic_pathpoint.example <guid>
+```
+
+~> **NOTE:** The `account_id` attribute is set to `ForceNew`, meaning that changing the account will destroy and recreate the resource.

--- a/website/newrelic.erb
+++ b/website/newrelic.erb
@@ -10,6 +10,7 @@
     "application",
     "entity",
     "key_transaction",
+    "pathpoint",
     "synthetics_monitor",
     "synthetics_monitor_location",
     "synthetics_secure_credential",


### PR DESCRIPTION
## Summary

Adds a new Terraform resource `newrelic_pathpoint` generated from the go-client `pathpoint` namespace.

**Generated files:**
- `newrelic/resource_newrelic_pathpoint.go`
- `newrelic/structures_newrelic_pathpoint.go`
- `website/docs/r/pathpoint.html.markdown`

**go-client source:** https://github.com/newrelic/newrelic-client-go/pull/1443 (sha: `d45ed41675f32f828947b53c4aa14273cd303709`)

---
*Generated by [api-governance codegen](https://source.datanerd.us/after/api-governance)*