### PR TITLE
fix(oci): changes for resource name resolution

### DIFF
--- a/examples/modules/cloud-integrations/oci/policy-setup/main.tf
+++ b/examples/modules/cloud-integrations/oci/policy-setup/main.tf
@@ -121,6 +121,11 @@ resource "oci_identity_policy" "nr_common_policy" {
     "Allow dynamic-group ${local.dynamic_group_name} to use fn-function in tenancy",
     "Allow dynamic-group ${local.dynamic_group_name} to use fn-invocation in tenancy",
     "Allow dynamic-group ${local.dynamic_group_name} to read secret-bundles in tenancy where any { target.secret.id = '${local.ingest_key_secret_ocid}', target.secret.id = '${local.user_key_secret_ocid}' }",
+    "Allow dynamic-group ${local.dynamic_group_name} to inspect dns-family in tenancy",
+    "Allow dynamic-group ${local.dynamic_group_name} to inspect goldengate-family in tenancy",
+    "Allow dynamic-group ${local.dynamic_group_name} to inspect network-firewall-family in tenancy",
+    "Allow dynamic-group ${local.dynamic_group_name} to inspect cloudevents-rules in tenancy",
+    "Allow dynamic-group ${local.dynamic_group_name} to inspect integration-instance in tenancy",
   ]
   defined_tags  = {}
   freeform_tags = local.freeform_tags


### PR DESCRIPTION
Extend the common policy to grant `inspect` access on `dns-family`, `goldengate-family`, `network-firewall-family`, `cloudevents-rules`, and `integration-instance` resources in tenancy. This is needed to support resolving OCI resource names via OCID during entity synthesis.

## Description
Please include a summary of the change and which issue is fixed (if relevant).

Fixes # (issue)

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
Please delete options that are not relevant.

- [ ] My commit message follows conventional commits
- [ ] My code is formatted to Go standards
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. Go here for instructions on running tests locally.

## How to test this change?
Please describe how to test your changes. Include any relevant steps in the UI, HCL file(s), commands, etc

1. Step 1
2. Step 2
etc

We are making the change to support name resolution via ocid in entity synthesis