### PR TITLE
feat: update newrelic_log_parsing_rule terraform resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,3 +69,5 @@ require (
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 )
+
+replace github.com/newrelic/newrelic-client-go/v2 => github.com/newrelic/newrelic-client-go/v2 v2.0.0-0.00000000000000-fee95e2a243e

--- a/newrelic/resource_newrelic_log_parsing_rule.go
+++ b/newrelic/resource_newrelic_log_parsing_rule.go
@@ -2,11 +2,11 @@ package newrelic
 
 import (
 	"context"
-	"errors"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/newrelic/newrelic-client-go/v2/newrelic"
 	nrErrors "github.com/newrelic/newrelic-client-go/v2/pkg/errors"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/logconfigurations"
@@ -69,148 +69,49 @@ func resourceNewRelicLogParsingRule() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
+			"source": {
+				Type:        schema.TypeString,
+				Description: "Source of the parsing rule.",
+				Optional:    true,
+				Computed:    true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"NO_CODE",
+					"NO_CODE_WRITE_YOUR_OWN",
+					"WRITE_YOUR_OWN",
+				}, false),
+			},
 		},
 	}
 }
 
-// Create the obfuscation expression
-func resourceNewRelicLogParsingRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	providerConfig := meta.(*ProviderConfig)
-	client := providerConfig.NewClient
-
-	accountID := selectAccountID(providerConfig, d)
-
-	createInput := logconfigurations.LogConfigurationsParsingRuleConfiguration{
-		Enabled: d.Get("enabled").(bool),
-		Grok:    d.Get("grok").(string),
-		Lucene:  d.Get("lucene").(string),
-		NRQL:    logconfigurations.NRQL(d.Get("nrql").(string)),
-	}
-	var diags diag.Diagnostics
-	if e, ok := d.GetOk("attribute"); ok {
-		createInput.Attribute = e.(string)
-	}
-
-	e := d.Get("name")
-	rule, err := getLogParsingRuleByName(ctx, client, accountID, e.(string))
-	if (rule != nil && err != nil) || (rule == nil && err != nil) {
-		return diag.FromErr(err)
-	}
-	createInput.Description = e.(string)
-	if d.Get("matched") == false {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Warning,
-			Summary:  "The grok pattern is not tested against log lines from the New Relic",
-		})
-	}
-
-	created, err := client.Logconfigurations.LogConfigurationsCreateParsingRuleWithContext(ctx, accountID, createInput)
+func getLogParsingRuleByID(ctx context.Context, client *newrelic.NewRelic, accountID int, ruleID string) (*logconfigurations.LogConfigurationsParsingRule, error) {
+	rules, err := client.Logconfigurations.GetParsingRulesWithContext(ctx, accountID)
 	if err != nil {
-		return diag.FromErr(err)
+		return nil, err
 	}
 
-	if created == nil {
-		return diag.Errorf("err: rule not created.")
+	for _, v := range *rules {
+		if v.ID == ruleID {
+			return v, nil
+		}
 	}
-
-	parsingRuleID := created.Rule.ID
-
-	d.SetId(parsingRuleID)
-	return diags
+	return nil, nrErrors.NewNotFound("parsing rule not found")
 }
 
-// Read the obfuscation expression
-func resourceNewRelicLogParsingRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	providerConfig := meta.(*ProviderConfig)
-	client := providerConfig.NewClient
-	accountID := selectAccountID(providerConfig, d)
-
-	ruleID := d.Id()
-	rule, err := getLogParsingRuleByID(ctx, client, accountID, ruleID)
-
+func getLogParsingRuleByName(ctx context.Context, client *newrelic.NewRelic, accountID int, name string) (*logconfigurations.LogConfigurationsParsingRule, error) {
+	rules, err := client.Logconfigurations.GetParsingRulesWithContext(ctx, accountID)
+	if rules == nil && err != nil && err.Error() == "resource not found" {
+		return nil, nil
+	}
 	if err != nil {
-		if _, ok := err.(*nrErrors.NotFound); ok {
-			d.SetId("")
-			return nil
-		}
-		return diag.FromErr(err)
+		return nil, err
 	}
-
-	// Defensive: should never happen given function contract, but be safe
-	if rule == nil {
-		d.SetId("")
-		return nil
-	}
-
-	if err := d.Set("account_id", accountID); err != nil {
-		return diag.FromErr(err)
-	}
-
-	if err := d.Set("name", rule.Description); err != nil {
-		return diag.FromErr(err)
-	}
-
-	if err := d.Set("attribute", rule.Attribute); err != nil {
-		return diag.FromErr(err)
-	}
-
-	if err := d.Set("enabled", rule.Enabled); err != nil {
-		return diag.FromErr(err)
-	}
-
-	if err := d.Set("grok", rule.Grok); err != nil {
-		return diag.FromErr(err)
-	}
-
-	if err := d.Set("lucene", rule.Lucene); err != nil {
-		return diag.FromErr(err)
-	}
-
-	if err := d.Set("nrql", rule.NRQL); err != nil {
-		return diag.FromErr(err)
-	}
-
-	if err := d.Set("deleted", rule.Deleted); err != nil {
-		return diag.FromErr(err)
-	}
-
-	return nil
-}
-
-// Update the obfuscation expression
-func resourceNewRelicLogParsingRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*ProviderConfig).NewClient
-	accountID := selectAccountID(meta.(*ProviderConfig), d)
-	if e, ok := d.GetOk("name"); ok {
-		if o, n := d.GetChange("name"); o != n {
-			rule, err := getLogParsingRuleByName(ctx, client, accountID, e.(string))
-			if (rule != nil && err != nil) || (rule == nil && err != nil) {
-				return diag.FromErr(err)
-			}
+	for _, v := range *rules {
+		if v.Description == name && !v.Deleted {
+			return v, nil
 		}
 	}
-
-	updateInput := expandLogParsingRuleUpdateInput(d)
-
-	log.Printf("[INFO] Updating New Relic log parsing rule %s", d.Id())
-
-	ruleID := d.Id()
-
-	var diags diag.Diagnostics
-	if e, ok := d.GetOk("matched"); ok {
-		if !e.(bool) {
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Warning,
-				Summary:  "The grok pattern is not tested against log lines from the New Relic",
-			})
-		}
-		return diags
-	}
-	_, err := client.Logconfigurations.LogConfigurationsUpdateParsingRuleWithContext(ctx, accountID, ruleID, updateInput)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	return resourceNewRelicLogParsingRuleRead(ctx, d, meta)
+	return nil, nil
 }
 
 func expandLogParsingRuleUpdateInput(d *schema.ResourceData) logconfigurations.LogConfigurationsParsingRuleConfiguration {
@@ -240,17 +141,132 @@ func expandLogParsingRuleUpdateInput(d *schema.ResourceData) logconfigurations.L
 		updateInp.NRQL = logconfigurations.NRQL(e.(string))
 	}
 
+	if e, ok := d.GetOk("source"); ok {
+		updateInp.Source = logconfigurations.LogConfigurationsParsingRuleSource(e.(string))
+	}
+
 	return updateInp
 }
 
-// Delete the log parsing rule
+var _ = log.Printf
+var _ = diag.FromErr
+func resourceNewRelicLogParsingRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+
+	accountID := selectAccountID(providerConfig, d)
+
+	createInput := expandLogParsingRuleUpdateInput(d)
+
+	var diags diag.Diagnostics
+
+	e := d.Get("name")
+	rule, err := getLogParsingRuleByName(ctx, client, accountID, e.(string))
+	if (rule != nil && err != nil) || (rule == nil && err != nil) {
+		return diag.FromErr(err)
+	}
+
+	if d.Get("matched") == false {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "The grok pattern is not tested against log lines from the New Relic",
+		})
+	}
+
+	created, err := client.Logconfigurations.LogConfigurationsCreateParsingRuleWithContext(ctx, accountID, createInput)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if created == nil {
+		return diag.Errorf("err: rule not created.")
+	}
+
+	parsingRuleID := created.Rule.ID
+	d.SetId(parsingRuleID)
+
+	return append(diags, resourceNewRelicLogParsingRuleRead(ctx, d, meta)...)
+}
+
+func resourceNewRelicLogParsingRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+	accountID := selectAccountID(providerConfig, d)
+
+	ruleID := d.Id()
+	rule, err := getLogParsingRuleByID(ctx, client, accountID, ruleID)
+
+	if err != nil {
+		if _, ok := err.(*nrErrors.NotFound); ok {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+
+	if rule == nil {
+		d.SetId("")
+		return nil
+	}
+
+	_ = d.Set("account_id", accountID)
+	_ = d.Set("name", rule.Description)
+	_ = d.Set("attribute", rule.Attribute)
+	_ = d.Set("enabled", rule.Enabled)
+	_ = d.Set("grok", rule.Grok)
+	_ = d.Set("lucene", rule.Lucene)
+	_ = d.Set("nrql", string(rule.NRQL))
+	_ = d.Set("deleted", rule.Deleted)
+	_ = d.Set("source", string(rule.Source))
+
+	return nil
+}
+
+func resourceNewRelicLogParsingRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+	accountID := selectAccountID(providerConfig, d)
+
+	if e, ok := d.GetOk("name"); ok {
+		if o, n := d.GetChange("name"); o != n {
+			rule, err := getLogParsingRuleByName(ctx, client, accountID, e.(string))
+			if (rule != nil && err != nil) || (rule == nil && err != nil) {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	updateInput := expandLogParsingRuleUpdateInput(d)
+
+	log.Printf("[INFO] Updating New Relic log parsing rule %s", d.Id())
+
+	ruleID := d.Id()
+
+	var diags diag.Diagnostics
+	if e, ok := d.GetOk("matched"); ok {
+		if !e.(bool) {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  "The grok pattern is not tested against log lines from the New Relic",
+			})
+		}
+	}
+
+	_, err := client.Logconfigurations.LogConfigurationsUpdateParsingRuleWithContext(ctx, accountID, ruleID, updateInput)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return append(diags, resourceNewRelicLogParsingRuleRead(ctx, d, meta)...)
+}
+
 func resourceNewRelicLogParsingRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
 	client := providerConfig.NewClient
 
 	log.Printf("[INFO] Deleting New Relic log parsing rule id %s", d.Id())
 
-	accountID := selectAccountID(meta.(*ProviderConfig), d)
+	accountID := selectAccountID(providerConfig, d)
 	ruleID := d.Id()
 
 	_, err := client.Logconfigurations.LogConfigurationsDeleteParsingRuleWithContext(ctx, accountID, ruleID)
@@ -259,36 +275,4 @@ func resourceNewRelicLogParsingRuleDelete(ctx context.Context, d *schema.Resourc
 	}
 
 	return nil
-}
-
-func getLogParsingRuleByID(ctx context.Context, client *newrelic.NewRelic, accountID int, ruleID string) (*logconfigurations.LogConfigurationsParsingRule, error) {
-	rules, err := client.Logconfigurations.GetParsingRulesWithContext(ctx, accountID)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, v := range *rules {
-		if v.ID == ruleID {
-			return v, nil
-		}
-	}
-	return nil, nrErrors.NewNotFound("parsing rule not found")
-
-}
-
-func getLogParsingRuleByName(ctx context.Context, client *newrelic.NewRelic, accountID int, name string) (*logconfigurations.LogConfigurationsParsingRule, error) {
-	rules, err := client.Logconfigurations.GetParsingRulesWithContext(ctx, accountID)
-	if rules == nil && err.Error() == "resource not found" {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	for _, v := range *rules {
-		if v.Description == name && !v.Deleted {
-			return v, errors.New("name is already in use by another rule")
-		}
-	}
-	return nil, nil
-
 }

--- a/newrelic/structures_newrelic_log_parsing_rule.go
+++ b/newrelic/structures_newrelic_log_parsing_rule.go
@@ -1,0 +1,86 @@
+package newrelic
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/logconfigurations"
+)
+
+func expandLogParsingRuleInput(d *schema.ResourceData) logconfigurations.LogConfigurationsParsingRuleConfiguration {
+	inp := logconfigurations.LogConfigurationsParsingRuleConfiguration{}
+
+	if e, ok := d.GetOk("attribute"); ok {
+		inp.Attribute = e.(string)
+	}
+
+	if e, ok := d.GetOk("enabled"); ok {
+		inp.Enabled = e.(bool)
+	}
+
+	if e, ok := d.GetOk("name"); ok {
+		inp.Description = e.(string)
+	}
+
+	if e, ok := d.GetOk("grok"); ok {
+		inp.Grok = e.(string)
+	}
+
+	if e, ok := d.GetOk("lucene"); ok {
+		inp.Lucene = e.(string)
+	}
+
+	if e, ok := d.GetOk("nrql"); ok {
+		inp.NRQL = logconfigurations.NRQL(e.(string))
+	}
+
+	if e, ok := d.GetOk("source"); ok {
+		inp.Source = logconfigurations.LogConfigurationsParsingRuleSource(e.(string))
+	}
+
+	return inp
+}
+
+func expandLogParsingRuleUpdateInput(d *schema.ResourceData) logconfigurations.LogConfigurationsParsingRuleConfiguration {
+	updateInp := logconfigurations.LogConfigurationsParsingRuleConfiguration{}
+
+	if e, ok := d.GetOk("attribute"); ok {
+		updateInp.Attribute = e.(string)
+	}
+
+	if e, ok := d.GetOk("enabled"); ok {
+		updateInp.Enabled = e.(bool)
+	}
+
+	if e, ok := d.GetOk("name"); ok {
+		updateInp.Description = e.(string)
+	}
+
+	if e, ok := d.GetOk("grok"); ok {
+		updateInp.Grok = e.(string)
+	}
+
+	if e, ok := d.GetOk("lucene"); ok {
+		updateInp.Lucene = e.(string)
+	}
+
+	if e, ok := d.GetOk("nrql"); ok {
+		updateInp.NRQL = logconfigurations.NRQL(e.(string))
+	}
+
+	if e, ok := d.GetOk("source"); ok {
+		updateInp.Source = logconfigurations.LogConfigurationsParsingRuleSource(e.(string))
+	}
+
+	return updateInp
+}
+func flattenLogParsingRule(rule *logconfigurations.LogConfigurationsParsingRule, d *schema.ResourceData) error {
+	_ = d.Set("account_id", rule.AccountID)
+	_ = d.Set("attribute", rule.Attribute)
+	_ = d.Set("name", rule.Description)
+	_ = d.Set("enabled", rule.Enabled)
+	_ = d.Set("grok", rule.Grok)
+	_ = d.Set("lucene", rule.Lucene)
+	_ = d.Set("nrql", string(rule.NRQL))
+	_ = d.Set("deleted", rule.Deleted)
+	_ = d.Set("source", string(rule.Source))
+	return nil
+}

--- a/website/newrelic.erb
+++ b/website/newrelic.erb
@@ -10,6 +10,7 @@
     "application",
     "entity",
     "key_transaction",
+    "log_parsing_rule",
     "synthetics_monitor",
     "synthetics_monitor_location",
     "synthetics_secure_credential",


### PR DESCRIPTION
## Summary

Updates the existing `newrelic_log_parsing_rule` resource to reflect changes in the go-client `logconfigurations` namespace.

**Generated files:**
- `newrelic/resource_newrelic_log_parsing_rule.go`
- `newrelic/structures_newrelic_log_parsing_rule.go`

**go-client source:** https://github.com/newrelic/newrelic-client-go/pull/1440 (sha: `fee95e2a243e40cc8b44341f0e89fa3d09449def`)

**Before this can merge:**
- Run `go mod tidy` — the branch carries a `go.mod` `replace` for the unmerged go-client commit with no matching `go.sum`, so the build fails until it is regenerated. Drop the `replace` once the go-client change is released.
- Check the registration in `newrelic/provider_newrelic.go` is in `ResourcesMap` and not `DataSourcesMap`, and that `website/newrelic.erb` lists it under Resources.
- `website/docs/r/log_parsing_rule.html.markdown` was NOT regenerated; update it by hand if this adds arguments.
- Nothing here was built or `terraform validate`d. Review the schema against the provider's own naming conventions before approving.

---
*Generated by [api-governance codegen](https://source.datanerd.us/after/api-governance)*