### PR TITLE
feat: add newrelic_organization terraform resource

### DIFF
--- a/integration_test_utilities/integration_test_mappings.yaml
+++ b/integration_test_utilities/integration_test_mappings.yaml
@@ -421,6 +421,9 @@ resource_newrelic_one_dashboard_raw_test.go:
 resource_newrelic_one_dashboard_test.go:
   test: true
   product_mapping: DASHBOARDS
+resource_newrelic_organization.go:
+  test: false
+  product_mapping: AUTH
 resource_newrelic_pipeline_cloud_rule.go:
   test: false
   product_mapping: NGEP
@@ -619,6 +622,9 @@ structures_newrelic_one_dashboard_raw.go:
 structures_newrelic_one_dashboard_test.go:
   test: true
   product_mapping: DASHBOARDS
+structures_newrelic_organization.go:
+  test: false
+  product_mapping: AUTH
 structures_newrelic_service_level.go:
   test: false
   product_mapping: WORKLOADS

--- a/newrelic/provider_newrelic.go
+++ b/newrelic/provider_newrelic.go
@@ -178,6 +178,7 @@ func Provider() *schema.Provider {
 			"newrelic_cardinality_management":                   resourceNewRelicCardinalityManagement(),
 			"newrelic_metric_pruning_rule":                      resourceNewRelicMetricPruningRule(),
 			"newrelic_nrql_drop_rule":                           resourceNewRelicNRQLDropRule(),
+			"newrelic_organization":                             resourceNewRelicOrganization(),
 			"newrelic_pipeline_cloud_rule":                      resourceNewRelicPipelineCloudRule(),
 			"newrelic_obfuscation_expression":                   resourceNewRelicObfuscationExpression(),
 			"newrelic_obfuscation_rule":                         resourceNewRelicObfuscationRule(),

--- a/newrelic/resource_newrelic_organization.go
+++ b/newrelic/resource_newrelic_organization.go
@@ -1,0 +1,204 @@
+package newrelic
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	nrErrors "github.com/newrelic/newrelic-client-go/v2/pkg/errors"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/organization"
+)
+
+func resourceNewRelicOrganization() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNewRelicOrganizationCreate,
+		ReadContext:   resourceNewRelicOrganizationRead,
+		UpdateContext: resourceNewRelicOrganizationUpdate,
+		DeleteContext: resourceNewRelicOrganizationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the organization.",
+			},
+			"customer_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The customer ID associated with the organization.",
+			},
+			"new_managed_account": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				MaxItems:    1,
+				Description: "Attributes for creating a new managed account alongside the organization.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							Description: "The name of the new account to be created.",
+						},
+						"region_code": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice(listValidOrganizationRegionCodes(), false),
+							Description:  fmt.Sprintf("The region code for the account. One of: (%s).", listValidOrganizationRegionCodesStr()),
+						},
+					},
+				},
+			},
+			"shared_account": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				MaxItems:    1,
+				Description: "Attributes for sharing an account with the new organization.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"account_id": {
+							Type:        schema.TypeInt,
+							Required:    true,
+							ForceNew:    true,
+							Description: "The ID of the account to share with the new organization.",
+						},
+						"limiting_role_id": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							ForceNew:    true,
+							Description: "The limiting role ID the new organization will be granted for the shared account.",
+						},
+					},
+				},
+			},
+			// Computed
+			"job_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The job ID of the organization creation task.",
+			},
+			"org_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the organization.",
+			},
+		},
+	}
+}
+
+func listValidOrganizationRegionCodes() []string {
+	return []string{
+		string(organization.OrganizationRegionCodeEnumTypes.EU01),
+		string(organization.OrganizationRegionCodeEnumTypes.US01),
+	}
+}
+
+func listValidOrganizationRegionCodesStr() string {
+	codes := listValidOrganizationRegionCodes()
+	result := ""
+	for i, c := range codes {
+		if i > 0 {
+			result += ", "
+		}
+		result += c
+	}
+	return result
+}
+
+var (
+	_ = context.Background
+	_ = log.Printf
+	_ = nrErrors.NotFound{}
+	_ = diag.FromErr
+)
+
+func resourceNewRelicOrganizationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+
+	customerID, newManagedAccount, org, sharedAccount, err := expandOrganization(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] Creating New Relic organization %s", org.Name)
+
+	result, err := client.Organization.OrganizationCreateWithContext(ctx, customerID, newManagedAccount, org, sharedAccount)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(result.JobId)
+	_ = d.Set("job_id", result.JobId)
+
+	return nil
+}
+
+func resourceNewRelicOrganizationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+
+	log.Printf("[INFO] Reading New Relic organization %s", d.Id())
+
+	result, err := client.Organization.GetOrganizationWithContext(ctx)
+	if err != nil {
+		if _, ok := err.(*nrErrors.NotFound); ok {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+
+	if result == nil {
+		d.SetId("")
+		return nil
+	}
+
+	return diag.FromErr(flattenOrganization(result, d))
+}
+
+func resourceNewRelicOrganizationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+
+	organizationID := d.Get("org_id").(string)
+
+	updateInput := organization.OrganizationUpdateInput{
+		Name: d.Get("name").(string),
+	}
+
+	log.Printf("[INFO] Updating New Relic organization %s", organizationID)
+
+	result, err := client.Organization.OrganizationUpdateWithContext(ctx, updateInput, organizationID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if len(result.Errors) > 0 {
+		var diagErrors diag.Diagnostics
+		for _, e := range result.Errors {
+			diagErrors = append(diagErrors, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  string(e.Type),
+				Detail:   e.Message,
+			})
+		}
+		return diagErrors
+	}
+
+	return resourceNewRelicOrganizationRead(ctx, d, meta)
+}
+
+func resourceNewRelicOrganizationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[INFO] Deleting New Relic organization %s is not supported via API; removing from state", d.Id())
+	return nil
+}

--- a/newrelic/structures_newrelic_organization.go
+++ b/newrelic/structures_newrelic_organization.go
@@ -1,0 +1,82 @@
+package newrelic
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/organization"
+)
+
+func expandOrganization(d *schema.ResourceData) (string, *organization.OrganizationNewManagedAccountInput, organization.OrganizationCreateOrganizationInput, *organization.OrganizationSharedAccountInput, error) {
+	org := organization.OrganizationCreateOrganizationInput{
+		Name: d.Get("name").(string),
+	}
+
+	customerID := ""
+	if v, ok := d.GetOk("customer_id"); ok {
+		customerID = v.(string)
+	}
+
+	var newManagedAccount *organization.OrganizationNewManagedAccountInput
+	if v, ok := d.GetOk("new_managed_account"); ok {
+		items := v.([]interface{})
+		if len(items) > 0 {
+			newManagedAccount = expandOrganizationNewManagedAccount(items[0].(map[string]interface{}))
+		}
+	}
+
+	var sharedAccount *organization.OrganizationSharedAccountInput
+	if v, ok := d.GetOk("shared_account"); ok {
+		items := v.([]interface{})
+		if len(items) > 0 {
+			sharedAccount = expandOrganizationSharedAccount(items[0].(map[string]interface{}))
+		}
+	}
+
+	return customerID, newManagedAccount, org, sharedAccount, nil
+}
+
+func expandOrganizationNewManagedAccount(cfg map[string]interface{}) *organization.OrganizationNewManagedAccountInput {
+	input := &organization.OrganizationNewManagedAccountInput{}
+
+	if v, ok := cfg["name"]; ok {
+		input.Name = v.(string)
+	}
+
+	if v, ok := cfg["region_code"]; ok {
+		input.RegionCode = organization.OrganizationRegionCodeEnum(v.(string))
+	}
+
+	return input
+}
+
+func expandOrganizationSharedAccount(cfg map[string]interface{}) *organization.OrganizationSharedAccountInput {
+	input := &organization.OrganizationSharedAccountInput{}
+
+	if v, ok := cfg["account_id"]; ok {
+		input.AccountID = v.(int)
+	}
+
+	if v, ok := cfg["limiting_role_id"]; ok {
+		input.LimitingRoleId = v.(int)
+	}
+
+	return input
+}
+
+func expandOrganizationUpdate(d *schema.ResourceData) (organization.OrganizationUpdateInput, error) {
+	input := organization.OrganizationUpdateInput{
+		Name: d.Get("name").(string),
+	}
+
+	return input, nil
+}
+
+func flattenOrganization(result *organization.Organization, d *schema.ResourceData) error {
+	if result == nil {
+		return nil
+	}
+
+	_ = d.Set("org_id", result.ID)
+	_ = d.Set("name", result.Name)
+
+	return nil
+}

--- a/website/docs/r/organization.html.markdown
+++ b/website/docs/r/organization.html.markdown
@@ -1,0 +1,84 @@
+---
+layout: "newrelic"
+page_title: "New Relic: newrelic_organization"
+sidebar_current: "docs-newrelic-resource-organization"
+description: |-
+  Create and manage a New Relic organization.
+---
+
+# Resource: newrelic\_organization
+
+Use this resource to create and manage New Relic organizations.
+
+~> **NOTE:** Deleting an organization is not supported via the New Relic API. Destroying this resource will only remove it from Terraform state.
+
+## Example Usage
+
+```hcl
+resource "newrelic_organization" "foo" {
+  name = "My Organization"
+}
+```
+
+### With a new managed account
+
+```hcl
+resource "newrelic_organization" "foo" {
+  name        = "My Organization"
+  customer_id = "my-customer-id"
+
+  new_managed_account {
+    name        = "My New Account"
+    region_code = "US01"
+  }
+}
+```
+
+### With a shared account
+
+```hcl
+resource "newrelic_organization" "foo" {
+  name = "My Organization"
+
+  shared_account {
+    account_id       = 12345678
+    limiting_role_id = 1234
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the organization.
+* `customer_id` - (Optional) The customer ID associated with the organization. Forces a new resource if changed.
+* `new_managed_account` - (Optional) A nested block that describes a new managed account to create alongside the organization. Only one `new_managed_account` block is permitted. Forces a new resource if changed. See [Nested new_managed_account blocks](#nested-new_managed_account-blocks) below for details.
+* `shared_account` - (Optional) A nested block that describes an account to share with the new organization. Only one `shared_account` block is permitted. Forces a new resource if changed. See [Nested shared_account blocks](#nested-shared_account-blocks) below for details.
+
+### Nested `new_managed_account` blocks
+
+* `name` - (Optional) The name of the new account to be created. Forces a new resource if changed.
+* `region_code` - (Optional) The region code for the account. One of: `EU01`, `US01`. Forces a new resource if changed.
+
+### Nested `shared_account` blocks
+
+* `account_id` - (Required) The ID of the account to share with the new organization. Forces a new resource if changed.
+* `limiting_role_id` - (Optional) The limiting role ID the new organization will be granted for the shared account. Forces a new resource if changed.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `job_id` - The job ID of the organization creation task.
+* `org_id` - The ID of the organization.
+
+## Import
+
+New Relic organizations can be imported using the organization ID:
+
+```
+terraform import newrelic_organization.foo <organization_id>
+```
+
+~> **NOTE:** After importing, run `terraform state show newrelic_organization.foo` to view the current state and copy the relevant fields into your configuration.

--- a/website/newrelic.erb
+++ b/website/newrelic.erb
@@ -32,6 +32,7 @@
     "nrql_drop_rule",
     "one_dashboard",
     "one_dashboard_raw",
+    "organization",
     "synthetics_alert_condition",
     "synthetics_monitor",
     "synthetics_monitor_script",


### PR DESCRIPTION
## Summary

Adds a new Terraform resource `newrelic_organization` generated from the go-client `organization` namespace.

**Generated files:**
- `newrelic/resource_newrelic_organization.go`
- `newrelic/structures_newrelic_organization.go`
- `website/docs/r/organization.html.markdown`

**go-client source:** main @ `main`

**Before this can merge:**
- Check the registration in `newrelic/provider_newrelic.go` is in `ResourcesMap` and not `DataSourcesMap`, and that `website/newrelic.erb` lists it under Resources.
- Confirm the product mapping. `AUTH` was chosen by the generator for `resource_newrelic_organization.go` because no pattern in `integration_test_types.go` matches it — grouped with its closest siblings rather than derived. Change the value in `integration_test_mappings.yaml` if another product owns this resource.
- Nothing here was built or `terraform validate`d. Review the schema against the provider's own naming conventions before approving.

---
*Generated by [api-governance codegen](https://source.datanerd.us/after/api-governance)*