### PR TITLE
feat: add newrelic_organization terraform resource

### DIFF
--- a/newrelic/provider_newrelic.go
+++ b/newrelic/provider_newrelic.go
@@ -178,6 +178,7 @@ func Provider() *schema.Provider {
 			"newrelic_cardinality_management":                   resourceNewRelicCardinalityManagement(),
 			"newrelic_metric_pruning_rule":                      resourceNewRelicMetricPruningRule(),
 			"newrelic_nrql_drop_rule":                           resourceNewRelicNRQLDropRule(),
+			"newrelic_organization":                             resourceNewRelicOrganization(),
 			"newrelic_pipeline_cloud_rule":                      resourceNewRelicPipelineCloudRule(),
 			"newrelic_obfuscation_expression":                   resourceNewRelicObfuscationExpression(),
 			"newrelic_obfuscation_rule":                         resourceNewRelicObfuscationRule(),

--- a/newrelic/resource_newrelic_organization.go
+++ b/newrelic/resource_newrelic_organization.go
@@ -1,0 +1,192 @@
+package newrelic
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	nrErrors "github.com/newrelic/newrelic-client-go/v2/pkg/errors"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/organization"
+)
+
+func resourceNewRelicOrganization() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNewRelicOrganizationCreate,
+		ReadContext:   resourceNewRelicOrganizationRead,
+		UpdateContext: resourceNewRelicOrganizationUpdate,
+		DeleteContext: resourceNewRelicOrganizationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the organization.",
+			},
+			"customer_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The customer ID to associate with the new organization.",
+			},
+			"new_managed_account": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				MaxItems:    1,
+				Description: "Attributes for creating a new managed account within the organization.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							Description: "The name of the new account to be created.",
+						},
+						"region_code": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice(listValidOrganizationRegionCodes(), false),
+							Description:  fmt.Sprintf("The region code for the account. One of: (%s).", listValidOrganizationRegionCodesStr()),
+						},
+					},
+				},
+			},
+			"shared_account": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				MaxItems:    1,
+				Description: "Attributes for sharing an account with the new organization.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"account_id": {
+							Type:        schema.TypeInt,
+							Required:    true,
+							ForceNew:    true,
+							Description: "The ID of the account to share with the new organization.",
+						},
+						"limiting_role_id": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							ForceNew:    true,
+							Description: "The limiting role ID the new organization will be granted for the shared account.",
+						},
+					},
+				},
+			},
+			"job_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The job ID of the organization creation task.",
+			},
+		},
+	}
+}
+
+func listValidOrganizationRegionCodes() []string {
+	return []string{
+		string(organization.OrganizationRegionCodeEnumTypes.EU01),
+		string(organization.OrganizationRegionCodeEnumTypes.US01),
+	}
+}
+
+func listValidOrganizationRegionCodesStr() string {
+	codes := listValidOrganizationRegionCodes()
+	result := ""
+	for i, c := range codes {
+		if i > 0 {
+			result += ", "
+		}
+		result += c
+	}
+	return result
+}
+
+var _ = log.Printf
+var _ = nrErrors.NotFound{}
+var _ diag.Diagnostics = nil
+var _ = context.Background
+var _ = fmt.Sprintf
+
+func resourceNewRelicOrganizationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+
+	customerId, newManagedAccount, org, sharedAccount, err := expandOrganization(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Creating New Relic organization %s", org.Name)
+
+	result, err := client.Organization.OrganizationCreateWithContext(ctx, customerId, newManagedAccount, org, sharedAccount)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(result.JobId)
+	_ = d.Set("job_id", result.JobId)
+
+	return nil
+}
+
+func resourceNewRelicOrganizationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+
+	log.Printf("[INFO] Reading New Relic organization %s", d.Id())
+
+	result, err := client.Organization.GetOrganizationWithContext(ctx)
+	if err != nil {
+		if _, ok := err.(*nrErrors.NotFound); ok {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+
+	return diag.FromErr(flattenOrganization(result, d))
+}
+
+func resourceNewRelicOrganizationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+
+	updateInput, err := expandOrganizationUpdate(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Updating New Relic organization %s", d.Id())
+
+	result, err := client.Organization.OrganizationUpdateWithContext(ctx, updateInput, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if len(result.Errors) > 0 {
+		var diags diag.Diagnostics
+		for _, e := range result.Errors {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  string(e.Type),
+				Detail:   e.Message,
+			})
+		}
+		return diags
+	}
+
+	return resourceNewRelicOrganizationRead(ctx, d, meta)
+}
+
+func resourceNewRelicOrganizationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[INFO] Deleting New Relic organization %s is not supported via API; removing from state", d.Id())
+	d.SetId("")
+	return nil
+}

--- a/newrelic/structures_newrelic_organization.go
+++ b/newrelic/structures_newrelic_organization.go
@@ -1,0 +1,78 @@
+package newrelic
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/organization"
+)
+
+func expandOrganization(d *schema.ResourceData) (string, *organization.OrganizationNewManagedAccountInput, organization.OrganizationCreateOrganizationInput, *organization.OrganizationSharedAccountInput, error) {
+	customerID := d.Get("customer_id").(string)
+
+	org := organization.OrganizationCreateOrganizationInput{
+		Name: d.Get("name").(string),
+	}
+
+	var newManagedAccount *organization.OrganizationNewManagedAccountInput
+	if v, ok := d.GetOk("new_managed_account"); ok {
+		items := v.([]interface{})
+		if len(items) > 0 {
+			newManagedAccount = expandOrganizationNewManagedAccount(items[0].(map[string]interface{}))
+		}
+	}
+
+	var sharedAccount *organization.OrganizationSharedAccountInput
+	if v, ok := d.GetOk("shared_account"); ok {
+		items := v.([]interface{})
+		if len(items) > 0 {
+			sharedAccount = expandOrganizationSharedAccount(items[0].(map[string]interface{}))
+		}
+	}
+
+	return customerID, newManagedAccount, org, sharedAccount, nil
+}
+
+func expandOrganizationNewManagedAccount(cfg map[string]interface{}) *organization.OrganizationNewManagedAccountInput {
+	input := &organization.OrganizationNewManagedAccountInput{}
+
+	if v, ok := cfg["name"]; ok {
+		input.Name = v.(string)
+	}
+
+	if v, ok := cfg["region_code"]; ok {
+		input.RegionCode = organization.OrganizationRegionCodeEnum(v.(string))
+	}
+
+	return input
+}
+
+func expandOrganizationSharedAccount(cfg map[string]interface{}) *organization.OrganizationSharedAccountInput {
+	input := &organization.OrganizationSharedAccountInput{}
+
+	if v, ok := cfg["account_id"]; ok {
+		input.AccountID = v.(int)
+	}
+
+	if v, ok := cfg["limiting_role_id"]; ok {
+		input.LimitingRoleId = v.(int)
+	}
+
+	return input
+}
+
+func expandOrganizationUpdate(d *schema.ResourceData) (organization.OrganizationUpdateInput, error) {
+	input := organization.OrganizationUpdateInput{
+		Name: d.Get("name").(string),
+	}
+
+	return input, nil
+}
+
+func flattenOrganization(result *organization.Organization, d *schema.ResourceData) error {
+	if result == nil {
+		return nil
+	}
+
+	_ = d.Set("name", result.Name)
+
+	return nil
+}

--- a/website/docs/r/organization.html.markdown
+++ b/website/docs/r/organization.html.markdown
@@ -1,0 +1,83 @@
+---
+layout: "newrelic"
+page_title: "New Relic: newrelic_organization"
+sidebar_current: "docs-newrelic-resource-organization"
+description: |-
+  Create and manage a New Relic organization.
+---
+
+# Resource: newrelic\_organization
+
+Use this resource to create and manage New Relic organizations.
+
+~> **NOTE:** Deleting an organization is not supported via the API. Removing this resource from Terraform configuration will only remove it from state — the organization itself will not be deleted in New Relic.
+
+## Example Usage
+
+```hcl
+resource "newrelic_organization" "foo" {
+  name = "My New Organization"
+}
+```
+
+### With a New Managed Account
+
+```hcl
+resource "newrelic_organization" "foo" {
+  name = "My New Organization"
+
+  new_managed_account {
+    name        = "My New Account"
+    region_code = "US01"
+  }
+}
+```
+
+### With a Shared Account
+
+```hcl
+resource "newrelic_organization" "foo" {
+  name = "My New Organization"
+
+  shared_account {
+    account_id       = 12345678
+    limiting_role_id = 1234
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the organization.
+* `customer_id` - (Optional) The customer ID to associate with the new organization. This value cannot be changed after creation.
+* `new_managed_account` - (Optional) A nested block that describes a new managed account to create within the organization. Only one `new_managed_account` block is permitted. This value cannot be changed after creation. See [Nested new_managed_account blocks](#nested-new_managed_account-blocks) below for details.
+* `shared_account` - (Optional) A nested block that describes an account to share with the new organization. Only one `shared_account` block is permitted. This value cannot be changed after creation. See [Nested shared_account blocks](#nested-shared_account-blocks) below for details.
+
+### Nested `new_managed_account` blocks
+
+* `name` - (Optional) The name of the new account to be created. This value cannot be changed after creation.
+* `region_code` - (Optional) The region code for the account. One of: `EU01`, `US01`. This value cannot be changed after creation.
+
+### Nested `shared_account` blocks
+
+* `account_id` - (Required) The ID of the account to share with the new organization. This value cannot be changed after creation.
+* `limiting_role_id` - (Optional) The limiting role ID the new organization will be granted for the shared account. This value cannot be changed after creation.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the organization creation job.
+* `job_id` - The job ID of the organization creation task.
+
+## Import
+
+New Relic organizations can be imported using the organization ID:
+
+```
+terraform import newrelic_organization.foo <organization_id>
+```
+
+~> **NOTE:** Sensitive data and certain read-only fields may not be returned from the underlying API and may not be set in state when importing.

--- a/website/newrelic.erb
+++ b/website/newrelic.erb
@@ -32,6 +32,7 @@
     "nrql_drop_rule",
     "one_dashboard",
     "one_dashboard_raw",
+    "organization",
     "synthetics_alert_condition",
     "synthetics_monitor",
     "synthetics_monitor_script",


### PR DESCRIPTION
## Summary

Adds a new Terraform resource `newrelic_organization` generated from the go-client `organization` namespace.

**Generated files:**
- `newrelic/resource_newrelic_organization.go`
- `newrelic/structures_newrelic_organization.go`
- `website/docs/r/organization.html.markdown`

**go-client source:** main @ `main`

**Before this can merge:**
- Check the registration in `newrelic/provider_newrelic.go` is in `ResourcesMap` and not `DataSourcesMap`, and that `website/newrelic.erb` lists it under Resources.
- Nothing here was built or `terraform validate`d. Review the schema against the provider's own naming conventions before approving.

---
*Generated by [api-governance codegen](https://source.datanerd.us/after/api-governance)*