### PR TITLE
feat: update 4 terraform resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,3 +69,5 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 )
+
+replace github.com/newrelic/newrelic-client-go/v2 => github.com/newrelic/newrelic-client-go/v2 v2.0.0-20260804122254-fee95e2a243e

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S3bfBjY=
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
-github.com/newrelic/newrelic-client-go/v2 v2.93.4 h1:NV2rYqVgv36D5l16wUeKnYR3hwtWmSXot2AQacmbQI0=
-github.com/newrelic/newrelic-client-go/v2 v2.93.4/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
+github.com/newrelic/newrelic-client-go/v2 v2.0.0-20260804122254-fee95e2a243e h1:pgNN0wasQNjZc66FiVXlCSCIdIc+NMDyWPXsCv5/YW0=
+github.com/newrelic/newrelic-client-go/v2 v2.0.0-20260804122254-fee95e2a243e/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/newrelic/resource_newrelic_data_partition.go
+++ b/newrelic/resource_newrelic_data_partition.go
@@ -64,6 +64,32 @@ func resourceNewRelicDataPartition() *schema.Resource {
 				Computed:    true,
 				Description: "Whether or not this data partition rule is deleted. Deleting a data partition rule does not delete the already persisted data. This data will be retained for a given period of time specified in the retention policy field.",
 			},
+			"matching_criteria": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "The matching criteria of the data partition rule.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"attribute_name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The attribute name against which this matching condition will be evaluated.",
+						},
+						"matching_expression": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The matching expression of the data partition rule definition.",
+						},
+						"matching_method": {
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "The matching method of the data partition rule definition.",
+							ValidateFunc: validation.StringInSlice([]string{string(logconfigurations.LogConfigurationsDataPartitionRuleMatchingOperatorTypes.EQUALS), string(logconfigurations.LogConfigurationsDataPartitionRuleMatchingOperatorTypes.LIKE)}, false),
+						},
+					},
+				},
+			},
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Second),
@@ -73,6 +99,7 @@ func resourceNewRelicDataPartition() *schema.Resource {
 
 func listValidDataPartitionRuleRetentionPolicyType() []string {
 	return []string{
+		string(logconfigurations.LogConfigurationsDataPartitionRuleRetentionPolicyTypeTypes.ARCHIVE),
 		string(logconfigurations.LogConfigurationsDataPartitionRuleRetentionPolicyTypeTypes.SECONDARY),
 		string(logconfigurations.LogConfigurationsDataPartitionRuleRetentionPolicyTypeTypes.STANDARD),
 	}
@@ -98,6 +125,13 @@ func resourceNewRelicDataPartitionCreate(ctx context.Context, d *schema.Resource
 
 	if e, ok := d.GetOk("retention_policy"); ok {
 		createInput.RetentionPolicy = logconfigurations.LogConfigurationsDataPartitionRuleRetentionPolicyType(e.(string))
+	}
+
+	if v, ok := d.GetOk("matching_criteria"); ok {
+		items := v.([]interface{})
+		if len(items) > 0 {
+			createInput.MatchingCriteria = expandDataPartitionMatchingCriteria(items[0].(map[string]interface{}))
+		}
 	}
 	log.Printf("[INFO] Creating New Relic Data Partition Rule  %s", createInput.TargetDataPartition)
 
@@ -177,6 +211,12 @@ func resourceNewRelicDataPartitionRead(ctx context.Context, d *schema.ResourceDa
 	_ = d.Set("retention_policy", rule.RetentionPolicy)
 	_ = d.Set("deleted", rule.Deleted)
 
+	if rule.MatchingCriteria.AttributeName != "" {
+		if err := d.Set("matching_criteria", flattenDataPartitionMatchingCriteria(rule.MatchingCriteria)); err != nil {
+			return diag.FromErr(fmt.Errorf("[DEBUG] Error setting `matching_criteria`: %v", err))
+		}
+	}
+
 	return nil
 }
 
@@ -228,6 +268,13 @@ func expandDataPartitionUpdateInput(d *schema.ResourceData) logconfigurations.Lo
 		updateInp.NRQL = logconfigurations.NRQL(e.(string))
 	}
 
+	if v, ok := d.GetOk("matching_criteria"); ok {
+		items := v.([]interface{})
+		if len(items) > 0 {
+			updateInp.MatchingCriteria = expandDataPartitionMatchingCriteria(items[0].(map[string]interface{}))
+		}
+	}
+
 	return updateInp
 }
 
@@ -248,6 +295,24 @@ func resourceNewRelicDataPartitionDelete(ctx context.Context, d *schema.Resource
 	}
 
 	return nil
+}
+
+func expandDataPartitionMatchingCriteria(cfg map[string]interface{}) *logconfigurations.LogConfigurationsDataPartitionRuleMatchingCriteriaInput {
+	return &logconfigurations.LogConfigurationsDataPartitionRuleMatchingCriteriaInput{
+		AttributeName:      cfg["attribute_name"].(string),
+		MatchingExpression: cfg["matching_expression"].(string),
+		MatchingMethod:     logconfigurations.LogConfigurationsDataPartitionRuleMatchingOperator(cfg["matching_method"].(string)),
+	}
+}
+
+func flattenDataPartitionMatchingCriteria(criteria logconfigurations.LogConfigurationsDataPartitionRuleMatchingCriteria) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"attribute_name":      criteria.AttributeName,
+			"matching_expression": criteria.MatchingExpression,
+			"matching_method":     string(criteria.MatchingOperator),
+		},
+	}
 }
 
 func getDataPartitionByID(ctx context.Context, client *newrelic.NewRelic, accountID int, ruleID string) (*logconfigurations.LogConfigurationsDataPartitionRule, error) {

--- a/newrelic/resource_newrelic_log_parsing_rule.go
+++ b/newrelic/resource_newrelic_log_parsing_rule.go
@@ -63,6 +63,17 @@ func resourceNewRelicLogParsingRule() *schema.Resource {
 				Description: "Whether or not this rule is deleted.",
 				Computed:    true,
 			},
+			"source": {
+				Type:        schema.TypeString,
+				Description: "The source of the parsing rule.",
+				Optional:    true,
+				Computed:    true,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Description: "The date and time when the rule was last updated.",
+				Computed:    true,
+			},
 			"matched": {
 				Type:        schema.TypeBool,
 				Description: "Whether the Grok pattern matched.",
@@ -174,6 +185,14 @@ func resourceNewRelicLogParsingRuleRead(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
+	if err := d.Set("source", string(rule.Source)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("updated_at", string(rule.UpdatedAt)); err != nil {
+		return diag.FromErr(err)
+	}
+
 	return nil
 }
 
@@ -238,6 +257,10 @@ func expandLogParsingRuleUpdateInput(d *schema.ResourceData) logconfigurations.L
 
 	if e, ok := d.GetOk("nrql"); ok {
 		updateInp.NRQL = logconfigurations.NRQL(e.(string))
+	}
+
+	if e, ok := d.GetOk("source"); ok {
+		updateInp.Source = logconfigurations.LogConfigurationsParsingRuleSource(e.(string))
 	}
 
 	return updateInp

--- a/newrelic/resource_newrelic_obfuscation_expression.go
+++ b/newrelic/resource_newrelic_obfuscation_expression.go
@@ -42,6 +42,16 @@ func resourceNewRelicObfuscationExpression() *schema.Resource {
 				Description: "Regex of expression.",
 				Required:    true,
 			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Description: "The date and time the expression was created.",
+				Computed:    true,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Description: "The date and time the expression was last updated.",
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -104,6 +114,9 @@ func resourceNewRelicObfuscationExpressionRead(ctx context.Context, d *schema.Re
 	if err := d.Set("regex", expression.Regex); err != nil {
 		return diag.FromErr(err)
 	}
+
+	_ = d.Set("created_at", string(expression.CreatedAt))
+	_ = d.Set("updated_at", string(expression.UpdatedAt))
 
 	return nil
 }

--- a/newrelic/resource_newrelic_obfuscation_rule.go
+++ b/newrelic/resource_newrelic_obfuscation_rule.go
@@ -57,6 +57,16 @@ func resourceNewRelicObfuscationRule() *schema.Resource {
 				Required:    true,
 				Elem:        ObfuscationRuleActionInputSchemaElem(),
 			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Description: "The date and time when the rule was created.",
+				Computed:    true,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Description: "The date and time when the rule was last updated.",
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -183,6 +193,9 @@ func resourceNewRelicObfuscationRuleRead(ctx context.Context, d *schema.Resource
 	if err := d.Set("action", flattenActions(&rule.Actions)); err != nil {
 		return diag.FromErr(err)
 	}
+
+	_ = d.Set("created_at", string(rule.CreatedAt))
+	_ = d.Set("updated_at", string(rule.UpdatedAt))
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Updates 4 existing resources to reflect changes in the go-client `logconfigurations` namespace.

**Resources:**
- `newrelic_data_partition_rule`
- `newrelic_log_parsing_rule`
- `newrelic_obfuscation_expression`
- `newrelic_obfuscation_rule`

**Generated files:**
- `newrelic/resource_newrelic_data_partition.go`
- `newrelic/resource_newrelic_log_parsing_rule.go`
- `newrelic/resource_newrelic_obfuscation_expression.go`
- `newrelic/resource_newrelic_obfuscation_rule.go`

**go-client source:** https://github.com/newrelic/newrelic-client-go/pull/1440 (sha: `fee95e2a243e40cc8b44341f0e89fa3d09449def`)

**Before this can merge:**
- Drop the `go.mod` `replace` once the go-client change is released. Its `go.sum` entries are already on the branch, so no `go mod tidy` is needed to build.
- Check the registration in `newrelic/provider_newrelic.go` is in `ResourcesMap` and not `DataSourcesMap`, and that `website/newrelic.erb` lists it under Resources.
- **TIER 2 RESOURCE.** At least one resource here carries hand-tuned body logic (a retry loop, CustomizeDiff, state upgraders, or a field-level DiffSuppressFunc/StateFunc/ConflictsWith/ExactlyOneOf) that the schema-contract check cannot verify was preserved. Diff the regenerated body logic against the original by hand before approving.
- `website/docs/r/data_partition_rule.html.markdown` was NOT regenerated; update it by hand if this adds arguments.
- `website/docs/r/log_parsing_rule.html.markdown` was NOT regenerated; update it by hand if this adds arguments.
- `website/docs/r/obfuscation_expression.html.markdown` was NOT regenerated; update it by hand if this adds arguments.
- `website/docs/r/obfuscation_rule.html.markdown` was NOT regenerated; update it by hand if this adds arguments.
- Nothing here was built or `terraform validate`d. Review the schema against the provider's own naming conventions before approving.

---
*Generated by [api-governance codegen](https://source.datanerd.us/after/api-governance)*