### PR TITLE
fix(oci): scope read secret-bundles policy to New Relic's own secrets

### DIFF
--- a/examples/modules/cloud-integrations/oci/policy-setup/locals.tf
+++ b/examples/modules/cloud-integrations/oci/policy-setup/locals.tf
@@ -14,6 +14,12 @@ locals {
   create_vault = !local.is_user_vault_key_present || !local.is_ingest_vault_key_present
   user_api_key = local.is_user_vault_key_present ? base64decode(data.oci_secrets_secretbundle.user_api_key[0].secret_bundle_content[0].content) : var.newrelic_user_api_key
 
+  # Resolve the actual secret OCIDs New Relic uses (the caller-provided secret when present,
+  # otherwise the vault secret this module creates). These scope the "read secret-bundles"
+  # policy below to only New Relic's secrets instead of every secret in the tenancy.
+  ingest_key_secret_ocid = local.is_ingest_vault_key_present ? var.ingest_key_secret_ocid : oci_vault_secret.ingest_api_key[0].id
+  user_key_secret_ocid   = local.is_user_vault_key_present ? var.user_key_secret_ocid : oci_vault_secret.user_api_key[0].id
+
   freeform_tags = {
     newrelic-terraform = "true"
   }

--- a/examples/modules/cloud-integrations/oci/policy-setup/main.tf
+++ b/examples/modules/cloud-integrations/oci/policy-setup/main.tf
@@ -120,7 +120,7 @@ resource "oci_identity_policy" "nr_common_policy" {
   statements = [
     "Allow dynamic-group ${local.dynamic_group_name} to use fn-function in tenancy",
     "Allow dynamic-group ${local.dynamic_group_name} to use fn-invocation in tenancy",
-    "Allow dynamic-group ${local.dynamic_group_name} to read secret-bundles in tenancy",
+    "Allow dynamic-group ${local.dynamic_group_name} to read secret-bundles in tenancy where any { target.secret.id = '${local.ingest_key_secret_ocid}', target.secret.id = '${local.user_key_secret_ocid}' }",
   ]
   defined_tags  = {}
   freeform_tags = local.freeform_tags


### PR DESCRIPTION
Narrow the common policy's 'read secret-bundles in tenancy' grant to only the Ingest and User API key secrets (by target.secret.id) instead of every secret in the tenancy. Mirrors newrelic/newrelic-oracle-cloud-integration#63.

# Description

Please include a summary of the change and which issue is fixed (if relevant).

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [ ] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

- Step 1
- Step 2
- etc
