### PR TITLE
feat: update newrelic_data_partition_rule terraform resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,3 +69,5 @@ require (
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 )
+
+replace github.com/newrelic/newrelic-client-go/v2 => github.com/newrelic/newrelic-client-go/v2 v2.0.0-20260804122254-fee95e2a243e

--- a/newrelic/resource_newrelic_data_partition.go
+++ b/newrelic/resource_newrelic_data_partition.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
-	"time"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/newrelic/newrelic-client-go/v2/newrelic"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/logconfigurations"
+	"log"
+	"time"
 )
 
 func resourceNewRelicDataPartition() *schema.Resource {
@@ -44,7 +43,7 @@ func resourceNewRelicDataPartition() *schema.Resource {
 			"nrql": {
 				Type:        schema.TypeString,
 				Description: "The NRQL to match events for this data partition rule. Logs matching this criteria will be routed to the specified data partition.",
-				Required:    true,
+				Optional:    true,
 			},
 			"retention_policy": {
 				Type:         schema.TypeString,
@@ -58,6 +57,32 @@ func resourceNewRelicDataPartition() *schema.Resource {
 				Description: "The name of the data partition where logs will be allocated once the rule is enabled.",
 				Required:    true,
 				ForceNew:    true,
+			},
+			"matching_criteria": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "The matching criteria of the data partition rule.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"attribute_name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The attribute name against which this matching condition will be evaluated.",
+						},
+						"matching_expression": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The matching expression of the data partition rule definition.",
+						},
+						"matching_method": {
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "The matching method of the data partition rule definition.",
+							ValidateFunc: validation.StringInSlice(listValidDataPartitionRuleMatchingOperator(), false),
+						},
+					},
+				},
 			},
 			"deleted": {
 				Type:        schema.TypeBool,
@@ -78,7 +103,52 @@ func listValidDataPartitionRuleRetentionPolicyType() []string {
 	}
 }
 
+func listValidDataPartitionRuleMatchingOperator() []string {
+	return []string{
+		string(logconfigurations.LogConfigurationsDataPartitionRuleMatchingOperatorTypes.EQUALS),
+		string(logconfigurations.LogConfigurationsDataPartitionRuleMatchingOperatorTypes.LIKE),
+	}
+}
+
+func expandDataPartitionUpdateInput(d *schema.ResourceData) logconfigurations.LogConfigurationsUpdateDataPartitionRuleInput {
+	updateInp := logconfigurations.LogConfigurationsUpdateDataPartitionRuleInput{
+		ID: d.Id(),
+	}
+	if e, ok := d.GetOk("enabled"); ok {
+		updateInp.Enabled = e.(bool)
+	}
+
+	if e, ok := d.GetOk("description"); ok {
+		updateInp.Description = e.(string)
+	}
+
+	if e, ok := d.GetOk("nrql"); ok {
+		updateInp.NRQL = logconfigurations.NRQL(e.(string))
+	}
+
+	if v, ok := d.GetOk("matching_criteria"); ok {
+		items := v.([]interface{})
+		if len(items) > 0 {
+			cfg := items[0].(map[string]interface{})
+			updateInp.MatchingCriteria = &logconfigurations.LogConfigurationsDataPartitionRuleMatchingCriteriaInput{
+				AttributeName:      cfg["attribute_name"].(string),
+				MatchingExpression: cfg["matching_expression"].(string),
+				MatchingMethod:     logconfigurations.LogConfigurationsDataPartitionRuleMatchingOperator(cfg["matching_method"].(string)),
+			}
+		}
+	}
+
+	return updateInp
+}
+
 // Create the data partition rule
+
+// Read the data partition rule
+
+// Update the data partition rule
+
+// Delete the data partition rule
+
 func resourceNewRelicDataPartitionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
 	client := providerConfig.NewClient
@@ -88,10 +158,12 @@ func resourceNewRelicDataPartitionCreate(ctx context.Context, d *schema.Resource
 	createInput := logconfigurations.LogConfigurationsCreateDataPartitionRuleInput{
 		Description: d.Get("description").(string),
 		Enabled:     d.Get("enabled").(bool),
-		NRQL:        logconfigurations.NRQL(d.Get("nrql").(string)),
 	}
 
-	//The name of a log data partition. Has to start with 'Log_' prefix and can only contain alphanumeric characters and underscores.
+	if e, ok := d.GetOk("nrql"); ok {
+		createInput.NRQL = logconfigurations.NRQL(e.(string))
+	}
+
 	if e, ok := d.GetOk("target_data_partition"); ok {
 		createInput.TargetDataPartition = logconfigurations.LogConfigurationsLogDataPartitionName(e.(string))
 	}
@@ -99,6 +171,19 @@ func resourceNewRelicDataPartitionCreate(ctx context.Context, d *schema.Resource
 	if e, ok := d.GetOk("retention_policy"); ok {
 		createInput.RetentionPolicy = logconfigurations.LogConfigurationsDataPartitionRuleRetentionPolicyType(e.(string))
 	}
+
+	if v, ok := d.GetOk("matching_criteria"); ok {
+		items := v.([]interface{})
+		if len(items) > 0 {
+			cfg := items[0].(map[string]interface{})
+			createInput.MatchingCriteria = &logconfigurations.LogConfigurationsDataPartitionRuleMatchingCriteriaInput{
+				AttributeName:      cfg["attribute_name"].(string),
+				MatchingExpression: cfg["matching_expression"].(string),
+				MatchingMethod:     logconfigurations.LogConfigurationsDataPartitionRuleMatchingOperator(cfg["matching_method"].(string)),
+			}
+		}
+	}
+
 	log.Printf("[INFO] Creating New Relic Data Partition Rule  %s", createInput.TargetDataPartition)
 
 	created, err := client.Logconfigurations.LogConfigurationsCreateDataPartitionRuleWithContext(ctx, accountID, createInput)
@@ -108,7 +193,6 @@ func resourceNewRelicDataPartitionCreate(ctx context.Context, d *schema.Resource
 
 	var apiDiags diag.Diagnostics
 
-	//Setting the errors
 	if created.Errors != nil {
 		for _, err := range created.Errors {
 			apiDiags = append(apiDiags, diag.Diagnostic{
@@ -128,7 +212,6 @@ func resourceNewRelicDataPartitionCreate(ctx context.Context, d *schema.Resource
 
 	d.SetId(ruleID)
 
-	//Need retry mechanism
 	retryErr := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		rules, err := client.Logconfigurations.GetDataPartitionRulesWithContext(ctx, accountID)
 		if err != nil {
@@ -149,7 +232,6 @@ func resourceNewRelicDataPartitionCreate(ctx context.Context, d *schema.Resource
 	return nil
 }
 
-// Read the data partition rule
 func resourceNewRelicDataPartitionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
 	client := providerConfig.NewClient
@@ -177,10 +259,20 @@ func resourceNewRelicDataPartitionRead(ctx context.Context, d *schema.ResourceDa
 	_ = d.Set("retention_policy", rule.RetentionPolicy)
 	_ = d.Set("deleted", rule.Deleted)
 
+	if rule.MatchingCriteria != (logconfigurations.LogConfigurationsDataPartitionRuleMatchingCriteria{}) {
+		mc := map[string]interface{}{
+			"attribute_name":      rule.MatchingCriteria.AttributeName,
+			"matching_expression": rule.MatchingCriteria.MatchingExpression,
+			"matching_method":     string(rule.MatchingCriteria.MatchingOperator),
+		}
+		if err := d.Set("matching_criteria", []interface{}{mc}); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	return nil
 }
 
-// Update the data partition rule
 func resourceNewRelicDataPartitionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderConfig).NewClient
 	updateInput := expandDataPartitionUpdateInput(d)
@@ -197,7 +289,6 @@ func resourceNewRelicDataPartitionUpdate(ctx context.Context, d *schema.Resource
 
 	var apiDiags diag.Diagnostics
 
-	//Setting the errors
 	if updated.Errors != nil {
 		for _, err := range updated.Errors {
 			apiDiags = append(apiDiags, diag.Diagnostic{
@@ -212,26 +303,6 @@ func resourceNewRelicDataPartitionUpdate(ctx context.Context, d *schema.Resource
 	return nil
 }
 
-func expandDataPartitionUpdateInput(d *schema.ResourceData) logconfigurations.LogConfigurationsUpdateDataPartitionRuleInput {
-	updateInp := logconfigurations.LogConfigurationsUpdateDataPartitionRuleInput{
-		ID: d.Id(),
-	}
-	if e, ok := d.GetOk("enabled"); ok {
-		updateInp.Enabled = e.(bool)
-	}
-
-	if e, ok := d.GetOk("description"); ok {
-		updateInp.Description = e.(string)
-	}
-
-	if e, ok := d.GetOk("nrql"); ok {
-		updateInp.NRQL = logconfigurations.NRQL(e.(string))
-	}
-
-	return updateInp
-}
-
-// Delete the data partition rule
 func resourceNewRelicDataPartitionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
 	client := providerConfig.NewClient
@@ -262,5 +333,103 @@ func getDataPartitionByID(ctx context.Context, client *newrelic.NewRelic, accoun
 		}
 	}
 	return nil, errors.New("data partition rule not found")
+}
 
+func expandDataPartitionRuleCreateInput(d *schema.ResourceData) logconfigurations.LogConfigurationsCreateDataPartitionRuleInput {
+	input := logconfigurations.LogConfigurationsCreateDataPartitionRuleInput{
+		Enabled: d.Get("enabled").(bool),
+	}
+
+	if e, ok := d.GetOk("description"); ok {
+		input.Description = e.(string)
+	}
+
+	if e, ok := d.GetOk("nrql"); ok {
+		input.NRQL = logconfigurations.NRQL(e.(string))
+	}
+
+	if e, ok := d.GetOk("target_data_partition"); ok {
+		input.TargetDataPartition = logconfigurations.LogConfigurationsLogDataPartitionName(e.(string))
+	}
+
+	if e, ok := d.GetOk("retention_policy"); ok {
+		input.RetentionPolicy = logconfigurations.LogConfigurationsDataPartitionRuleRetentionPolicyType(e.(string))
+	}
+
+	if v, ok := d.GetOk("matching_criteria"); ok {
+		items := v.([]interface{})
+		if len(items) > 0 {
+			input.MatchingCriteria = expandDataPartitionRuleMatchingCriteriaInput(items[0].(map[string]interface{}))
+		}
+	}
+
+	return input
+}
+
+func expandDataPartitionRuleUpdateInput(d *schema.ResourceData) logconfigurations.LogConfigurationsUpdateDataPartitionRuleInput {
+	input := logconfigurations.LogConfigurationsUpdateDataPartitionRuleInput{
+		ID:      d.Id(),
+		Enabled: d.Get("enabled").(bool),
+	}
+
+	if e, ok := d.GetOk("description"); ok {
+		input.Description = e.(string)
+	}
+
+	if e, ok := d.GetOk("nrql"); ok {
+		input.NRQL = logconfigurations.NRQL(e.(string))
+	}
+
+	if v, ok := d.GetOk("matching_criteria"); ok {
+		items := v.([]interface{})
+		if len(items) > 0 {
+			input.MatchingCriteria = expandDataPartitionRuleMatchingCriteriaInput(items[0].(map[string]interface{}))
+		}
+	}
+
+	return input
+}
+
+func expandDataPartitionRuleMatchingCriteriaInput(cfg map[string]interface{}) *logconfigurations.LogConfigurationsDataPartitionRuleMatchingCriteriaInput {
+	input := &logconfigurations.LogConfigurationsDataPartitionRuleMatchingCriteriaInput{}
+
+	if v, ok := cfg["attribute_name"]; ok {
+		input.AttributeName = v.(string)
+	}
+
+	if v, ok := cfg["matching_expression"]; ok {
+		input.MatchingExpression = v.(string)
+	}
+
+	if v, ok := cfg["matching_method"]; ok {
+		input.MatchingMethod = logconfigurations.LogConfigurationsDataPartitionRuleMatchingOperator(v.(string))
+	}
+
+	return input
+}
+
+func flattenDataPartitionRule(rule *logconfigurations.LogConfigurationsDataPartitionRule, d *schema.ResourceData) error {
+	if rule == nil {
+		return nil
+	}
+
+	_ = d.Set("description", rule.Description)
+	_ = d.Set("enabled", rule.Enabled)
+	_ = d.Set("target_data_partition", string(rule.TargetDataPartition))
+	_ = d.Set("nrql", string(rule.NRQL))
+	_ = d.Set("retention_policy", string(rule.RetentionPolicy))
+	_ = d.Set("deleted", rule.Deleted)
+
+	if rule.MatchingCriteria != (logconfigurations.LogConfigurationsDataPartitionRuleMatchingCriteria{}) {
+		mc := map[string]interface{}{
+			"attribute_name":      rule.MatchingCriteria.AttributeName,
+			"matching_expression": rule.MatchingCriteria.MatchingExpression,
+			"matching_method":     string(rule.MatchingCriteria.MatchingOperator),
+		}
+		if err := d.Set("matching_criteria", []interface{}{mc}); err != nil {
+			return fmt.Errorf("[DEBUG] Error setting `matching_criteria`: %v", err)
+		}
+	}
+
+	return nil
 }

--- a/newrelic/resource_newrelic_data_partition.go
+++ b/newrelic/resource_newrelic_data_partition.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/newrelic/newrelic-client-go/v2/newrelic"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/logconfigurations"
-	"log"
-	"time"
 )
 
 func resourceNewRelicDataPartition() *schema.Resource {
@@ -43,7 +44,7 @@ func resourceNewRelicDataPartition() *schema.Resource {
 			"nrql": {
 				Type:        schema.TypeString,
 				Description: "The NRQL to match events for this data partition rule. Logs matching this criteria will be routed to the specified data partition.",
-				Optional:    true,
+				Required:    true,
 			},
 			"retention_policy": {
 				Type:         schema.TypeString,
@@ -57,6 +58,11 @@ func resourceNewRelicDataPartition() *schema.Resource {
 				Description: "The name of the data partition where logs will be allocated once the rule is enabled.",
 				Required:    true,
 				ForceNew:    true,
+			},
+			"deleted": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether or not this data partition rule is deleted. Deleting a data partition rule does not delete the already persisted data. This data will be retained for a given period of time specified in the retention policy field.",
 			},
 			"matching_criteria": {
 				Type:        schema.TypeList,
@@ -79,15 +85,10 @@ func resourceNewRelicDataPartition() *schema.Resource {
 							Type:         schema.TypeString,
 							Required:     true,
 							Description:  "The matching method of the data partition rule definition.",
-							ValidateFunc: validation.StringInSlice(listValidDataPartitionRuleMatchingOperator(), false),
+							ValidateFunc: validation.StringInSlice([]string{string(logconfigurations.LogConfigurationsDataPartitionRuleMatchingOperatorTypes.EQUALS), string(logconfigurations.LogConfigurationsDataPartitionRuleMatchingOperatorTypes.LIKE)}, false),
 						},
 					},
 				},
-			},
-			"deleted": {
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Description: "Whether or not this data partition rule is deleted. Deleting a data partition rule does not delete the already persisted data. This data will be retained for a given period of time specified in the retention policy field.",
 			},
 		},
 		Timeouts: &schema.ResourceTimeout{
@@ -98,57 +99,13 @@ func resourceNewRelicDataPartition() *schema.Resource {
 
 func listValidDataPartitionRuleRetentionPolicyType() []string {
 	return []string{
+		string(logconfigurations.LogConfigurationsDataPartitionRuleRetentionPolicyTypeTypes.ARCHIVE),
 		string(logconfigurations.LogConfigurationsDataPartitionRuleRetentionPolicyTypeTypes.SECONDARY),
 		string(logconfigurations.LogConfigurationsDataPartitionRuleRetentionPolicyTypeTypes.STANDARD),
 	}
 }
 
-func listValidDataPartitionRuleMatchingOperator() []string {
-	return []string{
-		string(logconfigurations.LogConfigurationsDataPartitionRuleMatchingOperatorTypes.EQUALS),
-		string(logconfigurations.LogConfigurationsDataPartitionRuleMatchingOperatorTypes.LIKE),
-	}
-}
-
-func expandDataPartitionUpdateInput(d *schema.ResourceData) logconfigurations.LogConfigurationsUpdateDataPartitionRuleInput {
-	updateInp := logconfigurations.LogConfigurationsUpdateDataPartitionRuleInput{
-		ID: d.Id(),
-	}
-	if e, ok := d.GetOk("enabled"); ok {
-		updateInp.Enabled = e.(bool)
-	}
-
-	if e, ok := d.GetOk("description"); ok {
-		updateInp.Description = e.(string)
-	}
-
-	if e, ok := d.GetOk("nrql"); ok {
-		updateInp.NRQL = logconfigurations.NRQL(e.(string))
-	}
-
-	if v, ok := d.GetOk("matching_criteria"); ok {
-		items := v.([]interface{})
-		if len(items) > 0 {
-			cfg := items[0].(map[string]interface{})
-			updateInp.MatchingCriteria = &logconfigurations.LogConfigurationsDataPartitionRuleMatchingCriteriaInput{
-				AttributeName:      cfg["attribute_name"].(string),
-				MatchingExpression: cfg["matching_expression"].(string),
-				MatchingMethod:     logconfigurations.LogConfigurationsDataPartitionRuleMatchingOperator(cfg["matching_method"].(string)),
-			}
-		}
-	}
-
-	return updateInp
-}
-
 // Create the data partition rule
-
-// Read the data partition rule
-
-// Update the data partition rule
-
-// Delete the data partition rule
-
 func resourceNewRelicDataPartitionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
 	client := providerConfig.NewClient
@@ -158,12 +115,10 @@ func resourceNewRelicDataPartitionCreate(ctx context.Context, d *schema.Resource
 	createInput := logconfigurations.LogConfigurationsCreateDataPartitionRuleInput{
 		Description: d.Get("description").(string),
 		Enabled:     d.Get("enabled").(bool),
+		NRQL:        logconfigurations.NRQL(d.Get("nrql").(string)),
 	}
 
-	if e, ok := d.GetOk("nrql"); ok {
-		createInput.NRQL = logconfigurations.NRQL(e.(string))
-	}
-
+	//The name of a log data partition. Has to start with 'Log_' prefix and can only contain alphanumeric characters and underscores.
 	if e, ok := d.GetOk("target_data_partition"); ok {
 		createInput.TargetDataPartition = logconfigurations.LogConfigurationsLogDataPartitionName(e.(string))
 	}
@@ -175,15 +130,9 @@ func resourceNewRelicDataPartitionCreate(ctx context.Context, d *schema.Resource
 	if v, ok := d.GetOk("matching_criteria"); ok {
 		items := v.([]interface{})
 		if len(items) > 0 {
-			cfg := items[0].(map[string]interface{})
-			createInput.MatchingCriteria = &logconfigurations.LogConfigurationsDataPartitionRuleMatchingCriteriaInput{
-				AttributeName:      cfg["attribute_name"].(string),
-				MatchingExpression: cfg["matching_expression"].(string),
-				MatchingMethod:     logconfigurations.LogConfigurationsDataPartitionRuleMatchingOperator(cfg["matching_method"].(string)),
-			}
+			createInput.MatchingCriteria = expandDataPartitionMatchingCriteria(items[0].(map[string]interface{}))
 		}
 	}
-
 	log.Printf("[INFO] Creating New Relic Data Partition Rule  %s", createInput.TargetDataPartition)
 
 	created, err := client.Logconfigurations.LogConfigurationsCreateDataPartitionRuleWithContext(ctx, accountID, createInput)
@@ -193,6 +142,7 @@ func resourceNewRelicDataPartitionCreate(ctx context.Context, d *schema.Resource
 
 	var apiDiags diag.Diagnostics
 
+	//Setting the errors
 	if created.Errors != nil {
 		for _, err := range created.Errors {
 			apiDiags = append(apiDiags, diag.Diagnostic{
@@ -212,6 +162,7 @@ func resourceNewRelicDataPartitionCreate(ctx context.Context, d *schema.Resource
 
 	d.SetId(ruleID)
 
+	//Need retry mechanism
 	retryErr := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		rules, err := client.Logconfigurations.GetDataPartitionRulesWithContext(ctx, accountID)
 		if err != nil {
@@ -232,6 +183,7 @@ func resourceNewRelicDataPartitionCreate(ctx context.Context, d *schema.Resource
 	return nil
 }
 
+// Read the data partition rule
 func resourceNewRelicDataPartitionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
 	client := providerConfig.NewClient
@@ -259,20 +211,16 @@ func resourceNewRelicDataPartitionRead(ctx context.Context, d *schema.ResourceDa
 	_ = d.Set("retention_policy", rule.RetentionPolicy)
 	_ = d.Set("deleted", rule.Deleted)
 
-	if rule.MatchingCriteria != (logconfigurations.LogConfigurationsDataPartitionRuleMatchingCriteria{}) {
-		mc := map[string]interface{}{
-			"attribute_name":      rule.MatchingCriteria.AttributeName,
-			"matching_expression": rule.MatchingCriteria.MatchingExpression,
-			"matching_method":     string(rule.MatchingCriteria.MatchingOperator),
-		}
-		if err := d.Set("matching_criteria", []interface{}{mc}); err != nil {
-			return diag.FromErr(err)
+	if rule.MatchingCriteria.AttributeName != "" {
+		if err := d.Set("matching_criteria", flattenDataPartitionMatchingCriteria(rule.MatchingCriteria)); err != nil {
+			return diag.FromErr(fmt.Errorf("[DEBUG] Error setting `matching_criteria`: %v", err))
 		}
 	}
 
 	return nil
 }
 
+// Update the data partition rule
 func resourceNewRelicDataPartitionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*ProviderConfig).NewClient
 	updateInput := expandDataPartitionUpdateInput(d)
@@ -289,6 +237,7 @@ func resourceNewRelicDataPartitionUpdate(ctx context.Context, d *schema.Resource
 
 	var apiDiags diag.Diagnostics
 
+	//Setting the errors
 	if updated.Errors != nil {
 		for _, err := range updated.Errors {
 			apiDiags = append(apiDiags, diag.Diagnostic{
@@ -303,6 +252,33 @@ func resourceNewRelicDataPartitionUpdate(ctx context.Context, d *schema.Resource
 	return nil
 }
 
+func expandDataPartitionUpdateInput(d *schema.ResourceData) logconfigurations.LogConfigurationsUpdateDataPartitionRuleInput {
+	updateInp := logconfigurations.LogConfigurationsUpdateDataPartitionRuleInput{
+		ID: d.Id(),
+	}
+	if e, ok := d.GetOk("enabled"); ok {
+		updateInp.Enabled = e.(bool)
+	}
+
+	if e, ok := d.GetOk("description"); ok {
+		updateInp.Description = e.(string)
+	}
+
+	if e, ok := d.GetOk("nrql"); ok {
+		updateInp.NRQL = logconfigurations.NRQL(e.(string))
+	}
+
+	if v, ok := d.GetOk("matching_criteria"); ok {
+		items := v.([]interface{})
+		if len(items) > 0 {
+			updateInp.MatchingCriteria = expandDataPartitionMatchingCriteria(items[0].(map[string]interface{}))
+		}
+	}
+
+	return updateInp
+}
+
+// Delete the data partition rule
 func resourceNewRelicDataPartitionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	providerConfig := meta.(*ProviderConfig)
 	client := providerConfig.NewClient
@@ -321,6 +297,24 @@ func resourceNewRelicDataPartitionDelete(ctx context.Context, d *schema.Resource
 	return nil
 }
 
+func expandDataPartitionMatchingCriteria(cfg map[string]interface{}) *logconfigurations.LogConfigurationsDataPartitionRuleMatchingCriteriaInput {
+	return &logconfigurations.LogConfigurationsDataPartitionRuleMatchingCriteriaInput{
+		AttributeName:      cfg["attribute_name"].(string),
+		MatchingExpression: cfg["matching_expression"].(string),
+		MatchingMethod:     logconfigurations.LogConfigurationsDataPartitionRuleMatchingOperator(cfg["matching_method"].(string)),
+	}
+}
+
+func flattenDataPartitionMatchingCriteria(mc logconfigurations.LogConfigurationsDataPartitionRuleMatchingCriteria) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"attribute_name":      mc.AttributeName,
+			"matching_expression": mc.MatchingExpression,
+			"matching_method":     string(mc.MatchingOperator),
+		},
+	}
+}
+
 func getDataPartitionByID(ctx context.Context, client *newrelic.NewRelic, accountID int, ruleID string) (*logconfigurations.LogConfigurationsDataPartitionRule, error) {
 	rules, err := client.Logconfigurations.GetDataPartitionRulesWithContext(ctx, accountID)
 	if err != nil {
@@ -333,103 +327,5 @@ func getDataPartitionByID(ctx context.Context, client *newrelic.NewRelic, accoun
 		}
 	}
 	return nil, errors.New("data partition rule not found")
-}
 
-func expandDataPartitionRuleCreateInput(d *schema.ResourceData) logconfigurations.LogConfigurationsCreateDataPartitionRuleInput {
-	input := logconfigurations.LogConfigurationsCreateDataPartitionRuleInput{
-		Enabled: d.Get("enabled").(bool),
-	}
-
-	if e, ok := d.GetOk("description"); ok {
-		input.Description = e.(string)
-	}
-
-	if e, ok := d.GetOk("nrql"); ok {
-		input.NRQL = logconfigurations.NRQL(e.(string))
-	}
-
-	if e, ok := d.GetOk("target_data_partition"); ok {
-		input.TargetDataPartition = logconfigurations.LogConfigurationsLogDataPartitionName(e.(string))
-	}
-
-	if e, ok := d.GetOk("retention_policy"); ok {
-		input.RetentionPolicy = logconfigurations.LogConfigurationsDataPartitionRuleRetentionPolicyType(e.(string))
-	}
-
-	if v, ok := d.GetOk("matching_criteria"); ok {
-		items := v.([]interface{})
-		if len(items) > 0 {
-			input.MatchingCriteria = expandDataPartitionRuleMatchingCriteriaInput(items[0].(map[string]interface{}))
-		}
-	}
-
-	return input
-}
-
-func expandDataPartitionRuleUpdateInput(d *schema.ResourceData) logconfigurations.LogConfigurationsUpdateDataPartitionRuleInput {
-	input := logconfigurations.LogConfigurationsUpdateDataPartitionRuleInput{
-		ID:      d.Id(),
-		Enabled: d.Get("enabled").(bool),
-	}
-
-	if e, ok := d.GetOk("description"); ok {
-		input.Description = e.(string)
-	}
-
-	if e, ok := d.GetOk("nrql"); ok {
-		input.NRQL = logconfigurations.NRQL(e.(string))
-	}
-
-	if v, ok := d.GetOk("matching_criteria"); ok {
-		items := v.([]interface{})
-		if len(items) > 0 {
-			input.MatchingCriteria = expandDataPartitionRuleMatchingCriteriaInput(items[0].(map[string]interface{}))
-		}
-	}
-
-	return input
-}
-
-func expandDataPartitionRuleMatchingCriteriaInput(cfg map[string]interface{}) *logconfigurations.LogConfigurationsDataPartitionRuleMatchingCriteriaInput {
-	input := &logconfigurations.LogConfigurationsDataPartitionRuleMatchingCriteriaInput{}
-
-	if v, ok := cfg["attribute_name"]; ok {
-		input.AttributeName = v.(string)
-	}
-
-	if v, ok := cfg["matching_expression"]; ok {
-		input.MatchingExpression = v.(string)
-	}
-
-	if v, ok := cfg["matching_method"]; ok {
-		input.MatchingMethod = logconfigurations.LogConfigurationsDataPartitionRuleMatchingOperator(v.(string))
-	}
-
-	return input
-}
-
-func flattenDataPartitionRule(rule *logconfigurations.LogConfigurationsDataPartitionRule, d *schema.ResourceData) error {
-	if rule == nil {
-		return nil
-	}
-
-	_ = d.Set("description", rule.Description)
-	_ = d.Set("enabled", rule.Enabled)
-	_ = d.Set("target_data_partition", string(rule.TargetDataPartition))
-	_ = d.Set("nrql", string(rule.NRQL))
-	_ = d.Set("retention_policy", string(rule.RetentionPolicy))
-	_ = d.Set("deleted", rule.Deleted)
-
-	if rule.MatchingCriteria != (logconfigurations.LogConfigurationsDataPartitionRuleMatchingCriteria{}) {
-		mc := map[string]interface{}{
-			"attribute_name":      rule.MatchingCriteria.AttributeName,
-			"matching_expression": rule.MatchingCriteria.MatchingExpression,
-			"matching_method":     string(rule.MatchingCriteria.MatchingOperator),
-		}
-		if err := d.Set("matching_criteria", []interface{}{mc}); err != nil {
-			return fmt.Errorf("[DEBUG] Error setting `matching_criteria`: %v", err)
-		}
-	}
-
-	return nil
 }

--- a/newrelic/resource_newrelic_log_parsing_rule.go
+++ b/newrelic/resource_newrelic_log_parsing_rule.go
@@ -69,6 +69,12 @@ func resourceNewRelicLogParsingRule() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
+			"source": {
+				Type:        schema.TypeString,
+				Description: "The source of the parsing rule.",
+				Optional:    true,
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -85,6 +91,9 @@ func resourceNewRelicLogParsingRuleCreate(ctx context.Context, d *schema.Resourc
 		Grok:    d.Get("grok").(string),
 		Lucene:  d.Get("lucene").(string),
 		NRQL:    logconfigurations.NRQL(d.Get("nrql").(string)),
+	}
+	if e, ok := d.GetOk("source"); ok {
+		createInput.Source = logconfigurations.LogConfigurationsParsingRuleSource(e.(string))
 	}
 	var diags diag.Diagnostics
 	if e, ok := d.GetOk("attribute"); ok {
@@ -174,6 +183,10 @@ func resourceNewRelicLogParsingRuleRead(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
+	if err := d.Set("source", rule.Source); err != nil {
+		return diag.FromErr(err)
+	}
+
 	return nil
 }
 
@@ -238,6 +251,10 @@ func expandLogParsingRuleUpdateInput(d *schema.ResourceData) logconfigurations.L
 
 	if e, ok := d.GetOk("nrql"); ok {
 		updateInp.NRQL = logconfigurations.NRQL(e.(string))
+	}
+
+	if e, ok := d.GetOk("source"); ok {
+		updateInp.Source = logconfigurations.LogConfigurationsParsingRuleSource(e.(string))
 	}
 
 	return updateInp

--- a/newrelic/resource_newrelic_obfuscation_expression.go
+++ b/newrelic/resource_newrelic_obfuscation_expression.go
@@ -42,6 +42,16 @@ func resourceNewRelicObfuscationExpression() *schema.Resource {
 				Description: "Regex of expression.",
 				Required:    true,
 			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Description: "The date and time the expression was created.",
+				Computed:    true,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Description: "The date and time the expression was last updated.",
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -104,6 +114,9 @@ func resourceNewRelicObfuscationExpressionRead(ctx context.Context, d *schema.Re
 	if err := d.Set("regex", expression.Regex); err != nil {
 		return diag.FromErr(err)
 	}
+
+	_ = d.Set("created_at", expression.CreatedAt.String())
+	_ = d.Set("updated_at", expression.UpdatedAt.String())
 
 	return nil
 }

--- a/newrelic/resource_newrelic_obfuscation_rule.go
+++ b/newrelic/resource_newrelic_obfuscation_rule.go
@@ -76,6 +76,11 @@ func ObfuscationRuleActionInputSchemaElem() *schema.Resource {
 				Required:    true,
 				Description: "Expression Id for action.",
 			},
+			"action_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The id of the obfuscation action.",
+			},
 			"method": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -194,6 +199,7 @@ func flattenActions(actions *[]logconfigurations.LogConfigurationsObfuscationAct
 			"expression_id": v.Expression.ID,
 			"attribute":     v.Attributes,
 			"method":        v.Method,
+			"action_id":     v.ID,
 		}
 		flatActions = append(flatActions, m)
 	}

--- a/website/newrelic.erb
+++ b/website/newrelic.erb
@@ -24,6 +24,7 @@
     "alert_policy",
     "alert_policy_channel",
     "api_access_key",
+    "data_partition_rule",
     "entity_tags",
     "events_to_metrics_rule",
     "infra_alert_condition",

--- a/website/newrelic.erb
+++ b/website/newrelic.erb
@@ -31,6 +31,7 @@
     "insights_event",
     "nrql_alert_condition",
     "nrql_drop_rule",
+    "obfuscation_expression",
     "obfuscation_rule",
     "one_dashboard",
     "one_dashboard_raw",

--- a/website/newrelic.erb
+++ b/website/newrelic.erb
@@ -31,6 +31,7 @@
     "insights_event",
     "nrql_alert_condition",
     "nrql_drop_rule",
+    "obfuscation_rule",
     "one_dashboard",
     "one_dashboard_raw",
     "synthetics_alert_condition",

--- a/website/newrelic.erb
+++ b/website/newrelic.erb
@@ -29,6 +29,7 @@
     "events_to_metrics_rule",
     "infra_alert_condition",
     "insights_event",
+    "log_parsing_rule",
     "nrql_alert_condition",
     "nrql_drop_rule",
     "obfuscation_expression",


### PR DESCRIPTION
## Summary

Updates the existing `newrelic_data_partition_rule` resource to reflect changes in the go-client `logconfigurations` namespace.

**Generated files:**
- `newrelic/resource_newrelic_data_partition.go`
- `newrelic/structures_newrelic_data_partition.go`

**go-client source:** https://github.com/newrelic/newrelic-client-go/pull/1440 (sha: `fee95e2a243e40cc8b44341f0e89fa3d09449def`)

**Before this can merge:**
- Run `go mod tidy` — the branch carries a `go.mod` `replace` for the unmerged go-client commit with no matching `go.sum`, so the build fails until it is regenerated. Drop the `replace` once the go-client change is released.
- Check the registration in `newrelic/provider_newrelic.go` is in `ResourcesMap` and not `DataSourcesMap`, and that `website/newrelic.erb` lists it under Resources.
- `website/docs/r/data_partition_rule.html.markdown` was NOT regenerated; update it by hand if this adds arguments.
- Nothing here was built or `terraform validate`d. Review the schema against the provider's own naming conventions before approving.

---
*Generated by [api-governance codegen](https://source.datanerd.us/after/api-governance)*