### PR TITLE
feat: update 4 terraform resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,3 +69,5 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 )
+
+replace github.com/newrelic/newrelic-client-go/v2 => github.com/newrelic/newrelic-client-go/v2 v2.0.0-20260911183715-2d2bba5de8ff

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/newrelic/go-agent/v3 v3.30.0 h1:ZXHCT/Cot4iIPwcegCZURuRQOsfmGA6wilW+S3bfBjY=
 github.com/newrelic/go-agent/v3 v3.30.0/go.mod h1:9utrgxlSryNqRrTvII2XBL+0lpofXbqXApvVWPpbzUg=
-github.com/newrelic/newrelic-client-go/v2 v2.93.4 h1:NV2rYqVgv36D5l16wUeKnYR3hwtWmSXot2AQacmbQI0=
-github.com/newrelic/newrelic-client-go/v2 v2.93.4/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
+github.com/newrelic/newrelic-client-go/v2 v2.0.0-20260911183715-2d2bba5de8ff h1:ATWkHI2ZDRmYvo6cXKX1bZ53cC1SjhuHJem31sVhhTY=
+github.com/newrelic/newrelic-client-go/v2 v2.0.0-20260911183715-2d2bba5de8ff/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/newrelic/resource_newrelic_data_partition.go
+++ b/newrelic/resource_newrelic_data_partition.go
@@ -64,6 +64,16 @@ func resourceNewRelicDataPartition() *schema.Resource {
 				Computed:    true,
 				Description: "Whether or not this data partition rule is deleted. Deleting a data partition rule does not delete the already persisted data. This data will be retained for a given period of time specified in the retention policy field.",
 			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The date and time when the rule was created.",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The date and time when the rule was last updated.",
+			},
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Second),
@@ -176,6 +186,8 @@ func resourceNewRelicDataPartitionRead(ctx context.Context, d *schema.ResourceDa
 	_ = d.Set("nrql", rule.NRQL)
 	_ = d.Set("retention_policy", rule.RetentionPolicy)
 	_ = d.Set("deleted", rule.Deleted)
+	_ = d.Set("created_at", string(rule.CreatedAt))
+	_ = d.Set("updated_at", string(rule.UpdatedAt))
 
 	return nil
 }

--- a/newrelic/resource_newrelic_log_parsing_rule.go
+++ b/newrelic/resource_newrelic_log_parsing_rule.go
@@ -63,6 +63,12 @@ func resourceNewRelicLogParsingRule() *schema.Resource {
 				Description: "Whether or not this rule is deleted.",
 				Computed:    true,
 			},
+			"source": {
+				Type:        schema.TypeString,
+				Description: "The source of the parsing rule. Defaults to WRITE_YOUR_OWN.",
+				Optional:    true,
+				Computed:    true,
+			},
 			"matched": {
 				Type:        schema.TypeBool,
 				Description: "Whether the Grok pattern matched.",
@@ -85,6 +91,9 @@ func resourceNewRelicLogParsingRuleCreate(ctx context.Context, d *schema.Resourc
 		Grok:    d.Get("grok").(string),
 		Lucene:  d.Get("lucene").(string),
 		NRQL:    logconfigurations.NRQL(d.Get("nrql").(string)),
+	}
+	if e, ok := d.GetOk("source"); ok {
+		createInput.Source = logconfigurations.LogConfigurationsParsingRuleSource(e.(string))
 	}
 	var diags diag.Diagnostics
 	if e, ok := d.GetOk("attribute"); ok {
@@ -174,6 +183,10 @@ func resourceNewRelicLogParsingRuleRead(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
+	if err := d.Set("source", string(rule.Source)); err != nil {
+		return diag.FromErr(err)
+	}
+
 	return nil
 }
 
@@ -238,6 +251,10 @@ func expandLogParsingRuleUpdateInput(d *schema.ResourceData) logconfigurations.L
 
 	if e, ok := d.GetOk("nrql"); ok {
 		updateInp.NRQL = logconfigurations.NRQL(e.(string))
+	}
+
+	if e, ok := d.GetOk("source"); ok {
+		updateInp.Source = logconfigurations.LogConfigurationsParsingRuleSource(e.(string))
 	}
 
 	return updateInp

--- a/newrelic/resource_newrelic_obfuscation_expression.go
+++ b/newrelic/resource_newrelic_obfuscation_expression.go
@@ -42,6 +42,16 @@ func resourceNewRelicObfuscationExpression() *schema.Resource {
 				Description: "Regex of expression.",
 				Required:    true,
 			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Description: "The date and time the expression was created.",
+				Computed:    true,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Description: "The date and time the expression was last updated.",
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -104,6 +114,9 @@ func resourceNewRelicObfuscationExpressionRead(ctx context.Context, d *schema.Re
 	if err := d.Set("regex", expression.Regex); err != nil {
 		return diag.FromErr(err)
 	}
+
+	_ = d.Set("created_at", string(expression.CreatedAt))
+	_ = d.Set("updated_at", string(expression.UpdatedAt))
 
 	return nil
 }

--- a/newrelic/resource_newrelic_obfuscation_rule.go
+++ b/newrelic/resource_newrelic_obfuscation_rule.go
@@ -57,6 +57,16 @@ func resourceNewRelicObfuscationRule() *schema.Resource {
 				Required:    true,
 				Elem:        ObfuscationRuleActionInputSchemaElem(),
 			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Description: "The date and time when the rule was created.",
+				Computed:    true,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Description: "The date and time when the rule was last updated.",
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -183,6 +193,9 @@ func resourceNewRelicObfuscationRuleRead(ctx context.Context, d *schema.Resource
 	if err := d.Set("action", flattenActions(&rule.Actions)); err != nil {
 		return diag.FromErr(err)
 	}
+
+	_ = d.Set("created_at", string(rule.CreatedAt))
+	_ = d.Set("updated_at", string(rule.UpdatedAt))
 
 	return nil
 }

--- a/website/docs/r/data_partition_rule.html.markdown
+++ b/website/docs/r/data_partition_rule.html.markdown
@@ -40,6 +40,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The id of the data partition rule.
 * `deleted` - Whether or not this data partition rule is deleted. Deleting a data partition rule does not delete the already persisted data. This data will be retained for a given period of time specified in the retention policy field.
+* `created_at` - The date and time when the rule was created.
+* `updated_at` - The date and time when the rule was last updated.
 
 ## Import
 

--- a/website/docs/r/log_parsing_rule.html.markdown
+++ b/website/docs/r/log_parsing_rule.html.markdown
@@ -58,6 +58,7 @@ The following arguments are supported:
 * `nrql` - (Required) The NRQL to match events to the parsing rule.
 * `account_id` - (Optional) The account id associated with the obfuscation rule.
 * `matched` - (Optional) Whether the Grok pattern matched.
+* `source` - (Optional) The source of the parsing rule. Defaults to WRITE_YOUR_OWN.
 
 
 

--- a/website/docs/r/obfuscation_expression.html.markdown
+++ b/website/docs/r/obfuscation_expression.html.markdown
@@ -36,6 +36,8 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The id of the obfuscation expression.
+* `created_at` - The date and time the expression was created.
+* `updated_at` - The date and time the expression was last updated.
 
 ## Import
 

--- a/website/docs/r/obfuscation_rule.html.markdown
+++ b/website/docs/r/obfuscation_rule.html.markdown
@@ -59,6 +59,8 @@ All nested `action` blocks support the following common arguments:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The id of the obfuscation rule.
+* `created_at` - The date and time when the rule was created.
+* `updated_at` - The date and time when the rule was last updated.
 
 ## Import
 


### PR DESCRIPTION
## Summary

Updates 4 existing resources to reflect changes in the go-client `logconfigurations` namespace.

**Resources:**
- `newrelic_data_partition_rule`
- `newrelic_log_parsing_rule`
- `newrelic_obfuscation_expression`
- `newrelic_obfuscation_rule`

**Generated files:**
- `newrelic/resource_newrelic_data_partition.go`
- `newrelic/resource_newrelic_log_parsing_rule.go`
- `newrelic/resource_newrelic_obfuscation_expression.go`
- `newrelic/resource_newrelic_obfuscation_rule.go`

**go-client source:** https://github.com/newrelic/newrelic-client-go/pull/1488 (sha: `2d2bba5de8ff1bdbad1e13ab6851b3185a0eb52b`)

**Before this can merge:**
- Drop the `go.mod` `replace` once the go-client change is released. Its `go.sum` entries are already on the branch, so no `go mod tidy` is needed to build.
- Check the registration in `newrelic/provider_newrelic.go` is in `ResourcesMap` and not `DataSourcesMap`, and that `website/newrelic.erb` lists it under Resources.
- **TIER 2 RESOURCE.** At least one resource here carries hand-tuned body logic (a retry loop, CustomizeDiff, state upgraders, or a field-level DiffSuppressFunc/StateFunc/ConflictsWith/ExactlyOneOf) that the schema-contract check cannot verify was preserved. Diff the regenerated body logic against the original by hand before approving.
- `website/docs/r/data_partition_rule.html.markdown` was NOT regenerated; update it by hand if this adds arguments.
- `website/docs/r/log_parsing_rule.html.markdown` was NOT regenerated; update it by hand if this adds arguments.
- `website/docs/r/obfuscation_expression.html.markdown` was NOT regenerated; update it by hand if this adds arguments.
- `website/docs/r/obfuscation_rule.html.markdown` was NOT regenerated; update it by hand if this adds arguments.
- Nothing here was built or `terraform validate`d. Review the schema against the provider's own naming conventions before approving.

---
*Generated by [api-governance codegen](https://source.datanerd.us/after/api-governance)*