### PR TITLE
feat: update 2 terraform resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,3 +69,5 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 )
+
+replace github.com/newrelic/newrelic-client-go/v2 => github.com/newrelic/newrelic-client-go/v2 v2.0.0-20260816223630-d3d5b946d8ae

--- a/go.mod
+++ b/go.mod
@@ -70,4 +70,4 @@ require (
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 )
 
-replace github.com/newrelic/newrelic-client-go/v2 => github.com/newrelic/newrelic-client-go/v2 v2.0.0-20260816223630-d3d5b946d8ae
+replace github.com/newrelic/newrelic-client-go/v2 => github.com/driimus/newrelic-client-go/v2 v2.0.0-20260816223630-d3d5b946d8ae

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/driimus/newrelic-client-go/v2 v2.0.0-20260816223630-d3d5b946d8ae h1:G04qCzhDX5stdBg4RuWZhb4jizmzk4wNZcv4wq09BJU=
+github.com/driimus/newrelic-client-go/v2 v2.0.0-20260816223630-d3d5b946d8ae/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/elazarl/goproxy v0.0.0-20231117061959-7cc037d33fb5 h1:m62nsMU279qRD9PQSWD1l66kmkXzuYcnVJqL4XLeV2M=
 github.com/elazarl/goproxy v0.0.0-20231117061959-7cc037d33fb5/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
@@ -167,8 +169,6 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S3bfBjY=
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
-github.com/newrelic/newrelic-client-go/v2 v2.93.4 h1:NV2rYqVgv36D5l16wUeKnYR3hwtWmSXot2AQacmbQI0=
-github.com/newrelic/newrelic-client-go/v2 v2.93.4/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/newrelic/resource_newrelic_one_dashboard.go
+++ b/newrelic/resource_newrelic_one_dashboard.go
@@ -305,6 +305,16 @@ func dashboardWidgetSchemaBase() map[string]*schema.Schema {
 			Required:    true,
 			Description: "A title for the widget.",
 		},
+		"description": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "A description of the widget.",
+		},
+		"link_url": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "A URL to link to from the widget.",
+		},
 		"column": {
 			Type:     schema.TypeInt,
 			Required: true,

--- a/newrelic/resource_newrelic_one_dashboard_raw.go
+++ b/newrelic/resource_newrelic_one_dashboard_raw.go
@@ -111,6 +111,28 @@ func dashboardRawWidgetSchemaElem() *schema.Resource {
 		Description: "The visualization ID of the widget.",
 	}
 
+	s["description"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "A description of the widget.",
+	}
+
+	s["link"] = &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		MaxItems:    1,
+		Description: "A nested block describing a link to be displayed in the widget.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"url": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "The target URL for the link.",
+				},
+			},
+		},
+	}
+
 	// TODO: raw_configuration
 	s["configuration"] = &schema.Schema{
 		Type:             schema.TypeString,

--- a/newrelic/structures_newrelic_one_dashboard.go
+++ b/newrelic/structures_newrelic_one_dashboard.go
@@ -756,6 +756,12 @@ func expandDashboardWidgetInput(w map[string]interface{}, meta interface{}, visu
 	if i, ok := w["id"]; ok {
 		widget.ID = i.(string)
 	}
+	if i, ok := w["description"]; ok {
+		widget.Description = i.(string)
+	}
+	if i, ok := w["link_url"]; ok && i.(string) != "" {
+		widget.Link = dashboards.DashboardWidgetLinkInput{URL: i.(string)}
+	}
 	if i, ok := w["column"]; ok {
 		widget.Layout.Column = i.(int)
 	}
@@ -1420,6 +1426,12 @@ func flattenDashboardWidget(in *entities.DashboardWidget, pageGUID string) (stri
 	out["width"] = in.Layout.Width
 	if in.Title != "" {
 		out["title"] = in.Title
+	}
+	if in.Description != "" {
+		out["description"] = in.Description
+	}
+	if in.Link.URL != "" {
+		out["link_url"] = in.Link.URL
 	}
 
 	// NOTE: The widget types that currently support linked entities

--- a/newrelic/structures_newrelic_one_dashboard_raw.go
+++ b/newrelic/structures_newrelic_one_dashboard_raw.go
@@ -123,6 +123,17 @@ func expandDashboardRawWidgetInput(w map[string]interface{}, meta interface{}) (
 		widget.LinkedEntityGUIDs = expandLinkedEntityGUIDs(i.([]interface{}))
 	}
 
+	if i, ok := w["description"]; ok {
+		widget.Description = i.(string)
+	}
+
+	if i, ok := w["link"]; ok {
+		if l := i.([]interface{}); len(l) > 0 {
+			cfg := l[0].(map[string]interface{})
+			widget.Link.URL = cfg["url"].(string)
+		}
+	}
+
 	return widget, nil
 }
 
@@ -224,6 +235,16 @@ func flattenDashboardRawWidget(in *entities.DashboardWidget) (string, map[string
 	out["width"] = in.Layout.Width
 	if in.Title != "" {
 		out["title"] = in.Title
+	}
+	if in.Description != "" {
+		out["description"] = in.Description
+	}
+	if in.Link.URL != "" {
+		out["link"] = []interface{}{
+			map[string]interface{}{
+				"url": in.Link.URL,
+			},
+		}
 	}
 
 	// NOTE: The widget types that currently support linked entities


### PR DESCRIPTION
## Summary

Updates 2 existing resources to reflect changes in the go-client `dashboards` namespace.

**Resources:**
- `newrelic_one_dashboard`
- `newrelic_one_dashboard_raw`

**Generated files:**
- `newrelic/resource_newrelic_one_dashboard.go`
- `newrelic/structures_newrelic_one_dashboard.go`
- `newrelic/resource_newrelic_one_dashboard_raw.go`
- `newrelic/structures_newrelic_one_dashboard_raw.go`

**go-client source:** https://github.com/newrelic/newrelic-client-go/pull/1445 (sha: `d3d5b946d8ae57f0a03027715829aa603f5e7751`)

**Before this can merge:**
- Run `go mod tidy` — the branch carries a `go.mod` `replace` for the unmerged go-client commit with no matching `go.sum`, so the build fails until it is regenerated. Drop the `replace` once the go-client change is released.
- Check the registration in `newrelic/provider_newrelic.go` is in `ResourcesMap` and not `DataSourcesMap`, and that `website/newrelic.erb` lists it under Resources.
- **TIER 2 RESOURCE.** At least one resource here carries hand-tuned body logic (a retry loop, CustomizeDiff, state upgraders, or a field-level DiffSuppressFunc/StateFunc/ConflictsWith/ExactlyOneOf) that the schema-contract check cannot verify was preserved. Diff the regenerated body logic against the original by hand before approving.
- `newrelic_one_dashboard`'s expand entry point was told to take extra parameters beyond `d` alone (`meta interface{}, dashboardNameCustom string`) — a hand-authored override in `ResourceFamilyOverrides`, not derived. Confirm this still matches the target resource's real signature before merging.
- `newrelic_one_dashboard_raw`'s expand entry point was told to take extra parameters beyond `d` alone (`meta interface{}, dashboardNameCustom string`) — a hand-authored override in `ResourceFamilyOverrides`, not derived. Confirm this still matches the target resource's real signature before merging.
- `website/docs/r/one_dashboard.html.markdown` was NOT regenerated; update it by hand if this adds arguments.
- `website/docs/r/one_dashboard_raw.html.markdown` was NOT regenerated; update it by hand if this adds arguments.
- Nothing here was built or `terraform validate`d. Review the schema against the provider's own naming conventions before approving.

---
*Generated by [api-governance codegen](https://source.datanerd.us/after/api-governance)*