### PR TITLE
fix(events_to_metrics_rule): fall back to provider account_id

### DIFF
--- a/newrelic/resource_newrelic_events_to_metrics_rule.go
+++ b/newrelic/resource_newrelic_events_to_metrics_rule.go
@@ -68,7 +68,7 @@ func resourceNewRelicEventsToMetricsRuleCreate(ctx context.Context, d *schema.Re
 
 	createInput := []eventstometrics.EventsToMetricsCreateRuleInput{
 		{
-			AccountID:   d.Get("account_id").(int),
+			AccountID:   selectAccountID(providerConfig, d),
 			Description: d.Get("description").(string),
 			Name:        d.Get("name").(string),
 			NRQL:        d.Get("nrql").(string),

--- a/newrelic/resource_newrelic_events_to_metrics_rule_test.go
+++ b/newrelic/resource_newrelic_events_to_metrics_rule_test.go
@@ -4,6 +4,7 @@ package newrelic
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -33,6 +34,14 @@ func TestAccNewRelicEventsToMetricsRule_Basic(t *testing.T) {
 				Config: testAccNewRelicEventsToMetricsRuleConfigUpdated(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNewRelicEventsToMetricsRuleExists(resourceName),
+				),
+			},
+			// Test: account_id omitted falls back to the provider account
+			{
+				Config: testAccNewRelicEventsToMetricsRuleConfigNoAccountID(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNewRelicEventsToMetricsRuleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "account_id", strconv.Itoa(testAccountID)),
 				),
 			},
 			// Test: Import
@@ -116,4 +125,14 @@ resource "newrelic_events_to_metrics_rule" "foo" {
   enabled = false
 }
 `, testAccountID, name)
+}
+
+func testAccNewRelicEventsToMetricsRuleConfigNoAccountID(name string) string {
+	return fmt.Sprintf(`
+resource "newrelic_events_to_metrics_rule" "foo" {
+  name = "%s"
+  description = "test description"
+  nrql = "SELECT uniqueCount(account_id) AS `+"`"+"Transaction.account_id"+"`"+` FROM Transaction FACET appName, name"
+}
+`, name)
 }


### PR DESCRIPTION
# Description

The `newrelic_events_to_metrics_rule` resource read `account_id` directly from resource config via `d.Get("account_id").(int)` in its Create function. When `account_id` is omitted on the resource block, this returns the zero value `0`, which is sent straight to the `eventsToMetricsCreateRule` GraphQL mutation as `"accountId": 0` — even when the provider is configured with an account ID (e.g. via `NEW_RELIC_ACCOUNT_ID`).

This change uses the existing `selectAccountID(providerConfig, d)` helper, so the create mutation inherits the provider-level account ID when `account_id` is omitted on the resource, instead of sending `accountId: 0`. This brings the resource in line with the ~70 other resources in the provider that already use this helper.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code

## How to test this change?

Reproduce the bug (before the fix) and verify the fix resolves it:

- **Step 1** — Configure the provider with an account ID via environment variable and no `account_id` on the resource:
  ```hcl
  # NEW_RELIC_ACCOUNT_ID=<number> exported in the environment

  resource "newrelic_events_to_metrics_rule" "example" {
    name        = "Homepage Start to HomeReady duration by device"
    description = "Retain BrowserPerformance Start->HomeReady as a distribution metric by device type."
    enabled     = true
    nrql        = "FROM BrowserPerformance SELECT distribution(entryDuration) AS 'example.metric' FACET deviceType"
  }
  ```
- **Step 2** — Run `terraform apply`. Before the fix, the create mutation is sent with `"accountId": 0` and the rule is created under (or rejected for) account `0`. After the fix, the rule is created under the provider's account (`<number>`).
- **Step 3** — Confirm the resource's `account_id` in state resolves to the provider account ID, and that explicitly setting `account_id` on the resource still overrides the provider value.