### PR TITLE
fix: reject empty Azure credentials in newrelic_cloud_azure_link_account

### DIFF
--- a/newrelic/resource_newrelic_cloud_azure_link_account.go
+++ b/newrelic/resource_newrelic_cloud_azure_link_account.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/cloud"
 )
 
@@ -29,16 +30,18 @@ func resourceNewRelicCloudAzureLinkAccount() *schema.Resource {
 				ForceNew:    true,
 			},
 			"application_id": {
-				Type:        schema.TypeString,
-				Description: "Application ID for Azure account",
-				Required:    true,
-				Sensitive:   true,
+				Type:         schema.TypeString,
+				Description:  "Application ID for Azure account",
+				Required:     true,
+				Sensitive:    true,
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 			"client_secret": {
-				Type:        schema.TypeString,
-				Description: "Value of the client secret from Azure",
-				Required:    true,
-				Sensitive:   true,
+				Type:         schema.TypeString,
+				Description:  "Value of the client secret from Azure",
+				Required:     true,
+				Sensitive:    true,
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 			"name": {
 				Type:        schema.TypeString,
@@ -46,16 +49,18 @@ func resourceNewRelicCloudAzureLinkAccount() *schema.Resource {
 				Required:    true,
 			},
 			"subscription_id": {
-				Type:        schema.TypeString,
-				Description: "Subscription ID for the Azure account",
-				Required:    true,
-				Sensitive:   true,
+				Type:         schema.TypeString,
+				Description:  "Subscription ID for the Azure account",
+				Required:     true,
+				Sensitive:    true,
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 			"tenant_id": {
-				Type:        schema.TypeString,
-				Description: "Tenant ID for the Azure account",
-				Required:    true,
-				Sensitive:   true,
+				Type:         schema.TypeString,
+				Description:  "Tenant ID for the Azure account",
+				Required:     true,
+				Sensitive:    true,
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 		},
 	}

--- a/newrelic/resource_newrelic_cloud_azure_link_account.go
+++ b/newrelic/resource_newrelic_cloud_azure_link_account.go
@@ -49,11 +49,10 @@ func resourceNewRelicCloudAzureLinkAccount() *schema.Resource {
 				Required:    true,
 			},
 			"subscription_id": {
-				Type:         schema.TypeString,
-				Description:  "Subscription ID for the Azure account",
-				Required:     true,
-				Sensitive:    true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				Type:        schema.TypeString,
+				Description: "Subscription ID for the Azure account",
+				Required:    true,
+				Sensitive:   true,
 			},
 			"tenant_id": {
 				Type:         schema.TypeString,

--- a/newrelic/resource_newrelic_cloud_azure_link_account.go
+++ b/newrelic/resource_newrelic_cloud_azure_link_account.go
@@ -49,10 +49,11 @@ func resourceNewRelicCloudAzureLinkAccount() *schema.Resource {
 				Required:    true,
 			},
 			"subscription_id": {
-				Type:        schema.TypeString,
-				Description: "Subscription ID for the Azure account",
-				Required:    true,
-				Sensitive:   true,
+				Type:         schema.TypeString,
+				Description:  "Subscription ID for the Azure account",
+				Required:     true,
+				Sensitive:    true,
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 			"tenant_id": {
 				Type:         schema.TypeString,


### PR DESCRIPTION
## Why are you making this change?

`newrelic_cloud_azure_link_account`'s `application_id`, `client_secret`, `subscription_id`, and `tenant_id` fields are only marked `Required: true`. In the Terraform SDK, `Required` blocks an absent value but **not** an empty string, so `tenant_id = ""` (e.g. from an unset variable) passes `terraform apply` unvalidated.

An empty `tenant_id` then reaches Azure Identity's `ClientSecretCredentialBuilder`, which builds the authority URL as `https://login.microsoftonline.com/<tenantId>`. With an empty tenant ID that URL has no path segment, so `getToken()` fails deep in the Azure SDK with:

```
Azure Identity => ERROR in getToken() call for scopes [https://management.core.windows.net//.default]: authority Uri should have at least one segment in the path (i.e. https://<host>/<path>/...)
```

instead of a clear, actionable Terraform-side error at plan/apply time.

`application_id`/`client_secret`/`tenant_id` correspond to `clientId`/`clientKey`/`tenantId` in the related backend-side null-check: beyond-api-v2#663. `subscription_id` isn't part of that `ClientSecretCredentialBuilder` auth path (it's matched separately against the available-subscriptions list), but it's still a `Required` field on this resource, so an empty value is invalid here too and gets the same treatment.

Jira: NR-615282

## What did you change?

Added `ValidateFunc: validation.StringIsNotEmpty` (already used elsewhere in this provider, e.g. the AWS link-account resources) to all four credential fields in `resource_newrelic_cloud_azure_link_account.go`. Since it's on the schema itself, it applies on both create and update.

## Checklist

- [x] PR is linked to a JIRA ticket (NR-615282)
- [x] Change is tested in code (`go build`, `go vet`, and `go build -tags CLOUD` all pass)
- [x] Verified locally via `dev_overrides` + `terraform plan` (no live NR/Azure infra) — empty `application_id`/`client_secret`/`subscription_id`/`tenant_id` each fail plan with `expected "<field>" to not be an empty string, got`; all-valid input plans cleanly to `+ create`.
- [ ] Change is tested in staging — not yet re-verified against the live getToken() repro; the existing acceptance test (`TestAccNewRelicCloudAzureLinkAccount_Basic`) requires `TF_ACC=1` plus real Azure/NR credentials to run and doesn't yet cover the empty-string case.