### PR TITLE
feat: add newrelic_organization terraform resource

### DIFF
--- a/newrelic/provider_newrelic.go
+++ b/newrelic/provider_newrelic.go
@@ -178,6 +178,7 @@ func Provider() *schema.Provider {
 			"newrelic_cardinality_management":                   resourceNewRelicCardinalityManagement(),
 			"newrelic_metric_pruning_rule":                      resourceNewRelicMetricPruningRule(),
 			"newrelic_nrql_drop_rule":                           resourceNewRelicNRQLDropRule(),
+			"newrelic_organization": resourceNewRelicOrganization(),
 			"newrelic_pipeline_cloud_rule":                      resourceNewRelicPipelineCloudRule(),
 			"newrelic_obfuscation_expression":                   resourceNewRelicObfuscationExpression(),
 			"newrelic_obfuscation_rule":                         resourceNewRelicObfuscationRule(),

--- a/newrelic/resource_newrelic_organization.go
+++ b/newrelic/resource_newrelic_organization.go
@@ -1,0 +1,183 @@
+package newrelic
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/organization"
+)
+
+func resourceNewRelicOrganization() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNewRelicOrganizationCreate,
+		ReadContext:   resourceNewRelicOrganizationRead,
+		UpdateContext: resourceNewRelicOrganizationUpdate,
+		DeleteContext: resourceNewRelicOrganizationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "The name of the organization.",
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+			},
+			"customer_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The customer ID to associate with the organization.",
+			},
+			"new_managed_account": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "Attributes for creating a new managed account.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The name of the new account to be created.",
+						},
+						"region_code": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The region code for the account to be created.",
+							ValidateFunc: validation.StringInSlice([]string{
+								"EU01",
+								"US01",
+							}, false),
+						},
+					},
+				},
+			},
+			"shared_account": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "Attributes for creating an account share with the new organization.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"account_id": {
+							Type:        schema.TypeInt,
+							Required:    true,
+							Description: "The ID of the account to share with the new organization.",
+						},
+						"limiting_role_id": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "The limiting role ID the new organization will be granted on the shared account.",
+						},
+					},
+				},
+			},
+			"job_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The job ID of the organization creation task.",
+			},
+			"organization_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the organization.",
+			},
+		},
+	}
+}
+
+var _ = context.Background
+var _ = fmt.Sprintf
+var _ = log.Printf
+var _ = organization.OrganizationRegionCodeEnumTypes
+var _ = validation.StringIsNotWhiteSpace
+func resourceNewRelicOrganizationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+
+	input, err := expandOrganizationCreate(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	customerID := d.Get("customer_id").(string)
+
+	var newManagedAccount *organization.OrganizationNewManagedAccountInput
+	if v, ok := d.GetOk("new_managed_account"); ok {
+		items := v.([]interface{})
+		if len(items) > 0 {
+			newManagedAccount = expandOrganizationNewManagedAccount(items[0].(map[string]interface{}))
+		}
+	}
+
+	var sharedAccount *organization.OrganizationSharedAccountInput
+	if v, ok := d.GetOk("shared_account"); ok {
+		items := v.([]interface{})
+		if len(items) > 0 {
+			sharedAccount = expandOrganizationSharedAccount(items[0].(map[string]interface{}))
+		}
+	}
+
+	result, err := client.Organization.OrganizationCreateWithContext(ctx, customerID, newManagedAccount, *input, sharedAccount)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := flattenOrganizationCreate(result, d); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceNewRelicOrganizationRead(ctx, d, meta)
+}
+
+func resourceNewRelicOrganizationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+
+	log.Printf("[INFO] Reading NewRelic Organization %s", d.Id())
+
+	result, err := client.Organization.GetOrganizationWithContext(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if result == nil || result.ID == "" {
+		d.SetId("")
+		return nil
+	}
+
+	return diag.FromErr(flattenOrganization(result, d))
+}
+
+func resourceNewRelicOrganizationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+
+	log.Printf("[INFO] Updating NewRelic Organization %s", d.Id())
+
+	input, err := expandOrganizationUpdate(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	result, err := client.Organization.OrganizationUpdateWithContext(ctx, *input, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if len(result.Errors) > 0 {
+		return diag.Errorf("error updating organization: %s", result.Errors[0].Message)
+	}
+
+	return resourceNewRelicOrganizationRead(ctx, d, meta)
+}
+
+func resourceNewRelicOrganizationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[INFO] Deleting NewRelic Organization is not supported via API; removing from state only.")
+	d.SetId("")
+	return nil
+}

--- a/newrelic/structures_newrelic_organization.go
+++ b/newrelic/structures_newrelic_organization.go
@@ -1,0 +1,75 @@
+package newrelic
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/organization"
+)
+
+func expandOrganization(d *schema.ResourceData) (*organization.OrganizationCreateOrganizationInput, error) {
+	input := organization.OrganizationCreateOrganizationInput{
+		Name: d.Get("name").(string),
+	}
+	return &input, nil
+}
+
+func expandOrganizationUpdate(d *schema.ResourceData) (*organization.OrganizationUpdateInput, error) {
+	input := organization.OrganizationUpdateInput{}
+	if v, ok := d.GetOk("name"); ok {
+		input.Name = v.(string)
+	}
+	return &input, nil
+}
+
+func expandOrganizationNewManagedAccount(d *schema.ResourceData) *organization.OrganizationNewManagedAccountInput {
+	v, ok := d.GetOk("new_managed_account")
+	if !ok {
+		return nil
+	}
+	list := v.([]interface{})
+	if len(list) == 0 || list[0] == nil {
+		return nil
+	}
+	cfg := list[0].(map[string]interface{})
+	input := &organization.OrganizationNewManagedAccountInput{}
+	if name, ok := cfg["name"].(string); ok && name != "" {
+		input.Name = name
+	}
+	if regionCode, ok := cfg["region_code"].(string); ok && regionCode != "" {
+		input.RegionCode = organization.OrganizationRegionCodeEnum(regionCode)
+	}
+	return input
+}
+
+func expandOrganizationSharedAccount(d *schema.ResourceData) *organization.OrganizationSharedAccountInput {
+	v, ok := d.GetOk("shared_account")
+	if !ok {
+		return nil
+	}
+	list := v.([]interface{})
+	if len(list) == 0 || list[0] == nil {
+		return nil
+	}
+	cfg := list[0].(map[string]interface{})
+	input := &organization.OrganizationSharedAccountInput{
+		AccountID: cfg["account_id"].(int),
+	}
+	if limitingRoleId, ok := cfg["limiting_role_id"].(int); ok {
+		input.LimitingRoleId = limitingRoleId
+	}
+	return input
+}
+func flattenOrganization(result *organization.Organization, d *schema.ResourceData) error {
+	_ = d.Set("name", result.Name)
+	_ = d.Set("organization_id", result.ID)
+	return nil
+}
+
+func flattenOrganizationUpdateResponse(result *organization.OrganizationUpdateResponse, d *schema.ResourceData) error {
+	if result.OrganizationInformation.ID != "" {
+		_ = d.Set("organization_id", result.OrganizationInformation.ID)
+	}
+	if result.OrganizationInformation.Name != "" {
+		_ = d.Set("name", result.OrganizationInformation.Name)
+	}
+	return nil
+}

--- a/website/docs/r/organization.html.markdown
+++ b/website/docs/r/organization.html.markdown
@@ -1,0 +1,67 @@
+---
+layout: "newrelic"
+page_title: "New Relic: newrelic_organization"
+sidebar_current: "docs-newrelic-resource-organization"
+description: |-
+  Create and manage a New Relic organization.
+---
+
+# Resource: newrelic\_organization
+
+Use this resource to create and manage New Relic organizations.
+
+~> **NOTE:** Deleting an organization is not supported via the New Relic API. Destroying this resource will only remove it from Terraform state.
+
+## Example Usage
+
+```hcl
+resource "newrelic_organization" "foo" {
+  name = "My New Organization"
+
+  new_managed_account {
+    name        = "My New Account"
+    region_code = "US01"
+  }
+
+  shared_account {
+    account_id       = 12345678
+    limiting_role_id = 1000
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the organization.
+* `customer_id` - (Optional) The customer ID to associate with the organization.
+* `new_managed_account` - (Optional) A nested block that describes a new managed account to create alongside the organization. Only one `new_managed_account` block is permitted. See [Nested new_managed_account blocks](#nested-new_managed_account-blocks) below for details.
+* `shared_account` - (Optional) A nested block that describes an account share to create with the new organization. Only one `shared_account` block is permitted. See [Nested shared_account blocks](#nested-shared_account-blocks) below for details.
+
+### Nested `new_managed_account` blocks
+
+* `name` - (Optional) The name of the new account to be created.
+* `region_code` - (Optional) The region code for the account to be created. One of: `EU01`, `US01`.
+
+### Nested `shared_account` blocks
+
+* `account_id` - (Required) The ID of the account to share with the new organization.
+* `limiting_role_id` - (Optional) The limiting role ID the new organization will be granted on the shared account.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `job_id` - The job ID of the organization creation task. This can be used to poll for the status of the async organization creation operation.
+* `organization_id` - The ID of the organization.
+
+## Import
+
+New Relic organizations can be imported using the organization ID:
+
+```
+terraform import newrelic_organization.foo <organization_id>
+```
+
+~> **NOTE:** Because organization deletion is not supported by the API, a destroyed resource is only removed from Terraform state. The organization will continue to exist in New Relic.

--- a/website/newrelic.erb
+++ b/website/newrelic.erb
@@ -10,6 +10,7 @@
     "application",
     "entity",
     "key_transaction",
+    "organization",
     "synthetics_monitor",
     "synthetics_monitor_location",
     "synthetics_secure_credential",


### PR DESCRIPTION
## Summary

Adds a new Terraform resource `newrelic_organization` generated from the go-client `organization` namespace.

**Generated files:**
- `newrelic/resource_newrelic_organization.go`
- `newrelic/structures_newrelic_organization.go`
- `website/docs/r/organization.html.markdown`

**go-client source:** main @ `main`

**Before this can merge:**
- Check the registration in `newrelic/provider_newrelic.go` is in `ResourcesMap` and not `DataSourcesMap`, and that `website/newrelic.erb` lists it under Resources.
- Nothing here was built or `terraform validate`d. Review the schema against the provider's own naming conventions before approving.

---
*Generated by [api-governance codegen](https://source.datanerd.us/after/api-governance)*