### PR TITLE
feat(pipeline-cloud-rule): add ottl_transform block, make nrql optional, nil-safe Read

### DIFF
--- a/newrelic/resource_newrelic_pipeline_cloud_rule.go
+++ b/newrelic/resource_newrelic_pipeline_cloud_rule.go
@@ -35,14 +35,54 @@ func resourceNewRelicPipelineCloudRule() *schema.Resource {
 				Description: "The name of the rule. This must be unique within an account.",
 			},
 			"nrql": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "The NRQL query that defines which data will be processed by this pipeline cloud rule.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				Description:  "The NRQL query that defines which data will be processed by this pipeline cloud rule. Mutually exclusive with `ottl_transform`; exactly one must be set.",
+				AtLeastOneOf: []string{"nrql", "ottl_transform"},
+				ConflictsWith: []string{"ottl_transform"},
 			},
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Provides additional information about the rule.",
+			},
+			"ottl_transform": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				Computed:      true,
+				MaxItems:      1,
+				Description:   "OTTL transformation statements for non-NRQL pipeline cloud rules. Mutually exclusive with `nrql`; exactly one must be set.",
+				ConflictsWith: []string{"nrql"},
+				AtLeastOneOf:  []string{"nrql", "ottl_transform"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"log_statements": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "OTTL statements applied to log data.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+						},
+						"event_statements": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "OTTL statements applied to event data.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+						},
+						"metric_statements": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "OTTL statements applied to metric data.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+						},
+						"trace_statements": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "OTTL statements applied to trace data.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
 			},
 			//"entity_version": {
 			//	Type:     schema.TypeInt,
@@ -57,14 +97,21 @@ func resourceNewRelicPipelineCloudRuleCreate(ctx context.Context, d *schema.Reso
 	client := providerConfig.NewClient
 
 	accountID := selectAccountID(providerConfig, d)
-
 	description := d.Get("description").(string)
-	nrql := d.Get("nrql")
 	name := d.Get("name").(string)
+	nrqlStr := d.Get("nrql").(string)
 
+	if nrqlStr == "" {
+		// OTTL rule creation requires backend support not yet available. Once the
+		// ep-next-gen-api schema change lands, this guard will be removed and
+		// ottl_transform will be wired into the create input.
+		return diag.Errorf("nrql is required for pipeline cloud rules; OTTL rule creation is not yet supported by this resource")
+	}
+
+	nrqlVal := nrdb.NRQL(nrqlStr)
 	createInput := pipelinecontrol.EntityManagementPipelineCloudRuleEntityCreateInput{
 		Description: description,
-		NRQL:        nrdb.NRQL(nrql.(string)),
+		NRQL:        nrqlVal,
 		Name:        name,
 		Scope: pipelinecontrol.EntityManagementScopedReferenceInput{
 			Type: pipelinecontrol.EntityManagementEntityScopeTypes.ACCOUNT,
@@ -129,8 +176,16 @@ func resourceNewRelicPipelineCloudRuleRead(ctx context.Context, d *schema.Resour
 			return diag.FromErr(err)
 		}
 
-		if err := d.Set("nrql", entity.NRQL); err != nil {
-			return diag.FromErr(err)
+		if entity.NRQL != nil {
+			if err := d.Set("nrql", string(*entity.NRQL)); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+
+		if entity.OttlTransform != nil {
+			if err := d.Set("ottl_transform", flattenPipelineCloudRuleOttlTransform(entity.OttlTransform)); err != nil {
+				return diag.FromErr(err)
+			}
 		}
 
 		//if err := d.Set("entity_version", entity.Metadata.Version); err != nil {
@@ -148,13 +203,15 @@ func resourceNewRelicPipelineCloudRuleUpdate(ctx context.Context, d *schema.Reso
 	client := providerConfig.NewClient
 
 	description := d.Get("description").(string)
-	nrql := d.Get("nrql")
 	name := d.Get("name").(string)
 
 	updateInput := pipelinecontrol.EntityManagementPipelineCloudRuleEntityUpdateInput{
 		Description: description,
-		NRQL:        nrdb.NRQL(nrql.(string)),
 		Name:        name,
+	}
+
+	if nrqlStr := d.Get("nrql").(string); nrqlStr != "" {
+		updateInput.NRQL = nrdb.NRQL(nrqlStr)
 	}
 
 	ruleID := d.Id()
@@ -198,4 +255,16 @@ func resourceNewRelicPipelineCloudRuleDelete(ctx context.Context, d *schema.Reso
 		return diag.FromErr(fmt.Errorf("error in deleting entity with ruleID %s", ruleID))
 	}
 	return nil
+}
+
+func flattenPipelineCloudRuleOttlTransform(t *pipelinecontrol.EntityManagementPipelineCloudRuleEntityOttlTransform) []map[string]interface{} {
+	if t == nil {
+		return nil
+	}
+	return []map[string]interface{}{{
+		"log_statements":    t.LogStatements,
+		"event_statements":  t.EventStatements,
+		"metric_statements": t.MetricStatements,
+		"trace_statements":  t.TraceStatements,
+	}}
 }

--- a/website/docs/r/pipeline_cloud_rule.html.markdown
+++ b/website/docs/r/pipeline_cloud_rule.html.markdown
@@ -14,12 +14,32 @@ Use this resource to create and manage a New Relic Pipeline Cloud Rule.
 
 ## Example Usage
 
+### NRQL-based rule
+
 ```hcl
-resource "newrelic_pipeline_cloud_rule" "foo" {
+resource "newrelic_pipeline_cloud_rule" "nrql_example" {
   account_id  = 1000100
-  name        = "Test Pipeline Cloud Rule"
-  description = "This rule deletes all DEBUG logs from the dev environment."
+  name        = "Drop debug logs"
+  description = "Drops all DEBUG logs from the dev environment."
   nrql        = "DELETE FROM Log WHERE logLevel = 'DEBUG' AND environment = 'dev'"
+}
+```
+
+### OTTL-based rule
+
+~> **NOTE:** OTTL rule creation requires backend support that is currently being rolled out. This example shows the intended configuration once the feature is fully available.
+
+```hcl
+resource "newrelic_pipeline_cloud_rule" "ottl_example" {
+  account_id  = 1000100
+  name        = "Redact PII from logs"
+  description = "Uses OTTL to redact email addresses from log bodies."
+
+  ottl_transform {
+    log_statements = [
+      "replace_pattern(body, \"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[a-zA-Z]{2,}\", \"[REDACTED]\")",
+    ]
+  }
 }
 ```
 
@@ -29,8 +49,18 @@ The following arguments are supported:
 
 *   `account_id` - (Optional) The account ID where the Pipeline Cloud Rule will be created.
 *   `name` - (Required) The name of the rule. This must be unique within an account.
-*   `nrql` - (Required) The NRQL query that defines the data to be processed by this Pipeline Cloud Rule.
 *   `description` - (Optional) Additional information about the rule.
+*   `nrql` - (Optional) The NRQL query that defines the data to be processed by this Pipeline Cloud Rule. Mutually exclusive with `ottl_transform`; exactly one of `nrql` or `ottl_transform` must be set.
+*   `ottl_transform` - (Optional) OTTL transformation statements for non-NRQL pipeline cloud rules. Mutually exclusive with `nrql`; exactly one of `nrql` or `ottl_transform` must be set. See [OTTL Transform](#ottl-transform) below for details.
+
+### OTTL Transform
+
+The `ottl_transform` block supports the following arguments. Exactly one of the statement fields must be specified, scoped to a single telemetry type:
+
+*   `log_statements` - (Optional) List of OTTL statements applied to log data.
+*   `event_statements` - (Optional) List of OTTL statements applied to event data.
+*   `metric_statements` - (Optional) List of OTTL statements applied to metric data.
+*   `trace_statements` - (Optional) List of OTTL statements applied to trace data.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Summary

Prepares `newrelic_pipeline_cloud_rule` for the NGEP schema change ([ep-next-gen-api PR #1860](https://source.datanerd.us/entity-platform/ep-next-gen-api/pull/1860)) that relaxes `PipelineCloudRuleEntity.nrql` from `Nrql!` to `Nrql` and adds `ottlTransform` as a sibling field for OTTL-based rules.

> **Dependency:** This PR requires [newrelic-client-go feat/pipeline-cloud-rule-ottl-nullable-nrql](https://github.com/newrelic/newrelic-client-go/pull/1465) to merge first, after which `go.mod` must be bumped to the new client version. Provider CI will not pass until that dependency is in place.

## Changes

- **`nrql`**: `Required: true` → `Optional: true, Computed: true` with `ConflictsWith: ["ottl_transform"]` and `AtLeastOneOf: ["nrql", "ottl_transform"]`; Create guards against empty `nrql` with a clear error until OTTL creation is supported by the backend
- **`ottl_transform` block added** (`Optional + Computed`, max 1) with `log_statements`, `event_statements`, `metric_statements`, `trace_statements` list fields
- **Read**: nil-safe dereference of `entity.NRQL` (`*nrdb.NRQL` after Go client update); `ottl_transform` flattened from `entity.OttlTransform`
- **Update**: `nrql` only included in update body when non-empty (safe under the coordinator's stored-entity-state check)
- **Docs**: updated with NRQL and OTTL usage examples; `nrql` documented as Optional

## Test plan

- [ ] After Go client PR merges and `go.mod` is bumped: `go build ./...` passes
- [ ] Existing NRQL rule acceptance tests pass with no behaviour change
- [ ] After ep-next-gen-api PR #1860 lands: import an OTTL rule and verify `ottl_transform` populates in state with nil `nrql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)