### PR TITLE
feat: add newrelic_installation_recipe_event terraform resource

### DIFF
--- a/newrelic/provider_newrelic.go
+++ b/newrelic/provider_newrelic.go
@@ -169,6 +169,7 @@ func Provider() *schema.Provider {
 			"newrelic_group":                                    resourceNewRelicGroup(),
 			"newrelic_infra_alert_condition":                    resourceNewRelicInfraAlertCondition(),
 			"newrelic_insights_event":                           resourceNewRelicInsightsEvent(),
+			"newrelic_installation_recipe_event": resourceNewRelicInstallationRecipeEvent(),
 			"newrelic_key_transaction":                          resourceNewRelicKeyTransaction(),
 			"newrelic_log_parsing_rule":                         resourceNewRelicLogParsingRule(),
 			"newrelic_monitor_downtime":                         resourceNewRelicMonitorDowntime(),

--- a/newrelic/resource_newrelic_installation_recipe_event.go
+++ b/newrelic/resource_newrelic_installation_recipe_event.go
@@ -1,0 +1,195 @@
+package newrelic
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/installevents"
+)
+
+func resourceNewRelicInstallationRecipeEvent() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNewRelicInstallationRecipeEventCreate,
+		ReadContext:   resourceNewRelicInstallationRecipeEventRead,
+		UpdateContext: resourceNewRelicInstallationRecipeEventUpdate,
+		DeleteContext: resourceNewRelicInstallationRecipeEventDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"account_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"cli_version": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"complete": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"display_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"entity_guid": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"error": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"details": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"message": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"optimized_message": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"host_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"install_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"install_library_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"kernel_arch": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"kernel_version": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"log_file_path": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"os": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"platform": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"platform_family": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"platform_version": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"redirect_url": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"AVAILABLE",
+					"CANCELED",
+					"DETECTED",
+					"FAILED",
+					"INSTALLED",
+					"INSTALLING",
+					"RECOMMENDED",
+					"SKIPPED",
+					"UNSUPPORTED",
+				}, false),
+			},
+			"targeted_install": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"task_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"timestamp": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"validation_duration_milliseconds": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+		},
+	}
+}
+
+var _ = context.Background
+var _ = (*installevents.InstallationRecipeStatus)(nil)
+var _ diag.Diagnostics(nil)
+func resourceNewRelicInstallationRecipeEventCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+	accountID := selectAccountID(providerConfig, d)
+
+	input, err := expandInstallationRecipeEvent(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	result, err := client.Installevents.InstallationCreateRecipeEventWithContext(ctx, accountID, *input)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(result.InstallId)
+	return diag.FromErr(flattenInstallationRecipeEvent(result, d))
+}
+
+func resourceNewRelicInstallationRecipeEventRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceNewRelicInstallationRecipeEventUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+	accountID := selectAccountID(providerConfig, d)
+
+	input, err := expandInstallationRecipeEvent(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	result, err := client.Installevents.InstallationCreateRecipeEventWithContext(ctx, accountID, *input)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return diag.FromErr(flattenInstallationRecipeEvent(result, d))
+}
+
+func resourceNewRelicInstallationRecipeEventDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	d.SetId("")
+	return nil
+}

--- a/newrelic/structures_newrelic_installation_recipe_event.go
+++ b/newrelic/structures_newrelic_installation_recipe_event.go
@@ -1,0 +1,123 @@
+package newrelic
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/installevents"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/nrtime"
+)
+
+func expandInstallationRecipeEvent(d *schema.ResourceData) (*installevents.InstallationRecipeStatus, error) {
+	input := installevents.InstallationRecipeStatus{
+		CliVersion:                     d.Get("cli_version").(string),
+		Complete:                       d.Get("complete").(bool),
+		DisplayName:                    d.Get("display_name").(string),
+		EntityGUID:                     common.EntityGUID(d.Get("entity_guid").(string)),
+		HostName:                       d.Get("host_name").(string),
+		KernelArch:                     d.Get("kernel_arch").(string),
+		KernelVersion:                  d.Get("kernel_version").(string),
+		LogFilePath:                    d.Get("log_file_path").(string),
+		Name:                           d.Get("name").(string),
+		Os:                             d.Get("os").(string),
+		Platform:                       d.Get("platform").(string),
+		PlatformFamily:                 d.Get("platform_family").(string),
+		PlatformVersion:                d.Get("platform_version").(string),
+		Status:                         installevents.InstallationRecipeStatusType(d.Get("status").(string)),
+		TargetedInstall:                d.Get("targeted_install").(bool),
+		ValidationDurationMilliseconds: int64(d.Get("validation_duration_milliseconds").(int)),
+	}
+
+	if v, ok := d.GetOk("install_id"); ok {
+		input.InstallId = v.(string)
+	}
+
+	if v, ok := d.GetOk("install_library_version"); ok {
+		input.InstallLibraryVersion = v.(string)
+	}
+
+	if v, ok := d.GetOk("redirect_url"); ok {
+		input.RedirectURL = v.(string)
+	}
+
+	if v, ok := d.GetOk("task_path"); ok {
+		input.TaskPath = v.(string)
+	}
+
+	if v, ok := d.GetOk("timestamp"); ok {
+		input.Timestamp = nrtime.EpochSeconds(float64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("error"); ok {
+		items := v.([]interface{})
+		if len(items) > 0 && items[0] != nil {
+			input.Error = expandInstallationStatusErrorInput(items[0].(map[string]interface{}))
+		}
+	}
+
+	return &input, nil
+}
+
+func expandInstallationStatusErrorInput(cfg map[string]interface{}) installevents.InstallationStatusErrorInput {
+	out := installevents.InstallationStatusErrorInput{}
+
+	if v, ok := cfg["details"].(string); ok {
+		out.Details = v
+	}
+
+	if v, ok := cfg["message"].(string); ok {
+		out.Message = v
+	}
+
+	if v, ok := cfg["optimized_message"].(string); ok {
+		out.OptimizedMessage = v
+	}
+
+	return out
+}
+
+func expandInstallationRecipeEventUpdate(d *schema.ResourceData) (*installevents.InstallationRecipeStatus, error) {
+	return expandInstallationRecipeEvent(d)
+}
+
+var _ = (*schema.ResourceData)(nil)
+func flattenInstallationRecipeEvent(result *installevents.InstallationRecipeEvent, d *schema.ResourceData) error {
+	_ = d.Set("cli_version", result.CliVersion)
+	_ = d.Set("complete", result.Complete)
+	_ = d.Set("display_name", result.DisplayName)
+	_ = d.Set("entity_guid", string(result.EntityGUID))
+	_ = d.Set("host_name", result.HostName)
+	_ = d.Set("install_id", result.InstallId)
+	_ = d.Set("install_library_version", result.InstallLibraryVersion)
+	_ = d.Set("kernel_arch", result.KernelArch)
+	_ = d.Set("kernel_version", result.KernelVersion)
+	_ = d.Set("log_file_path", result.LogFilePath)
+	_ = d.Set("name", result.Name)
+	_ = d.Set("os", result.Os)
+	_ = d.Set("platform", result.Platform)
+	_ = d.Set("platform_family", result.PlatformFamily)
+	_ = d.Set("platform_version", result.PlatformVersion)
+	_ = d.Set("redirect_url", result.RedirectURL)
+	_ = d.Set("status", string(result.Status))
+	_ = d.Set("targeted_install", result.TargetedInstall)
+	_ = d.Set("task_path", result.TaskPath)
+	_ = d.Set("timestamp", int(result.Timestamp))
+	_ = d.Set("validation_duration_milliseconds", int(result.ValidationDurationMilliseconds))
+
+	if err := d.Set("error", flattenInstallationRecipeEventError(result.Error)); err != nil {
+		return fmt.Errorf("[DEBUG] Error setting `error`: %v", err)
+	}
+
+	return nil
+}
+
+func flattenInstallationRecipeEventError(e installevents.InstallationStatusError) []interface{} {
+	if e.Details == "" && e.Message == "" && e.OptimizedMessage == "" {
+		return []interface{}{}
+	}
+	m := map[string]interface{}{
+		"details":           e.Details,
+		"message":           e.Message,
+		"optimized_message": e.OptimizedMessage,
+	}
+	return []interface{}{m}
+}

--- a/website/docs/r/installation_recipe_event.html.markdown
+++ b/website/docs/r/installation_recipe_event.html.markdown
@@ -1,0 +1,96 @@
+---
+layout: "newrelic"
+page_title: "New Relic: newrelic_installation_recipe_event"
+sidebar_current: "docs-newrelic-resource-installation-recipe-event"
+description: |-
+  Create and manage an installation recipe event in New Relic.
+---
+
+# Resource: newrelic\_installation\_recipe\_event
+
+Use this resource to create and manage New Relic installation recipe events. These events are created on behalf of the newrelic-cli whenever the CLI attempts to install a recipe (e.g., the infrastructure-agent). Details regarding guided install can be found [here](https://docs.newrelic.com/docs/full-stack-observability/observe-everything/get-started/new-relic-guided-install-overview/).
+
+## Example Usage
+
+```hcl
+resource "newrelic_installation_recipe_event" "foo" {
+  account_id       = 12345678
+  cli_version      = "1.0.0"
+  complete         = true
+  display_name     = "Infrastructure Agent"
+  entity_guid      = "ABC123"
+  host_name        = "my-host"
+  kernel_arch      = "x86_64"
+  kernel_version   = "5.4.0"
+  log_file_path    = "/var/log/newrelic-cli.log"
+  name             = "infrastructure-agent-linux-installer"
+  os               = "linux"
+  platform         = "debian"
+  platform_family  = "debian"
+  platform_version = "10"
+  status           = "INSTALLED"
+  targeted_install = false
+  timestamp        = 1609459200
+  validation_duration_milliseconds = 5000
+
+  error {
+    details           = ""
+    message           = ""
+    optimized_message = ""
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `account_id` - (Optional) Determines the New Relic account where the installation recipe event will be created. Defaults to the account associated with the API key used.
+* `cli_version` - (Required) The version of the newrelic-cli that was used for a given recipe.
+* `complete` - (Required) Whether or not the recipe has been installed and all steps have been completed.
+* `display_name` - (Required) The display name for a given recipe.
+* `entity_guid` - (Required) The entity GUID for a given recipe.
+* `error` - (Optional) A nested block that describes the error returned for a given recipe. Only one `error` block is permitted per resource definition. See [Nested error blocks](#nested-error-blocks) below for details.
+* `host_name` - (Required) The host name of the customer's machine.
+* `install_id` - (Optional) The unique ID that corresponds to an install event.
+* `install_library_version` - (Optional) The version of the open-install-library that is being used.
+* `kernel_arch` - (Required) The kernel architecture of the customer's machine.
+* `kernel_version` - (Required) The kernel version of the customer's machine.
+* `log_file_path` - (Required) The path to the log file on the customer's host.
+* `name` - (Required) The unique name for a given recipe.
+* `os` - (Required) The OS of the customer's machine.
+* `platform` - (Required) The platform name provided by the open-install-library.
+* `platform_family` - (Required) The platform family name provided by the open-install-library.
+* `platform_version` - (Required) The platform version provided by the open-install-library.
+* `redirect_url` - (Optional) The redirect URL created by the CLI used for redirecting to a particular entity.
+* `status` - (Required) The status for a given recipe. One of: `AVAILABLE`, `CANCELED`, `DETECTED`, `FAILED`, `INSTALLED`, `INSTALLING`, `RECOMMENDED`, `SKIPPED`, `UNSUPPORTED`.
+* `targeted_install` - (Required) Whether or not the recipe being installed is a targeted install.
+* `task_path` - (Optional) The path to the installation task as defined in the open-install-library.
+* `timestamp` - (Required) The timestamp for when the recipe event occurred, in epoch seconds.
+* `validation_duration_milliseconds` - (Required) The number of milliseconds it took to validate the recipe.
+
+### Nested `error` blocks
+
+* `details` - (Optional) Error details, if any.
+* `message` - (Optional) The actual error message.
+* `optimized_message` - (Optional) An optimised message for the error.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The install ID of the recipe event.
+
+## Import
+
+New Relic installation recipe events can be imported using the install ID:
+
+```
+terraform import newrelic_installation_recipe_event.foo <install_id>
+```
+
+~> **NOTE:** Installation recipe events are write-only operations in the New Relic API. The Read operation is a no-op for this resource, meaning that after import, the state will only reflect what was last written via Terraform. Sensitive data is not returned from the underlying API.
+
+## Additional Information
+
+More information about the New Relic guided install and the newrelic-cli can be found in the [New Relic documentation](https://docs.newrelic.com/docs/full-stack-observability/observe-everything/get-started/new-relic-guided-install-overview/) and the [newrelic-cli GitHub repository](https://github.com/newrelic/newrelic-cli).

--- a/website/newrelic.erb
+++ b/website/newrelic.erb
@@ -9,6 +9,7 @@
     "alert_policy",
     "application",
     "entity",
+    "installation_recipe_event",
     "key_transaction",
     "synthetics_monitor",
     "synthetics_monitor_location",


### PR DESCRIPTION
## Summary

Adds a new Terraform resource `newrelic_installation_recipe_event` generated from the go-client `installevents` namespace.

**Generated files:**
- `newrelic/resource_newrelic_installation_recipe_event.go`
- `newrelic/structures_newrelic_installation_recipe_event.go`
- `website/docs/r/installation_recipe_event.html.markdown`

**go-client source:** main @ `main`

**Before this can merge:**
- Check the registration in `newrelic/provider_newrelic.go` is in `ResourcesMap` and not `DataSourcesMap`, and that `website/newrelic.erb` lists it under Resources.
- Nothing here was built or `terraform validate`d. Review the schema against the provider's own naming conventions before approving.

---
*Generated by [api-governance codegen](https://source.datanerd.us/after/api-governance)*