### PR TITLE
feat: add newrelic_change_tracking_deployment terraform resource

### DIFF
--- a/integration_test_utilities/integration_test_mappings.yaml
+++ b/integration_test_utilities/integration_test_mappings.yaml
@@ -199,6 +199,9 @@ resource_newrelic_cardinality_management.go:
 resource_newrelic_cardinality_management_test.go:
   test: true
   product_mapping: INGEST
+resource_newrelic_change_tracking_deployment.go:
+  test: false
+  product_mapping: EVENTS
 resource_newrelic_cloud_aws_eu_sovereign_integrations.go:
   test: false
   product_mapping: CLOUD
@@ -553,6 +556,9 @@ structures_newrelic_api_access_key.go:
 structures_newrelic_application_settings.go:
   test: false
   product_mapping: APM
+structures_newrelic_change_tracking_deployment.go:
+  test: false
+  product_mapping: EVENTS
 structures_newrelic_cloud_aws_eu_sovereign_link_account.go:
   test: false
   product_mapping: CLOUD

--- a/newrelic/provider_newrelic.go
+++ b/newrelic/provider_newrelic.go
@@ -151,6 +151,7 @@ func Provider() *schema.Provider {
 			"newrelic_api_access_key":                           resourceNewRelicAPIAccessKey(),
 			"newrelic_application_settings":                     resourceNewRelicApplicationSettings(),
 			"newrelic_browser_application":                      resourceNewRelicBrowserApplication(),
+			"newrelic_change_tracking_deployment":               resourceNewRelicChangeTrackingDeployment(),
 			"newrelic_cloud_aws_eu_sovereign_link_account":      resourceNewRelicCloudAwsEuSovereignLinkAccount(),
 			"newrelic_cloud_aws_eu_sovereign_integrations":      resourceNewRelicCloudAwsEuSovereignIntegrations(),
 			"newrelic_cloud_aws_govcloud_link_account":          resourceNewRelicAwsGovCloudLinkAccount(),

--- a/newrelic/resource_newrelic_change_tracking_deployment.go
+++ b/newrelic/resource_newrelic_change_tracking_deployment.go
@@ -1,0 +1,141 @@
+package newrelic
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/changetracking"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
+)
+
+func resourceNewRelicChangeTrackingDeployment() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNewRelicChangeTrackingDeploymentCreate,
+		ReadContext:   schema.NoopContext,
+		Delete:        schema.RemoveFromState,
+		Schema: map[string]*schema.Schema{
+			"version": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The version of the deployed software, for example, something like v1.1.",
+			},
+			"entity_guid": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "The GUID of the New Relic entity that was deployed.",
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+			},
+			"deployment_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(listValidChangeTrackingDeploymentTypes(), false),
+				Description:  fmt.Sprintf("The type of deployment. One of: (%s).", listChangeTrackingDeploymentTypesString()),
+			},
+			"changelog": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "A URL for the changelog or, if not linkable, a list of changes.",
+			},
+			"commit": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The commit identifier, for example, a Git commit SHA.",
+			},
+			"deep_link": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "A URL to the system that generated the deployment.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "A description of the deployment.",
+			},
+			"group_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "An identifier used to correlate account-wide changes across entities.",
+			},
+			"timestamp": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The start time of the deployment as the number of milliseconds since the Unix epoch. Defaults to now.",
+			},
+			"user": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The username of the deployer or bot.",
+			},
+			"account_id": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The account ID of the entity the deployment belongs to.",
+			},
+			"deployment_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The unique deployment identifier.",
+			},
+		},
+	}
+}
+
+func listValidChangeTrackingDeploymentTypes() []string {
+	return []string{
+		string(changetracking.ChangeTrackingDeploymentTypeTypes.BASIC),
+		string(changetracking.ChangeTrackingDeploymentTypeTypes.BLUE_GREEN),
+		string(changetracking.ChangeTrackingDeploymentTypeTypes.CANARY),
+		string(changetracking.ChangeTrackingDeploymentTypeTypes.OTHER),
+		string(changetracking.ChangeTrackingDeploymentTypeTypes.ROLLING),
+		string(changetracking.ChangeTrackingDeploymentTypeTypes.SHADOW),
+	}
+}
+
+func listChangeTrackingDeploymentTypesString() string {
+	types := listValidChangeTrackingDeploymentTypes()
+	result := ""
+	for i, t := range types {
+		if i > 0 {
+			result += ", "
+		}
+		result += t
+	}
+	return result
+}
+
+var _ common.EntityGUID
+var _ diag.Diagnostics
+var _ context.Context
+
+func resourceNewRelicChangeTrackingDeploymentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.NewClient
+
+	dataHandlingRules, deployment, err := expandChangeTrackingDeployment(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	result, err := client.ChangeTracking.ChangeTrackingCreateDeploymentWithContext(ctx, dataHandlingRules, deployment)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(result.DeploymentId)
+	return diag.FromErr(flattenChangeTrackingDeployment(result, d))
+}

--- a/newrelic/structures_newrelic_change_tracking_deployment.go
+++ b/newrelic/structures_newrelic_change_tracking_deployment.go
@@ -1,0 +1,54 @@
+package newrelic
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/changetracking"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/common"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/nrtime"
+	"time"
+)
+
+func expandChangeTrackingDeployment(d *schema.ResourceData) (changetracking.ChangeTrackingDataHandlingRules, changetracking.ChangeTrackingDeploymentInput, error) {
+	dataHandlingRules := changetracking.ChangeTrackingDataHandlingRules{}
+
+	deployment := changetracking.ChangeTrackingDeploymentInput{
+		EntityGUID: common.EntityGUID(d.Get("entity_guid").(string)),
+		Version:    d.Get("version").(string),
+	}
+
+	if v, ok := d.GetOk("deployment_type"); ok {
+		deployment.DeploymentType = changetracking.ChangeTrackingDeploymentType(v.(string))
+	}
+
+	if v, ok := d.GetOk("changelog"); ok {
+		deployment.Changelog = v.(string)
+	}
+
+	if v, ok := d.GetOk("commit"); ok {
+		deployment.Commit = v.(string)
+	}
+
+	if v, ok := d.GetOk("deep_link"); ok {
+		deployment.DeepLink = v.(string)
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		deployment.Description = v.(string)
+	}
+
+	if v, ok := d.GetOk("group_id"); ok {
+		deployment.GroupId = v.(string)
+	}
+
+	if v, ok := d.GetOk("timestamp"); ok {
+		deployment.Timestamp = nrtime.EpochMilliseconds(time.UnixMilli(int64(v.(int))))
+	}
+
+	if v, ok := d.GetOk("user"); ok {
+		deployment.User = v.(string)
+	}
+
+	return dataHandlingRules, deployment, nil
+}
+
+// No flatten functions: this API is write-only.

--- a/website/docs/r/change_tracking_deployment.html.markdown
+++ b/website/docs/r/change_tracking_deployment.html.markdown
@@ -1,0 +1,96 @@
+---
+layout: "newrelic"
+page_title: "New Relic: newrelic_change_tracking_deployment"
+sidebar_current: "docs-newrelic-resource-change-tracking-deployment"
+description: |-
+  Create and manage a deployment marker for change tracking in New Relic.
+---
+
+# Resource: newrelic\_change\_tracking\_deployment
+
+Use this resource to create deployment markers for change tracking in New Relic. Details regarding change tracking and deployment markers can be found [here](https://docs.newrelic.com/docs/change-tracking/change-tracking-introduction/).
+
+## Example Usage
+
+```hcl
+resource "newrelic_change_tracking_deployment" "foo" {
+  entity_guid     = "MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM4Nzk2"
+  version         = "v1.0.0"
+  deployment_type = "BASIC"
+  changelog       = "https://github.com/example/repo/CHANGELOG.md"
+  commit          = "abc123def456"
+  deep_link       = "https://ci.example.com/builds/1234"
+  description     = "Deployment of version v1.0.0"
+  group_id        = "deployment-group-1"
+  user            = "deployer-bot"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `entity_guid` - (Required) The GUID of the New Relic entity that was deployed.
+* `version` - (Required) The version of the deployed software, for example, something like v1.1.
+* `account_id` - (Optional) The account ID of the entity the deployment belongs to. Defaults to the account associated with the API key used.
+* `deployment_type` - (Optional) The type of deployment. One of: `BASIC`, `BLUE_GREEN`, `CANARY`, `OTHER`, `ROLLING`, `SHADOW`.
+* `changelog` - (Optional) A URL for the changelog or, if not linkable, a list of changes.
+* `commit` - (Optional) The commit identifier, for example, a Git commit SHA.
+* `deep_link` - (Optional) A URL to the system that generated the deployment.
+* `description` - (Optional) A description of the deployment.
+* `group_id` - (Optional) An identifier used to correlate account-wide changes across entities. These changes are shown together in the `Changes in group` section of the change event details UI.
+* `timestamp` - (Optional) The start time of the deployment as the number of milliseconds since the Unix epoch. Defaults to now.
+* `user` - (Optional) The username of the deployer or bot.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The unique deployment identifier.
+* `deployment_id` - The unique deployment identifier.
+
+## Additional Examples
+
+#### Basic Deployment
+
+```hcl
+resource "newrelic_change_tracking_deployment" "basic" {
+  entity_guid = "MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM4Nzk2"
+  version     = "1.0.0"
+}
+```
+
+#### Canary Deployment
+
+```hcl
+resource "newrelic_change_tracking_deployment" "canary" {
+  entity_guid     = "MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM4Nzk2"
+  version         = "2.0.0"
+  deployment_type = "CANARY"
+  user            = "ci-pipeline"
+  description     = "Canary release of version 2.0.0"
+  commit          = "deadbeef"
+}
+```
+
+#### Rolling Deployment with Group ID
+
+```hcl
+resource "newrelic_change_tracking_deployment" "rolling" {
+  entity_guid     = "MjUyMDUyOHxBUE18QVBQTElDQVRJT058MjE1MDM4Nzk2"
+  version         = "3.1.0"
+  deployment_type = "ROLLING"
+  group_id        = "release-2024-01"
+  user            = "release-bot"
+  changelog       = "https://github.com/example/repo/releases/tag/v3.1.0"
+  deep_link       = "https://jenkins.example.com/job/deploy/42"
+}
+```
+
+## Additional Information
+
+More information about change tracking can be found in the New Relic [documentation](https://docs.newrelic.com/docs/change-tracking/change-tracking-introduction/).
+
+More details about the change tracking API can be found [here](https://docs.newrelic.com/docs/change-tracking/change-tracking-graphql/).
+
+~> **NOTE:** This resource supports create operations only. Deployment markers cannot be updated or deleted through the New Relic API. The resource will be removed from Terraform state on destroy without making any API calls.

--- a/website/newrelic.erb
+++ b/website/newrelic.erb
@@ -24,6 +24,7 @@
     "alert_policy",
     "alert_policy_channel",
     "api_access_key",
+    "change_tracking_deployment",
     "entity_tags",
     "events_to_metrics_rule",
     "infra_alert_condition",


### PR DESCRIPTION
## Summary

Adds a new Terraform resource `newrelic_change_tracking_deployment` generated from the go-client `changetracking` namespace.

**Generated files:**
- `newrelic/resource_newrelic_change_tracking_deployment.go`
- `newrelic/structures_newrelic_change_tracking_deployment.go`
- `website/docs/r/change_tracking_deployment.html.markdown`

**go-client source:** main @ `main`

**Before this can merge:**
- Check the registration in `newrelic/provider_newrelic.go` is in `ResourcesMap` and not `DataSourcesMap`, and that `website/newrelic.erb` lists it under Resources.
- Confirm the product mapping. `EVENTS` was chosen by the generator for `resource_newrelic_change_tracking_deployment.go` because no pattern in `integration_test_types.go` matches it — grouped with its closest siblings rather than derived. Change the value in `integration_test_mappings.yaml` if another product owns this resource.
- Nothing here was built or `terraform validate`d. Review the schema against the provider's own naming conventions before approving.

---
*Generated by [api-governance codegen](https://source.datanerd.us/after/api-governance)*